### PR TITLE
LLM-23325 improve /status command output to match native Codex CLI

### DIFF
--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -15,6 +15,7 @@ import {AgentMode} from "./AgentMode";
 import type {EmbeddedResourceResource} from "@agentclientprotocol/sdk";
 import type {
     Model,
+    GetAccountResponse,
     ListMcpServerStatusParams,
     ListMcpServerStatusResponse,
     SkillsListParams,
@@ -125,6 +126,10 @@ export class CodexAcpClient {
 
         const response = await this.codexClient.accountRead({refreshToken: false})
         return response.requiresOpenaiAuth && !response.account;
+    }
+
+    async getAccount(): Promise<GetAccountResponse> {
+        return this.codexClient.accountRead({refreshToken: false});
     }
 
     async resumeSession(request: acp.ResumeSessionRequest, agentMode: AgentMode): Promise<SessionMetadata> {

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -11,12 +11,18 @@ import {AgentMode} from "./AgentMode";
 import type {TokenCount} from "./TokenCount";
 import {CodexCommands} from "./CodexCommands";
 import type {QuotaMeta} from "./QuotaMeta";
+import type {RateLimitSnapshot, Account} from "./app-server/v2";
 
 
 export interface SessionState {
     sessionMetadata: SessionMetadata;
     currentTurnId: string | null;
     lastTokenUsage: TokenCount | null;
+    totalTokenUsage: TokenCount | null;
+    modelContextWindow: number | null;
+    rateLimits: RateLimitSnapshot | null;
+    account: Account | null;
+    cwd: string;
 }
 
 export class CodexAcpServer implements acp.Agent {
@@ -78,11 +84,17 @@ export class CodexAcpServer implements acp.Agent {
         // we are retrieving available modes from the session, so setting it to a user-defined or default on the new session
         const agentMode = AgentMode.getInitialAgentMode();
         const sessionMetadata = await this.runWithProcessCheck(() => this.codexAcpClient.resumeSession(params, agentMode));
+        const accountResponse = await this.runWithProcessCheck(() => this.codexAcpClient.getAccount());
         const {sessionId, currentModelId, models} = sessionMetadata;
         this.sessions.set(sessionId, {
             sessionMetadata: sessionMetadata,
             currentTurnId: null,
-            lastTokenUsage: null
+            lastTokenUsage: null,
+            totalTokenUsage: null,
+            modelContextWindow: null,
+            rateLimits: null,
+            account: accountResponse.account,
+            cwd: params.cwd,
         });
 
         this.publishAvailableCommandsAsync(sessionId);
@@ -111,11 +123,17 @@ export class CodexAcpServer implements acp.Agent {
         // we are retrieving available modes from the session, so setting it to a user-defined or default on the new session
         const agentMode = AgentMode.getInitialAgentMode();
         const sessionMetadata = await this.runWithProcessCheck(() => this.codexAcpClient.newSession(_params, agentMode));
+        const accountResponse = await this.runWithProcessCheck(() => this.codexAcpClient.getAccount());
         const {sessionId, currentModelId, models} = sessionMetadata;
         this.sessions.set(sessionId, {
             sessionMetadata: sessionMetadata,
             currentTurnId: null,
-            lastTokenUsage: null
+            lastTokenUsage: null,
+            totalTokenUsage: null,
+            modelContextWindow: null,
+            rateLimits: null,
+            account: accountResponse.account,
+            cwd: _params.cwd,
         });
 
         this.publishAvailableCommandsAsync(sessionId);

--- a/src/CodexCommands.ts
+++ b/src/CodexCommands.ts
@@ -2,8 +2,9 @@ import type * as acp from "@agentclientprotocol/sdk";
 import type {AgentSideConnection, AvailableCommand} from "@agentclientprotocol/sdk";
 import {ACPSessionConnection} from "./ACPSessionConnection";
 import type {CodexAcpClient} from "./CodexAcpClient";
-import type {SkillsListEntry} from "./app-server/v2";
+import type {RateLimitSnapshot, SkillsListEntry} from "./app-server/v2";
 import type {SessionState} from "./CodexAcpServer";
+import type {TokenCount} from "./TokenCount";
 
 export class CodexCommands {
     private readonly connection: AgentSideConnection;
@@ -123,18 +124,7 @@ export class CodexCommands {
         switch (name) {
             case "status": {
                 const session = new ACPSessionConnection(this.connection, sessionId);
-                const usage = sessionState.lastTokenUsage;
-                const usageText = usage
-                    ? `tokens: total=${usage.totalTokens}, input=${usage.inputTokens} (cached=${usage.cachedInputTokens}), output=${usage.outputTokens}, reasoning=${usage.reasoningOutputTokens}`
-                    : "tokens: not available (no turn yet)";
-
-                const message = [
-                    "Session status:",
-                    `- mode: ${sessionState.sessionMetadata.agentMode.name}`,
-                    `- model: ${sessionState.sessionMetadata.currentModelId}`,
-                    `- ${usageText}`
-                ].join("\n");
-
+                const message = this.buildStatusMessage(sessionState);
                 await session.update({
                     sessionUpdate: "agent_message_chunk",
                     content: { type: "text", text: message }
@@ -204,6 +194,144 @@ export class CodexCommands {
             sessionUpdate: "agent_message_chunk",
             content: { type: "text", text: text.join("\n") }
         });
+    }
+
+    private buildStatusMessage(sessionState: SessionState): string {
+        const metadata = sessionState.sessionMetadata;
+        const agentMode = metadata.agentMode;
+        const accountText = this.formatAccountInfo(sessionState.account);
+        const tokenUsageText = this.formatTokenUsage(sessionState.totalTokenUsage);
+        const contextWindowText = this.formatContextWindow(
+            sessionState.totalTokenUsage,
+            sessionState.modelContextWindow
+        );
+
+        const lines = [
+            `**Model:** ${metadata.currentModelId}`,
+            `**Directory:** ${sessionState.cwd}`,
+            `**Approval:** ${agentMode.approvalPolicy}`,
+            `**Sandbox:** ${agentMode.sandboxMode}`,
+            `**Account:** ${accountText}`,
+            `**Session:** \`${metadata.sessionId}\``,
+            ``,
+            `**Token usage:** ${tokenUsageText}`,
+            `**Context window:** ${contextWindowText}`,
+            ...this.formatRateLimitLines(sessionState.rateLimits),
+        ];
+
+        return lines.join("  \n");
+    }
+
+    private formatAccountInfo(account: SessionState["account"]): string {
+        if (!account) {
+            return "not logged in";
+        }
+        if (account.type === "apiKey") {
+            return "API key configured";
+        }
+        if (account.type === "chatgpt") {
+            return `ChatGPT (${account.email})`;
+        }
+        return "unknown";
+    }
+
+    private formatTokenUsage(usage: TokenCount | null): string {
+        if (!usage) {
+            return "data not available yet";
+        }
+        const total = this.formatTokenCount(usage.totalTokens);
+        const input = this.formatTokenCount(usage.inputTokens);
+        const output = this.formatTokenCount(usage.outputTokens);
+        return `${total} total  (${input} input + ${output} output)`;
+    }
+
+    private formatContextWindow(usage: TokenCount | null, contextWindow: number | null): string {
+        if (!usage || !contextWindow) {
+            return "data not available yet";
+        }
+        const used = usage.totalTokens;
+        const percentLeft = Math.round(((contextWindow - used) / contextWindow) * 100);
+        const usedFormatted = this.formatTokenCount(used);
+        const totalFormatted = this.formatTokenCount(contextWindow);
+        return `${percentLeft}% left (${usedFormatted} used / ${totalFormatted})`;
+    }
+
+    private formatRateLimitLines(rateLimits: RateLimitSnapshot | null): string[] {
+        if (!rateLimits) {
+            return [`**Limits:** data not available yet`];
+        }
+
+        const lines: string[] = [];
+
+        if (rateLimits.primary) {
+            const percentLeft = Math.round(100 - rateLimits.primary.usedPercent);
+            const resetText = this.formatResetTime(rateLimits.primary.resetsAt);
+            const label = this.formatWindowLabel(rateLimits.primary.windowDurationMins);
+            lines.push(`**${label}:** ${percentLeft}% left${resetText}`);
+        }
+
+        if (rateLimits.secondary) {
+            const percentLeft = Math.round(100 - rateLimits.secondary.usedPercent);
+            const resetText = this.formatResetTime(rateLimits.secondary.resetsAt);
+            const label = this.formatWindowLabel(rateLimits.secondary.windowDurationMins);
+            lines.push(`**${label}:** ${percentLeft}% left${resetText}`);
+        }
+
+        if (rateLimits.credits) {
+            if (rateLimits.credits.unlimited) {
+                lines.push(`**Credits:** unlimited`);
+            } else if (rateLimits.credits.balance) {
+                lines.push(`**Credits:** ${rateLimits.credits.balance}`);
+            }
+        }
+
+        return lines.length > 0 ? lines : [`**Limits:** data not available yet`];
+    }
+
+    private formatWindowLabel(windowDurationMins: number | null): string {
+        if (windowDurationMins === null) {
+            return "Limit";
+        }
+        if (windowDurationMins < 60) {
+            return `${windowDurationMins}m limit`;
+        }
+        if (windowDurationMins < 1440) {
+            const hours = Math.round(windowDurationMins / 60);
+            return `${hours}h limit`;
+        }
+        if (windowDurationMins < 10080) {
+            const days = Math.round(windowDurationMins / 1440);
+            return `${days}d limit`;
+        }
+        return "Weekly limit";
+    }
+
+    private formatResetTime(resetsAt: number | null): string {
+        if (resetsAt === null) {
+            return "";
+        }
+        const resetDate = new Date(resetsAt * 1000);
+        const now = new Date();
+        const isToday = resetDate.toDateString() === now.toDateString();
+
+        const timeStr = resetDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+
+        if (isToday) {
+            return ` (resets ${timeStr})`;
+        }
+
+        const dateStr = resetDate.toLocaleDateString([], { day: 'numeric', month: 'short' });
+        return ` (resets ${timeStr} on ${dateStr})`;
+    }
+
+    private formatTokenCount(count: number): string {
+        if (count >= 1000000) {
+            return `${(count / 1000000).toFixed(1)}M`;
+        }
+        if (count >= 1000) {
+            return `${(count / 1000).toFixed(1)}K`;
+        }
+        return count.toString();
     }
 }
 

--- a/src/CodexEventHandler.ts
+++ b/src/CodexEventHandler.ts
@@ -5,6 +5,7 @@ import {type PlanEntry, RequestError, type ToolCallContent} from "@agentclientpr
 import {applyPatch} from "diff";
 import {ACPSessionConnection, type UpdateSessionEvent} from "./ACPSessionConnection";
 import type {
+    AccountRateLimitsUpdatedNotification,
     AgentMessageDeltaNotification, CodexErrorInfo,
     CommandAction,
     CommandExecutionStatus,
@@ -95,7 +96,10 @@ export class CodexEventHandler {
             case "item/fileChange/outputDelta":
             case "item/mcpToolCall/progress":
             case "account/updated":
+                return null;
             case "account/rateLimits/updated":
+                this.handleRateLimitsUpdated(notification.params);
+                return null;
             case "thread/compacted":
             case "windows/worldWritableWarning":
             case "account/login/completed":
@@ -323,5 +327,11 @@ export class CodexEventHandler {
 
     private handleTokenUsageUpdated(params: ThreadTokenUsageUpdatedNotification): void {
         this.sessionState.lastTokenUsage = toTokenCount(params.tokenUsage.last);
+        this.sessionState.totalTokenUsage = toTokenCount(params.tokenUsage.total);
+        this.sessionState.modelContextWindow = params.tokenUsage.modelContextWindow;
+    }
+
+    private handleRateLimitsUpdated(params: AccountRateLimitsUpdatedNotification): void {
+        this.sessionState.rateLimits = params.rateLimits;
     }
 }

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -3,7 +3,7 @@
 import {describe, expect, it, vi, beforeEach} from 'vitest';
 import type {CodexAuthRequest} from "../../CodexAuthMethod";
 import type * as acp from "@agentclientprotocol/sdk";
-import {createTestFixture, createCodexMockTestFixture, type TestFixture} from "../acp-test-utils";
+import {createTestFixture, createCodexMockTestFixture, createTestSessionState, type TestFixture} from "../acp-test-utils";
 import type {ServerNotification} from "../../app-server";
 import type {SessionState} from "../../CodexAcpServer";
 import {AgentMode} from "../../AgentMode";
@@ -115,16 +115,14 @@ describe('ACP server test', { timeout: 40_000 }, () => {
             threadId: "id",
             turn: { id: "turn-id", items: [], status: "completed", error: null }
         });
-        const sessionState: SessionState = {
-            currentTurnId: null,
-            lastTokenUsage: null,
+        const sessionState: SessionState = createTestSessionState({
             sessionMetadata: {
                 sessionId: "id",
                 currentModelId: "model-id",
                 models: [],
                 agentMode: AgentMode.DEFAULT_AGENT_MODE
             }
-        };
+        });
         vi.spyOn(codexAcpAgent, "getSessionState").mockReturnValue(sessionState);
 
         await codexAcpAgent.prompt({ sessionId: "id", prompt: [{type: "text", text: ""}] });
@@ -145,16 +143,14 @@ describe('ACP server test', { timeout: 40_000 }, () => {
             turn: { id: "turn-id", items: [], status: "completed", error: null }
         });
 
-        const sessionState: SessionState = {
-            currentTurnId: null,
-            lastTokenUsage: null,
+        const sessionState: SessionState = createTestSessionState({
             sessionMetadata: {
                 sessionId: "id",
                 currentModelId: "model-id",
                 models: [],
                 agentMode: AgentMode.DEFAULT_AGENT_MODE
             }
-        };
+        });
         vi.spyOn(codexAcpAgent, "getSessionState").mockReturnValue(sessionState);
 
         // First prompt - registers first notification handler
@@ -196,26 +192,22 @@ describe('ACP server test', { timeout: 40_000 }, () => {
             turn: { id: "turn-id", items: [], status: "completed", error: null }
         });
 
-        const sessionState1: SessionState = {
-            currentTurnId: null,
-            lastTokenUsage: null,
+        const sessionState1: SessionState = createTestSessionState({
             sessionMetadata: {
                 sessionId: "session-1",
                 currentModelId: "model-id",
                 models: [],
                 agentMode: AgentMode.DEFAULT_AGENT_MODE
             }
-        };
-        const sessionState2: SessionState = {
-            currentTurnId: null,
-            lastTokenUsage: null,
+        });
+        const sessionState2: SessionState = createTestSessionState({
             sessionMetadata: {
                 sessionId: "session-2",
                 currentModelId: "model-id",
                 models: [],
                 agentMode: AgentMode.DEFAULT_AGENT_MODE
             }
-        };
+        });
 
         vi.spyOn(codexAcpAgent, "getSessionState").mockImplementation((sessionId: string) => {
             return sessionId === "session-1" ? sessionState1 : sessionState2;
@@ -255,16 +247,7 @@ describe('ACP server test', { timeout: 40_000 }, () => {
             turn: { id: "turn-id", items: [], status: "completed", error: null }
         });
 
-        const sessionState: SessionState = {
-            currentTurnId: null,
-            sessionMetadata: {
-                sessionId: "session-id",
-                currentModelId: "model-id",
-                models: [],
-                agentMode: AgentMode.DEFAULT_AGENT_MODE,
-            },
-            lastTokenUsage: null
-        };
+        const sessionState: SessionState = createTestSessionState();
         vi.spyOn(codexAcpAgent, "getSessionState").mockReturnValue(sessionState);
 
         const prompt: acp.ContentBlock[] = [
@@ -363,16 +346,7 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         const mockFixture = createCodexMockTestFixture();
         const codexAcpAgent = mockFixture.getCodexAcpAgent();
 
-        const sessionState: SessionState = {
-            currentTurnId: null,
-            lastTokenUsage: null,
-            sessionMetadata: {
-                sessionId: "session-id",
-                currentModelId: "model-id",
-                models: [],
-                agentMode: AgentMode.DEFAULT_AGENT_MODE
-            }
-        };
+        const sessionState: SessionState = createTestSessionState();
         vi.spyOn(codexAcpAgent, "getSessionState").mockReturnValue(sessionState);
 
         await codexAcpAgent.prompt({ sessionId: "session-id", prompt: [{ type: "text", text: "/status" }] });
@@ -383,16 +357,7 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         const mockFixture = createCodexMockTestFixture();
         const codexAcpAgent = mockFixture.getCodexAcpAgent();
 
-        const sessionState: SessionState = {
-            currentTurnId: null,
-            lastTokenUsage: null,
-            sessionMetadata: {
-                sessionId: "session-id",
-                currentModelId: "model-id",
-                models: [],
-                agentMode: AgentMode.DEFAULT_AGENT_MODE
-            }
-        };
+        const sessionState: SessionState = createTestSessionState();
 
         const logoutSpy = vi.spyOn(mockFixture.getCodexAcpClient(), "logout").mockResolvedValue(undefined);
 
@@ -408,16 +373,7 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         const mockFixture = createCodexMockTestFixture();
         const codexAcpAgent = mockFixture.getCodexAcpAgent();
 
-        const sessionState: SessionState = {
-            currentTurnId: null,
-            lastTokenUsage: null,
-            sessionMetadata: {
-                sessionId: "session-id",
-                currentModelId: "model-id",
-                models: [],
-                agentMode: AgentMode.DEFAULT_AGENT_MODE
-            }
-        };
+        const sessionState: SessionState = createTestSessionState();
 
         const skillsResponse: SkillsListResponse = {
             data: [{
@@ -443,16 +399,7 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         const mockFixture = createCodexMockTestFixture();
         const codexAcpAgent = mockFixture.getCodexAcpAgent();
 
-        const sessionState: SessionState = {
-            currentTurnId: null,
-            lastTokenUsage: null,
-            sessionMetadata: {
-                sessionId: "session-id",
-                currentModelId: "model-id",
-                models: [],
-                agentMode: AgentMode.DEFAULT_AGENT_MODE
-            }
-        };
+        const sessionState: SessionState = createTestSessionState();
 
         const mcpResponse: ListMcpServerStatusResponse = {
             data: [

--- a/src/__tests__/CodexACPAgent/approval-events.test.ts
+++ b/src/__tests__/CodexACPAgent/approval-events.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { CommandExecutionRequestApprovalParams, FileChangeRequestApprovalParams } from '../../app-server/v2';
-import { createCodexMockTestFixture, type CodexMockTestFixture } from '../acp-test-utils';
+import { createCodexMockTestFixture, createTestSessionState, type CodexMockTestFixture } from '../acp-test-utils';
 import type { SessionState } from '../../CodexAcpServer';
 import {AgentMode} from "../../AgentMode";
 
@@ -26,16 +26,14 @@ describe('Approval Events', () => {
         });
         fixture.getCodexAppServerClient().awaitTurnCompleted = vi.fn().mockReturnValue(turnCompletedPromise);
 
-        const sessionState: SessionState = {
-            currentTurnId: null,
-            lastTokenUsage: null,
+        const sessionState: SessionState = createTestSessionState({
             sessionMetadata: {
                 sessionId,
                 currentModelId: 'model-id',
                 models: [],
                 agentMode: AgentMode.DEFAULT_AGENT_MODE
             }
-        };
+        });
         vi.spyOn(codexAcpAgent, 'getSessionState').mockReturnValue(sessionState);
 
         const promptPromise = codexAcpAgent.prompt({

--- a/src/__tests__/CodexACPAgent/command-action-events.test.ts
+++ b/src/__tests__/CodexACPAgent/command-action-events.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { SessionState } from '../../CodexAcpServer';
 import type { ServerNotification } from '../../app-server';
-import { createCodexMockTestFixture, type CodexMockTestFixture } from '../acp-test-utils';
+import { createCodexMockTestFixture, createTestSessionState, type CodexMockTestFixture } from '../acp-test-utils';
 import {AgentMode} from "../../AgentMode";
 
 describe('CodexEventHandler - command action events', () => {
@@ -13,16 +13,14 @@ describe('CodexEventHandler - command action events', () => {
         vi.clearAllMocks();
     });
 
-    const sessionState: SessionState = {
-        currentTurnId: null,
-        lastTokenUsage: null,
+    const sessionState: SessionState = createTestSessionState({
         sessionMetadata: {
             sessionId,
             currentModelId: 'model-id',
             models: [],
             agentMode: AgentMode.DEFAULT_AGENT_MODE
         },
-    };
+    });
 
     async function setupAndSendNotifications(notifications: ServerNotification[]) {
         const codexAcpAgent = mockFixture.getCodexAcpAgent();

--- a/src/__tests__/CodexACPAgent/data/auth-with-key.json
+++ b/src/__tests__/CodexACPAgent/data/auth-with-key.json
@@ -115,6 +115,20 @@
 }
 {
   "eventType": "request",
+  "method": "account/read",
+  "params": {
+    "refreshToken": false
+  }
+}
+{
+  "eventType": "response",
+  "account": {
+    "type": "apiKey"
+  },
+  "requiresOpenaiAuth": true
+}
+{
+  "eventType": "request",
   "method": "skills/list",
   "params": {}
 }

--- a/src/__tests__/CodexACPAgent/data/command-status.json
+++ b/src/__tests__/CodexACPAgent/data/command-status.json
@@ -7,7 +7,7 @@
         "sessionUpdate": "agent_message_chunk",
         "content": {
           "type": "text",
-          "text": "Session status:\n- mode: Agent\n- model: model-id\n- tokens: not available (no turn yet)"
+          "text": "**Model:** model-id  \n**Directory:** /test/cwd  \n**Approval:** on-request  \n**Sandbox:** workspace-write  \n**Account:** not logged in  \n**Session:** `session-id`  \n  \n**Token usage:** data not available yet  \n**Context window:** data not available yet  \n**Limits:** data not available yet"
         }
       }
     }

--- a/src/__tests__/CodexACPAgent/data/thread-resume.json
+++ b/src/__tests__/CodexACPAgent/data/thread-resume.json
@@ -55,6 +55,18 @@
 }
 {
   "eventType": "request",
+  "method": "account/read",
+  "params": {
+    "refreshToken": false
+  }
+}
+{
+  "eventType": "response",
+  "account": null,
+  "requiresOpenaiAuth": true
+}
+{
+  "eventType": "request",
   "method": "skills/list",
   "params": {}
 }

--- a/src/__tests__/CodexACPAgent/file-change-events.test.ts
+++ b/src/__tests__/CodexACPAgent/file-change-events.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { SessionState } from '../../CodexAcpServer';
 import type { ServerNotification } from '../../app-server';
-import { createCodexMockTestFixture, type CodexMockTestFixture } from '../acp-test-utils';
+import { createCodexMockTestFixture, createTestSessionState, type CodexMockTestFixture } from '../acp-test-utils';
 import {AgentMode} from "../../AgentMode";
 
 const { mockFiles, mockFileContent, clearMockFiles } = vi.hoisted(() => {
@@ -33,16 +33,14 @@ describe('CodexEventHandler - file change events', () => {
         mockFileContent('/test/project/OldFile.kt', 'package test.project\n\nclass OldFile {}');
     });
 
-    const sessionState: SessionState = {
-        currentTurnId: null,
-        lastTokenUsage: null,
+    const sessionState: SessionState = createTestSessionState({
         sessionMetadata: {
             sessionId,
             currentModelId: 'model-id',
             models: [],
             agentMode: AgentMode.DEFAULT_AGENT_MODE
         },
-    };
+    });
 
     async function setupAndSendNotifications(notifications: ServerNotification[]) {
         const codexAcpAgent = mockFixture.getCodexAcpAgent();

--- a/src/__tests__/CodexACPAgent/token-usage-events.test.ts
+++ b/src/__tests__/CodexACPAgent/token-usage-events.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { SessionState } from '../../CodexAcpServer';
 import type { ServerNotification } from '../../app-server';
-import { createCodexMockTestFixture, type CodexMockTestFixture } from '../acp-test-utils';
+import { createCodexMockTestFixture, createTestSessionState, type CodexMockTestFixture } from '../acp-test-utils';
 import { AgentMode } from "../../AgentMode";
 import type { TokenUsageBreakdown } from '../../app-server/v2';
 
@@ -35,16 +35,14 @@ describe('Token Usage Events', () => {
                 };
             });
 
-            const sessionState: SessionState = {
-                currentTurnId: null,
-                lastTokenUsage: null,
+            const sessionState: SessionState = createTestSessionState({
                 sessionMetadata: {
                     sessionId,
                     currentModelId: 'model-id[medium]',
                     models: [],
                     agentMode: AgentMode.DEFAULT_AGENT_MODE
                 },
-            };
+            });
             vi.spyOn(codexAcpAgent, 'getSessionState').mockReturnValue(sessionState);
 
             return codexAcpAgent;

--- a/src/__tests__/acp-test-utils.ts
+++ b/src/__tests__/acp-test-utils.ts
@@ -1,12 +1,13 @@
 import {CodexAcpClient} from '../CodexAcpClient';
 import {type CodexConnectionEvent, CodexAppServerClient} from '../CodexAppServerClient';
 import {startCodexConnection} from "../CodexJsonRpcConnection";
-import {CodexAcpServer} from "../CodexAcpServer";
+import {CodexAcpServer, type SessionState} from "../CodexAcpServer";
 import type {AgentSideConnection, RequestPermissionResponse} from "@agentclientprotocol/sdk";
 import type {ServerNotification} from "../app-server";
 import type {MessageConnection} from "vscode-jsonrpc/node";
 import path from "node:path";
 import fs from "node:fs";
+import {AgentMode} from "../AgentMode";
 
 export type MethodCallEvent = { method: string; args: any[] };
 
@@ -230,4 +231,27 @@ export function createObjectDump(obj: any, anonymizedFields: string[] = []) {
 
 export function createArrayDump(objects: any[], anonymizedFields: string[]): string {
     return objects.map(event => createObjectDump(event, anonymizedFields)).join("\n");
+}
+
+/**
+ * Creates a default SessionState for use in tests.
+ * Override specific fields as needed.
+ */
+export function createTestSessionState(overrides?: Partial<SessionState>): SessionState {
+    return {
+        currentTurnId: null,
+        lastTokenUsage: null,
+        totalTokenUsage: null,
+        modelContextWindow: null,
+        rateLimits: null,
+        account: null,
+        cwd: "/test/cwd",
+        sessionMetadata: {
+            sessionId: "session-id",
+            currentModelId: "model-id",
+            models: [],
+            agentMode: AgentMode.DEFAULT_AGENT_MODE
+        },
+        ...overrides,
+    };
 }


### PR DESCRIPTION
- Add session state fields: cwd, totalTokenUsage, modelContextWindow,
  rateLimits, account
- Handle account/rateLimits/updated events for rate limit tracking
- Fetch account info during session creation
- Display token usage, context window, and rate limits with reset times
- Format output as markdown with bold labels

<img width="652" height="404" alt="image" src="https://github.com/user-attachments/assets/78c1a46d-4460-48e4-911f-50647498b0a5" />
