### PR TITLE
Approval commands improvment

### DIFF
--- a/src/CodexApprovalHandler.ts
+++ b/src/CodexApprovalHandler.ts
@@ -9,6 +9,7 @@ import type {
 } from "./app-server/v2";
 import type {ToolCallContent} from "@agentclientprotocol/sdk/dist/schema/types.gen";
 import {logger} from "./Logger";
+import {stripShellPrefix} from "./CodexEventHandler";
 
 const APPROVAL_OPTIONS: acp.PermissionOption[] = [
     { optionId: "allow_once", name: "Allow Once", kind: "allow_once" },
@@ -68,7 +69,7 @@ export class CodexApprovalHandler implements ApprovalHandler {
                 kind: "execute",
                 status: "pending",
                 content: reasonContent ? [reasonContent] : null,
-                rawInput: params.command ? { command: params.command, cwd: params.cwd } : null,
+                rawInput: params.command ? { command: stripShellPrefix(params.command), cwd: params.cwd } : null,
             },
             options: APPROVAL_OPTIONS,
         };

--- a/src/CodexApprovalHandler.ts
+++ b/src/CodexApprovalHandler.ts
@@ -68,6 +68,7 @@ export class CodexApprovalHandler implements ApprovalHandler {
                 kind: "execute",
                 status: "pending",
                 content: reasonContent ? [reasonContent] : null,
+                rawInput: params.command ? { command: params.command, cwd: params.cwd } : null,
             },
             options: APPROVAL_OPTIONS,
         };

--- a/src/CodexEventHandler.ts
+++ b/src/CodexEventHandler.ts
@@ -37,6 +37,18 @@ function toAcpStatus(status: CodexItemStatus): AcpToolCallStatus {
     }
 }
 
+/**
+ * Strips shell prefix from command string (e.g., "/bin/bash -lc 'command'", "/bin/zsh -c command")
+ */
+export function stripShellPrefix(command: string): string {
+    const withoutShell = command.replace(/^(?:\/bin\/)?(?:bash|zsh|sh)\s+(?:-[lc]+\s+)?/, "");
+    // Strip surrounding single quotes if present
+    if (withoutShell.startsWith("'") && withoutShell.endsWith("'")) {
+        return withoutShell.slice(1, -1);
+    }
+    return withoutShell;
+}
+
 export class CodexEventHandler {
 
     private readonly connection: acp.AgentSideConnection;
@@ -252,7 +264,7 @@ export class CodexEventHandler {
         if (commandAction) {
             return this.createCommandActionEvent(item.id, item.status, item.cwd, commandAction);
         }
-        const command = item.command.replace(/^(?:\/bin\/)?bash\s+/, "");
+        const command = stripShellPrefix(item.command);
         return {
             sessionUpdate: "tool_call",
             toolCallId: item.id,

--- a/src/__tests__/CodexACPAgent/approval-events.test.ts
+++ b/src/__tests__/CodexACPAgent/approval-events.test.ts
@@ -150,6 +150,35 @@ describe('Approval Events', () => {
             completeTurn();
             await promptPromise;
         });
+
+        it('should include rawInput with command and cwd', async () => {
+            const { promptPromise, completeTurn } = setupSessionWithPendingPrompt();
+            fixture.setPermissionResponse({
+                outcome: { outcome: 'selected', optionId: 'allow_once' }
+            });
+
+            const params: CommandExecutionRequestApprovalParams = {
+                threadId: sessionId,
+                turnId: 'turn-1',
+                itemId: 'item-with-command',
+                reason: 'Installing dependencies',
+                command: 'npm install',
+                cwd: '/home/user/project',
+                proposedExecpolicyAmendment: null,
+            };
+
+            await fixture.sendServerRequest(
+                'item/commandExecution/requestApproval',
+                params
+            );
+
+            await expect(fixture.getAcpConnectionDump(['_meta'])).toMatchFileSnapshot(
+                'data/approval-command-with-rawInput.json'
+            );
+
+            completeTurn();
+            await promptPromise;
+        });
     });
 
     describe('File change approval', () => {

--- a/src/__tests__/CodexACPAgent/approval-events.test.ts
+++ b/src/__tests__/CodexACPAgent/approval-events.test.ts
@@ -179,6 +179,43 @@ describe('Approval Events', () => {
             completeTurn();
             await promptPromise;
         });
+
+        it.each([
+            { command: '/bin/zsh -c npm install', expected: 'npm install' },
+            { command: '/bin/bash -lc npm install', expected: 'npm install' },
+            { command: 'zsh npm install', expected: 'npm install' },
+            { command: 'sh -c ls -la', expected: 'ls -la' },
+            { command: 'npm install', expected: 'npm install' },
+            { command: "/bin/bash -lc './tests.cmd -Darg=value'", expected: './tests.cmd -Darg=value' },
+            { command: "/bin/zsh -c 'echo hello'", expected: 'echo hello' },
+        ])('should strip shell prefix from "$command" in rawInput', async ({ command, expected }) => {
+            const { promptPromise, completeTurn } = setupSessionWithPendingPrompt();
+            fixture.setPermissionResponse({
+                outcome: { outcome: 'selected', optionId: 'allow_once' }
+            });
+
+            const params: CommandExecutionRequestApprovalParams = {
+                threadId: sessionId,
+                turnId: 'turn-1',
+                itemId: 'item-shell-prefix',
+                reason: 'Installing dependencies',
+                command,
+                cwd: '/home/user/project',
+                proposedExecpolicyAmendment: null,
+            };
+
+            await fixture.sendServerRequest(
+                'item/commandExecution/requestApproval',
+                params
+            );
+
+            const dump = fixture.getAcpConnectionDump(['_meta']);
+            const parsed = JSON.parse(dump);
+            expect(parsed.args[0].toolCall.rawInput.command).toBe(expected);
+
+            completeTurn();
+            await promptPromise;
+        });
     });
 
     describe('File change approval', () => {

--- a/src/__tests__/CodexACPAgent/data/approval-command-with-rawInput.json
+++ b/src/__tests__/CodexACPAgent/data/approval-command-with-rawInput.json
@@ -4,7 +4,7 @@
     {
       "sessionId": "test-session-id",
       "toolCall": {
-        "toolCallId": "item-snapshot",
+        "toolCallId": "item-with-command",
         "kind": "execute",
         "status": "pending",
         "content": [
@@ -12,11 +12,14 @@
             "type": "content",
             "content": {
               "type": "text",
-              "text": "Running npm install"
+              "text": "Installing dependencies"
             }
           }
         ],
-        "rawInput": null
+        "rawInput": {
+          "command": "npm install",
+          "cwd": "/home/user/project"
+        }
       },
       "options": [
         {

--- a/src/__tests__/CodexACPAgent/terminal-output-events.test.ts
+++ b/src/__tests__/CodexACPAgent/terminal-output-events.test.ts
@@ -77,6 +77,43 @@ describe('CodexEventHandler - terminal output events', () => {
         );
     });
 
+    it.each([
+        { command: '/bin/zsh -c npm install', expected: 'npm install' },
+        { command: '/bin/bash -lc npm install', expected: 'npm install' },
+        { command: 'zsh npm install', expected: 'npm install' },
+        { command: 'sh -c ls -la', expected: 'ls -la' },
+        { command: 'npm install', expected: 'npm install' },
+        { command: "/bin/bash -lc './tests.cmd -Darg=value'", expected: './tests.cmd -Darg=value' },
+        { command: "/bin/zsh -c 'echo hello'", expected: 'echo hello' },
+    ])('should strip shell prefix from "$command"', async ({ command, expected }) => {
+        const commandStartNotification: ServerNotification = {
+            method: 'item/started',
+            params: {
+                threadId: 'thread-1',
+                turnId: 'turn-1',
+                item: {
+                    type: 'commandExecution',
+                    id: 'command-shell-prefix',
+                    command,
+                    cwd: '/test/project',
+                    processId: null,
+                    status: 'inProgress',
+                    commandActions: [],
+                    aggregatedOutput: null,
+                    exitCode: null,
+                    durationMs: null,
+                },
+            },
+        };
+
+        await setupAndSendNotifications([commandStartNotification]);
+
+        const dump = mockFixture.getAcpConnectionDump([]);
+        const parsed = JSON.parse(dump);
+        expect(parsed.args[0].update.title).toBe(expected);
+        expect(parsed.args[0].update.rawInput.command).toBe(command);
+    });
+
     it('should stream terminal output delta', async () => {
         const outputDeltaNotification: ServerNotification = {
             method: 'item/commandExecution/outputDelta',


### PR DESCRIPTION
[LLM-24245](https://youtrack.jetbrains.com/issue/LLM-24245) [Codex] Permission Dialog: Command not displayed and duplicate approval buttons

These commits fix only missing command in approval block, the duplication should be fixed in the plugin


<img width="874" height="493" alt="image" src="https://github.com/user-attachments/assets/b528202e-3deb-446a-8a3b-7a41a06150a8" />
