### PR TITLE
LLM-25262 Account for cached input tokens separately

### DIFF
--- a/src/CodexCommands.ts
+++ b/src/CodexCommands.ts
@@ -245,8 +245,9 @@ export class CodexCommands {
         }
         const total = this.formatTokenCount(usage.totalTokens);
         const input = this.formatTokenCount(usage.inputTokens);
+        const cachedInput = this.formatTokenCount(usage.cachedInputTokens);
         const output = this.formatTokenCount(usage.outputTokens);
-        return `${total} total  (${input} input + ${output} output)`;
+        return `${total} total  (${input} input + ${cachedInput} cached input, ${output} output)`;
     }
 
     private formatContextWindow(usage: TokenCount | null, contextWindow: number | null): string {

--- a/src/TokenCount.ts
+++ b/src/TokenCount.ts
@@ -3,6 +3,12 @@ import type {TokenUsageBreakdown} from "./app-server/v2";
 /**
  * Token usage information for a turn.
  * This interface decouples our API from Codex's internal types.
+ *
+ * [totalTokens]: total number of tokens used (the sum of all other fields)
+ * [inputTokens]: number of non-cached input tokens
+ * [cachedInputTokens]: number of cached input tokens
+ * [outputTokens]: number of output tokens (including reasoning output tokens)
+ * [reasoningOutputTokens]: number of reasoning output tokens
  */
 export interface TokenCount {
     totalTokens: number;
@@ -15,11 +21,13 @@ export interface TokenCount {
 /**
  * Maps Codex's TokenUsageBreakdown to our TokenCount interface.
  * This explicit mapping ensures compile-time errors if Codex changes their types.
+ * Note: Codex includes cached input tokens in the input token count, so they are subtracted here.
  */
 export function toTokenCount(usage: TokenUsageBreakdown): TokenCount {
+
     return {
         totalTokens: usage.totalTokens,
-        inputTokens: usage.inputTokens,
+        inputTokens: usage.inputTokens - usage.cachedInputTokens,
         cachedInputTokens: usage.cachedInputTokens,
         outputTokens: usage.outputTokens,
         reasoningOutputTokens: usage.reasoningOutputTokens,

--- a/src/__tests__/CodexACPAgent/data/token-usage-end-turn.json
+++ b/src/__tests__/CodexACPAgent/data/token-usage-end-turn.json
@@ -4,7 +4,7 @@
     "quota": {
       "token_count": {
         "totalTokens": 2500,
-        "inputTokens": 2000,
+        "inputTokens": 1500,
         "cachedInputTokens": 500,
         "outputTokens": 450,
         "reasoningOutputTokens": 50
@@ -14,7 +14,7 @@
           "model": "model-id",
           "token_count": {
             "totalTokens": 2500,
-            "inputTokens": 2000,
+            "inputTokens": 1500,
             "cachedInputTokens": 500,
             "outputTokens": 450,
             "reasoningOutputTokens": 50

--- a/src/__tests__/CodexACPAgent/data/token-usage-multiple-updates.json
+++ b/src/__tests__/CodexACPAgent/data/token-usage-multiple-updates.json
@@ -4,7 +4,7 @@
     "quota": {
       "token_count": {
         "totalTokens": 1500,
-        "inputTokens": 1200,
+        "inputTokens": 700,
         "cachedInputTokens": 500,
         "outputTokens": 200,
         "reasoningOutputTokens": 100
@@ -14,7 +14,7 @@
           "model": "model-id",
           "token_count": {
             "totalTokens": 1500,
-            "inputTokens": 1200,
+            "inputTokens": 700,
             "cachedInputTokens": 500,
             "outputTokens": 200,
             "reasoningOutputTokens": 100


### PR DESCRIPTION
The number of input tokens reported by Codex includes the cached input tokens count. Codex CLI itself subtracts cached tokens count when reporting token usage (see `protocol.rs`: `impl fmt::Display for FinalOutput`. The ACP server does not do this.
 
Changes:
  * Cached input tokens are no more included in the input tokens.
  * Changed the token usage text in the `/status` command.
  
<img width="649" height="391" alt="Screenshot 2026-03-18 at 11 30 32" src="https://github.com/user-attachments/assets/e5f326dc-ae7a-4b6e-bece-9beb1f4c1485" />

<img width="671" height="453" alt="Screenshot 2026-03-18 at 11 30 14" src="https://github.com/user-attachments/assets/e8730e43-f1e4-4cda-b0c8-ee57fc64519b" />
