### PR TITLE
LLM-22554 Fix incorrectly handled file deletion

### DIFF
--- a/src/CodexEventHandler.ts
+++ b/src/CodexEventHandler.ts
@@ -197,11 +197,16 @@ export class CodexEventHandler {
                 oldText: null,
                 newText: change.diff,
                 path: change.path,
+                _meta: {
+                    kind: "add"
+                }
             }
         }
 
         const oldContent = change.kind.type === "add" ? "" : await readFile(change.path, { encoding: "utf8" });
         const newContent = applyPatch(oldContent, change.diff);
+        // For deleted files, diff may contain raw file content instead of a patch.
+        // Since new text is not optional, we need to pass kind in meta and set newText to null on the client side
         if (newContent === false) {
             return null
         }
@@ -210,6 +215,9 @@ export class CodexEventHandler {
             oldText: change.kind.type === "add" ? null : oldContent,
             newText: newContent,
             path: change.path,
+            _meta: {
+                kind: change.kind.type
+            }
         }
     }
 

--- a/src/__tests__/CodexACPAgent/data/file-change-add-multiple-files.json
+++ b/src/__tests__/CodexACPAgent/data/file-change-add-multiple-files.json
@@ -14,13 +14,19 @@
             "type": "diff",
             "oldText": null,
             "newText": "class FileA\n",
-            "path": "/test/project/FileA.kt"
+            "path": "/test/project/FileA.kt",
+            "_meta": {
+              "kind": "add"
+            }
           },
           {
             "type": "diff",
             "oldText": null,
             "newText": "class FileB\n",
-            "path": "/test/project/FileB.kt"
+            "path": "/test/project/FileB.kt",
+            "_meta": {
+              "kind": "add"
+            }
           }
         ]
       }

--- a/src/__tests__/CodexACPAgent/data/file-change-add-new-file.json
+++ b/src/__tests__/CodexACPAgent/data/file-change-add-new-file.json
@@ -14,7 +14,10 @@
             "type": "diff",
             "oldText": null,
             "newText": "package test.project\n\nclass NewFile {\n    fun hello() = \"Hello\"\n}\n",
-            "path": "/test/project/NewFile.kt"
+            "path": "/test/project/NewFile.kt",
+            "_meta": {
+              "kind": "add"
+            }
           }
         ]
       }

--- a/src/__tests__/CodexACPAgent/data/file-change-delete-file.json
+++ b/src/__tests__/CodexACPAgent/data/file-change-delete-file.json
@@ -14,7 +14,10 @@
             "type": "diff",
             "oldText": "package test.project\n\nclass OldFile {}",
             "newText": "",
-            "path": "/test/project/OldFile.kt"
+            "path": "/test/project/OldFile.kt",
+            "_meta": {
+              "kind": "delete"
+            }
           }
         ]
       }

--- a/src/__tests__/CodexACPAgent/data/file-change-delete-raw-content.json
+++ b/src/__tests__/CodexACPAgent/data/file-change-delete-raw-content.json
@@ -5,18 +5,18 @@
       "sessionId": "test-session-id",
       "update": {
         "sessionUpdate": "tool_call",
-        "toolCallId": "file-change-raw",
+        "toolCallId": "file-delete-raw",
         "title": "Editing files",
         "kind": "edit",
         "status": "completed",
         "content": [
           {
             "type": "diff",
-            "oldText": null,
+            "oldText": "fun main() {\n    println(\"Hello, World!\")\n}\n",
             "newText": "fun main() {\n    println(\"Hello, World!\")\n}\n",
-            "path": "/test/project/RawFile.kt",
+            "path": "/test/project/RawDeleteFile.kt",
             "_meta": {
-              "kind": "add"
+              "kind": "delete"
             }
           }
         ]

--- a/src/__tests__/CodexACPAgent/file-change-events.test.ts
+++ b/src/__tests__/CodexACPAgent/file-change-events.test.ts
@@ -207,4 +207,35 @@ describe('CodexEventHandler - file change events', () => {
             'data/file-change-delete-file.json'
         );
     });
+
+    it('should handle file deletion with raw content', async () => {
+        mockFileContent('/test/project/RawDeleteFile.kt', 'fun main() {\n    println("Hello, World!")\n}\n');
+
+        // Codex sends raw file content (not unified diff) for deleted files
+        const deletedFileNotification: ServerNotification = {
+            method: 'item/started',
+            params: {
+                threadId: 'thread-1',
+                turnId: 'turn-1',
+                item: {
+                    type: 'fileChange',
+                    id: 'file-delete-raw',
+                    changes: [
+                        {
+                            path: '/test/project/RawDeleteFile.kt',
+                            kind: { type: 'delete' },
+                            diff: 'fun main() {\n    println("Hello, World!")\n}\n',
+                        },
+                    ],
+                    status: 'completed',
+                },
+            },
+        };
+
+        await setupAndSendNotifications([deletedFileNotification]);
+
+        await expect(mockFixture.getAcpConnectionDump(['id'])).toMatchFileSnapshot(
+            'data/file-change-delete-raw-content.json'
+        );
+    });
 });


### PR DESCRIPTION
Send patch event kind in the meta field so client can set mandatory newText field to null