### PR TITLE
fix: LLM-23018 Search titles not displayed for file glob rg commands

### DIFF
--- a/src/CodexEventHandler.ts
+++ b/src/CodexEventHandler.ts
@@ -234,13 +234,13 @@ export class CodexEventHandler {
                 title: "Read file",
                 locations: [{path: commandAction.path}],
             };
-        } else if (commandAction.type === "search" && commandAction.query) {
+        } else if (commandAction.type === "search") {
             return {
                 sessionUpdate: "tool_call",
                 toolCallId: id,
                 status: acpStatus,
                 kind: "search",
-                title: `Search '${commandAction.query}'`,
+                title: this.createSearchTitle(commandAction.query, commandAction.path),
             }
         } else if (commandAction.type === "listFiles") {
             const title = commandAction.path
@@ -251,7 +251,7 @@ export class CodexEventHandler {
                 toolCallId: id,
                 status: acpStatus,
                 kind: "read",
-                title,
+                title: title,
             }
         }
         return {
@@ -261,6 +261,17 @@ export class CodexEventHandler {
             kind: "execute",
             title: commandAction.command,
         }
+    }
+
+    private createSearchTitle(query: string | null, path: string | null): string {
+        if (query && path) {
+            return `Search for '${query}' in ${path}`;
+        } else if (query) {
+            return `Search for '${query}'`;
+        } else if (path) {
+            return `Search in '${path}'`;
+        }
+        return "Search";
     }
 
     private async updatePlan(event: TurnPlanUpdatedNotification): Promise<UpdateSessionEvent> {

--- a/src/__tests__/CodexACPAgent/command-action-events.test.ts
+++ b/src/__tests__/CodexACPAgent/command-action-events.test.ts
@@ -121,4 +121,144 @@ describe('CodexEventHandler - command action events', () => {
             'data/command-list-files-without-path.json'
         );
     });
+
+    it('should handle search command with query and path', async () => {
+        const searchNotification: ServerNotification = {
+            method: 'item/started',
+            params: {
+                threadId: 'thread-1',
+                turnId: 'turn-1',
+                item: {
+                    type: 'commandExecution',
+                    id: 'command-search-query-path',
+                    command: 'rg "Service" src',
+                    cwd: '/test/project',
+                    processId: null,
+                    status: 'inProgress',
+                    commandActions: [
+                        {
+                            type: 'search',
+                            command: 'rg Service src',
+                            query: 'Service',
+                            path: 'src',
+                        },
+                    ],
+                    aggregatedOutput: null,
+                    exitCode: null,
+                    durationMs: null,
+                },
+            },
+        };
+
+        await setupAndSendNotifications([searchNotification]);
+
+        await expect(mockFixture.getAcpConnectionDump([])).toMatchFileSnapshot(
+            'data/command-search-with-query-and-path.json'
+        );
+    });
+
+    it('should handle search command with only query', async () => {
+        const searchNotification: ServerNotification = {
+            method: 'item/started',
+            params: {
+                threadId: 'thread-1',
+                turnId: 'turn-1',
+                item: {
+                    type: 'commandExecution',
+                    id: 'command-search-query-only',
+                    command: 'rg "Service"',
+                    cwd: '/test/project',
+                    processId: null,
+                    status: 'inProgress',
+                    commandActions: [
+                        {
+                            type: 'search',
+                            command: 'rg Service',
+                            query: 'Service',
+                            path: null,
+                        },
+                    ],
+                    aggregatedOutput: null,
+                    exitCode: null,
+                    durationMs: null,
+                },
+            },
+        };
+
+        await setupAndSendNotifications([searchNotification]);
+
+        await expect(mockFixture.getAcpConnectionDump([])).toMatchFileSnapshot(
+            'data/command-search-with-query-only.json'
+        );
+    });
+
+    it('should handle search command with only path (file glob search)', async () => {
+        const searchNotification: ServerNotification = {
+            method: 'item/started',
+            params: {
+                threadId: 'thread-1',
+                turnId: 'turn-1',
+                item: {
+                    type: 'commandExecution',
+                    id: 'command-search-path-only',
+                    command: 'rg --files -g "*service*"',
+                    cwd: '/test/project',
+                    processId: null,
+                    status: 'inProgress',
+                    commandActions: [
+                        {
+                            type: 'search',
+                            command: "rg --files -g '*service*'",
+                            query: null,
+                            path: '*service*',
+                        },
+                    ],
+                    aggregatedOutput: null,
+                    exitCode: null,
+                    durationMs: null,
+                },
+            },
+        };
+
+        await setupAndSendNotifications([searchNotification]);
+
+        await expect(mockFixture.getAcpConnectionDump([])).toMatchFileSnapshot(
+            'data/command-search-with-path-only.json'
+        );
+    });
+
+    it('should handle search command with neither query nor path', async () => {
+        const searchNotification: ServerNotification = {
+            method: 'item/started',
+            params: {
+                threadId: 'thread-1',
+                turnId: 'turn-1',
+                item: {
+                    type: 'commandExecution',
+                    id: 'command-search-no-query-no-path',
+                    command: 'rg',
+                    cwd: '/test/project',
+                    processId: null,
+                    status: 'inProgress',
+                    commandActions: [
+                        {
+                            type: 'search',
+                            command: 'rg',
+                            query: null,
+                            path: null,
+                        },
+                    ],
+                    aggregatedOutput: null,
+                    exitCode: null,
+                    durationMs: null,
+                },
+            },
+        };
+
+        await setupAndSendNotifications([searchNotification]);
+
+        await expect(mockFixture.getAcpConnectionDump([])).toMatchFileSnapshot(
+            'data/command-search-no-query-no-path.json'
+        );
+    });
 });

--- a/src/__tests__/CodexACPAgent/data/command-search-no-query-no-path.json
+++ b/src/__tests__/CodexACPAgent/data/command-search-no-query-no-path.json
@@ -1,0 +1,15 @@
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "command-search-no-query-no-path",
+        "status": "in_progress",
+        "kind": "search",
+        "title": "Search"
+      }
+    }
+  ]
+}

--- a/src/__tests__/CodexACPAgent/data/command-search-with-path-only.json
+++ b/src/__tests__/CodexACPAgent/data/command-search-with-path-only.json
@@ -1,0 +1,15 @@
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "command-search-path-only",
+        "status": "in_progress",
+        "kind": "search",
+        "title": "Search in '*service*'"
+      }
+    }
+  ]
+}

--- a/src/__tests__/CodexACPAgent/data/command-search-with-query-and-path.json
+++ b/src/__tests__/CodexACPAgent/data/command-search-with-query-and-path.json
@@ -1,0 +1,15 @@
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "command-search-query-path",
+        "status": "in_progress",
+        "kind": "search",
+        "title": "Search for 'Service' in src"
+      }
+    }
+  ]
+}

--- a/src/__tests__/CodexACPAgent/data/command-search-with-query-only.json
+++ b/src/__tests__/CodexACPAgent/data/command-search-with-query-only.json
@@ -1,0 +1,15 @@
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "command-search-query-only",
+        "status": "in_progress",
+        "kind": "search",
+        "title": "Search for 'Service'"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Handle all search command types, not just those with query parameter.
Generate human-readable titles based on available fields:
- Query + path: "Search for 'X' in Y"
- Query only: "Search for 'X'"
- Path only: "Search in 'Y'"
- Neither: "Search"