### PR TITLE
Update update guidelines and stabilize tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@
 
 - Keep edits consistent with existing formatting.
 - When adding env/config knobs, document them in `readme-dev.md`.
+- When updating discriminated-union/event `switch` statements, do not add a trailing fallback like `return null` only to satisfy TypeScript.
+- Handle each variant with an explicit `case`; if intentionally ignored, use an explicit no-op case.
 
 ## Testing Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@
 - Tests live under `src/__tests__/` and use Vitest.
 - Favor event-driven assertions (see `src/__tests__/CodexACPAgent/*`).
 - Prefer snapshot-based tests using `toMatchFileSnapshot()` over inline assertions.
+- When snapshot response data drifts, prefer replacing that response payload with a stable placeholder over asserting fragile fields.
 - Focus on behavior and outputs rather than implementation details.
 - Use `/run-codex` skill (`.claude/skills/run-codex/`) to test with real Codex and observe actual events.
 

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -1,6 +1,9 @@
 // noinspection ES6RedundantAwait
 
 import {describe, expect, it, vi, beforeEach} from 'vitest';
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import type {CodexAuthRequest} from "../../CodexAuthMethod";
 import type * as acp from "@agentclientprotocol/sdk";
 import {createTestFixture, createCodexMockTestFixture, createTestSessionState, type TestFixture} from "../acp-test-utils";
@@ -10,6 +13,26 @@ import {AgentMode} from "../../AgentMode";
 import type {ListMcpServerStatusResponse, Model, SkillsListResponse} from "../../app-server/v2";
 import type {RateLimitsMap} from "../../RateLimitsMap";
 import {ModelId} from "../../ModelId";
+
+const CODEX_HOME_ENV = "CODEX_HOME";
+
+async function overrideCodexHome<T>(configToml: string, run: () => Promise<T>): Promise<T> {
+    const previousCodexHome = process.env[CODEX_HOME_ENV];
+    const codexHome = fs.mkdtempSync(path.join(os.tmpdir(), "codex-acp-codex-home-"));
+    fs.writeFileSync(path.join(codexHome, "config.toml"), configToml, "utf8");
+    process.env[CODEX_HOME_ENV] = codexHome;
+
+    try {
+        return await run();
+    } finally {
+        if (previousCodexHome === undefined) {
+            delete process.env[CODEX_HOME_ENV];
+        } else {
+            process.env[CODEX_HOME_ENV] = previousCodexHome;
+        }
+        fs.rmSync(codexHome, { recursive: true, force: true });
+    }
+}
 
 describe('ACP server test', { timeout: 40_000 }, () => {
 
@@ -50,31 +73,35 @@ describe('ACP server test', { timeout: 40_000 }, () => {
     });
 
     it('should authenticate with key', async () => {
-        const codexAcpAgent = fixture.getCodexAcpAgent();
+        // In sandboxed environments Codex may fail when trying to write to the OS keychain (`Operation not permitted`).
+        await overrideCodexHome('cli_auth_credentials_store = "file"', async () => {
+            const keyFixture = createTestFixture();
+            const codexAcpAgent = keyFixture.getCodexAcpAgent();
 
-        await codexAcpAgent.initialize({protocolVersion: 1});
-        await fixture.getCodexAcpClient().logout();
+            await codexAcpAgent.initialize({protocolVersion: 1});
+            await keyFixture.getCodexAcpClient().logout();
 
 
-        const unauthenticatedResponse = await fixture.getCodexAcpAgent().extMethod("authentication/status", {});
-        expect(unauthenticatedResponse).toEqual({type: "unauthenticated"});
+            const unauthenticatedResponse = await keyFixture.getCodexAcpAgent().extMethod("authentication/status", {});
+            expect(unauthenticatedResponse).toEqual({type: "unauthenticated"});
 
-        fixture.clearCodexConnectionDump();
+            keyFixture.clearCodexConnectionDump();
 
-        const authRequest: CodexAuthRequest = { methodId: "api-key", _meta: { "api-key": { apiKey: "TOKEN" }}}
-        await codexAcpAgent.authenticate(authRequest);
-        const newSessionResponse = await codexAcpAgent.newSession({cwd: "", mcpServers: []});
-        expect(newSessionResponse.sessionId).toBeDefined()
+            const authRequest: CodexAuthRequest = { methodId: "api-key", _meta: { "api-key": { apiKey: "TOKEN" }}}
+            await codexAcpAgent.authenticate(authRequest);
+            const newSessionResponse = await codexAcpAgent.newSession({cwd: "", mcpServers: []});
+            expect(newSessionResponse.sessionId).toBeDefined()
 
-        const transportDump = fixture.getCodexConnectionDump([...ignoredFields, "upgrade"]);
-        await expect(transportDump).toMatchFileSnapshot("data/auth-with-key.json");
+            const transportDump = keyFixture.getCodexConnectionDump([...ignoredFields, "upgrade"]);
+            await expect(transportDump).toMatchFileSnapshot("data/auth-with-key.json");
 
-        const authenticatedResponse = await fixture.getCodexAcpAgent().extMethod("authentication/status", {});
-        expect(authenticatedResponse).toEqual({type: "api-key"});
+            const authenticatedResponse = await keyFixture.getCodexAcpAgent().extMethod("authentication/status", {});
+            expect(authenticatedResponse).toEqual({type: "api-key"});
 
-        await fixture.getCodexAcpAgent().extMethod("authentication/logout", {});
-        const logoutResponse = await fixture.getCodexAcpAgent().extMethod("authentication/status", {});
-        expect(logoutResponse).toEqual({type: "unauthenticated"});
+            await keyFixture.getCodexAcpAgent().extMethod("authentication/logout", {});
+            const logoutResponse = await keyFixture.getCodexAcpAgent().extMethod("authentication/status", {});
+            expect(logoutResponse).toEqual({type: "unauthenticated"});
+        });
     });
 
     it('should authenticate with a gateway', async () => {

--- a/src/__tests__/acp-test-utils.ts
+++ b/src/__tests__/acp-test-utils.ts
@@ -40,12 +40,16 @@ export interface TestFixture {
     getCodexAcpAgent(): CodexAcpServer,
 
     onCodexConnectionEvent(handler: (event: CodexConnectionEvent) => void): void,
-    getCodexConnectionDump(ignoredFields: string[]): string,
+    getCodexConnectionDump(ignoredFields: string[], options?: CodexConnectionDumpOptions): string,
     clearCodexConnectionDump(): void,
 
     onAcpConnectionEvent(handler: (event: MethodCallEvent) => void): void,
     getAcpConnectionDump(ignoredFields: string[]): string,
     clearAcpConnectionDump(): void,
+}
+
+export interface CodexConnectionDumpOptions {
+    placeholderResponseMethods?: string[];
 }
 
 export interface AcpConnectionConfig {
@@ -86,8 +90,29 @@ export function createBaseTestFixture(config: ConnectionConfig): TestFixture {
         getCodexAcpClient(): CodexAcpClient {
             return codexAcpClient;
         },
-        getCodexConnectionDump(ignoredFields: string[]): string {
-            return createArrayDump(transportEvents, ignoredFields);
+        getCodexConnectionDump(ignoredFields: string[], options?: CodexConnectionDumpOptions): string {
+            const placeholderResponseMethods = new Set(options?.placeholderResponseMethods ?? []);
+            const pendingRequestMethods: string[] = [];
+
+            const filteredEvents = transportEvents.flatMap((event) => {
+                switch (event.eventType) {
+                    case "request":
+                        pendingRequestMethods.push(event.method);
+                        break;
+                    case "response":
+                        const requestMethod = pendingRequestMethods.shift();
+                        if (requestMethod && placeholderResponseMethods.has(requestMethod)) {
+                            return [{
+                                eventType: "response" as const,
+                                placeholder: requestMethod,
+                            }];
+                        }
+                        break;
+                }
+
+                return [event];
+            });
+            return createArrayDump(filteredEvents, ignoredFields);
         },
         onCodexConnectionEvent(handler: (event: CodexConnectionEvent) => void): void {
             codexEventHandlers.push(handler);

--- a/src/__tests__/acp-test-utils.ts
+++ b/src/__tests__/acp-test-utils.ts
@@ -40,7 +40,7 @@ export interface TestFixture {
     getCodexAcpAgent(): CodexAcpServer,
 
     onCodexConnectionEvent(handler: (event: CodexConnectionEvent) => void): void,
-    getCodexConnectionDump(ignoredFields: string[], options?: { ignoreNotificationMethods?: string[] }): string,
+    getCodexConnectionDump(ignoredFields: string[]): string,
     clearCodexConnectionDump(): void,
 
     onAcpConnectionEvent(handler: (event: MethodCallEvent) => void): void,
@@ -86,14 +86,8 @@ export function createBaseTestFixture(config: ConnectionConfig): TestFixture {
         getCodexAcpClient(): CodexAcpClient {
             return codexAcpClient;
         },
-        getCodexConnectionDump(ignoredFields: string[], options?: { ignoreNotificationMethods?: string[] }): string {
-            const ignoredMethods = new Set(options?.ignoreNotificationMethods ?? []);
-            const filteredEvents = ignoredMethods.size === 0
-                ? transportEvents
-                : transportEvents.filter((event) =>
-                    !(event.eventType === "notification" && ignoredMethods.has(event.method))
-                );
-            return createArrayDump(filteredEvents, ignoredFields);
+        getCodexConnectionDump(ignoredFields: string[]): string {
+            return createArrayDump(transportEvents, ignoredFields);
         },
         onCodexConnectionEvent(handler: (event: CodexConnectionEvent) => void): void {
             codexEventHandlers.push(handler);


### PR DESCRIPTION
- Force file-based credential storage via temp CODEX_HOME in auth test. Otherwise, they fail when running by sandboxed codex.
- Stabilize snapshot comparison by replacing response payload with a placeholder.
- Update AGENTS.md test/style guidance for explicit switch cases and snapshot placeholders.