### PR TITLE
Use last-turn token usage for ACP context updates

### DIFF
--- a/src/CodexCommands.ts
+++ b/src/CodexCommands.ts
@@ -206,7 +206,7 @@ export class CodexCommands {
         const accountText = this.formatAccountInfo(sessionState.account);
         const tokenUsageText = this.formatTokenUsage(sessionState.totalTokenUsage);
         const contextWindowText = this.formatContextWindow(
-            sessionState.totalTokenUsage,
+            sessionState.lastTokenUsage,
             sessionState.modelContextWindow
         );
 

--- a/src/CodexEventHandler.ts
+++ b/src/CodexEventHandler.ts
@@ -401,7 +401,7 @@ export class CodexEventHandler {
     private createUsageUpdate(params: ThreadTokenUsageUpdatedNotification): UpdateSessionEvent | null {
         this.handleTokenUsageUpdated(params);
 
-        const used = this.sessionState.totalTokenUsage?.totalTokens;
+        const used = this.sessionState.lastTokenUsage?.totalTokens;
         const size = this.sessionState.modelContextWindow;
         if (used == null || size == null || size <= 0) {
             return null;

--- a/src/__tests__/CodexACPAgent/data/token-usage-session-update-multiple.json
+++ b/src/__tests__/CodexACPAgent/data/token-usage-session-update-multiple.json
@@ -19,7 +19,7 @@
         "sessionId": "test-session-id",
         "update": {
           "sessionUpdate": "usage_update",
-          "used": 2000,
+          "used": 1000,
           "size": 128000
         }
       }
@@ -32,7 +32,7 @@
         "sessionId": "test-session-id",
         "update": {
           "sessionUpdate": "usage_update",
-          "used": 3500,
+          "used": 1500,
           "size": 128000
         }
       }

--- a/src/__tests__/CodexACPAgent/data/token-usage-session-update.json
+++ b/src/__tests__/CodexACPAgent/data/token-usage-session-update.json
@@ -5,7 +5,7 @@
       "sessionId": "test-session-id",
       "update": {
         "sessionUpdate": "usage_update",
-        "used": 5000,
+        "used": 2500,
         "size": 128000
       }
     }

--- a/src/__tests__/CodexACPAgent/token-usage-events.test.ts
+++ b/src/__tests__/CodexACPAgent/token-usage-events.test.ts
@@ -190,7 +190,7 @@ describe('Token Usage Events', () => {
             };
         }
 
-        it('should emit usage_update with cumulative context usage', async () => {
+        it('should emit usage_update with latest turn usage as a context proxy', async () => {
             const events = await setupPromptAndReturnEvents([
                 createTokenUsageNotification(sessionId, {
                     total: {
@@ -214,7 +214,7 @@ describe('Token Usage Events', () => {
             await expect(`${JSON.stringify(events[0], null, 2)}\n`).toMatchFileSnapshot('data/token-usage-session-update.json');
         });
 
-        it('should emit latest cumulative usage from multiple updates', async () => {
+        it('should emit latest turn usage from multiple updates', async () => {
             const events = await setupPromptAndReturnEvents([
                 createTokenUsageNotification(sessionId, {
                     total: { totalTokens: 1000, inputTokens: 800, cachedInputTokens: 0, outputTokens: 200, reasoningOutputTokens: 0 },


### PR DESCRIPTION
Report ACP context usage from last-turn token usage instead of cumulative totals, and align the status context window output with the same source.