### PR TITLE
Advertise auth logout capability

### DIFF
--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -35,7 +35,7 @@ import type {
     UserInput,
 } from "./app-server/v2";
 import packageJson from "../package.json";
-import type {AuthenticationLogoutResponse, AuthenticationStatusResponse} from "./AcpExtensions";
+import type {AuthenticationStatusResponse} from "./AcpExtensions";
 
 /**
  * API for accessing the Codex App Server using ACP requests.
@@ -176,11 +176,10 @@ export class CodexAcpClient {
         return settingsModelProvider.config.model_provider;
     }
 
-    async logout(): Promise<AuthenticationLogoutResponse> {
+    async logout(): Promise<void> {
         const accountUpdatedPromise = this.awaitNextAccountUpdated();
         await this.codexClient.accountLogout();
         await accountUpdatedPromise;
-        return {};
     }
 
     async authRequired(): Promise<Boolean> {

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -96,6 +96,9 @@ export class CodexAcpServer implements acp.Agent {
         return {
             protocolVersion: acp.PROTOCOL_VERSION,
             agentCapabilities: {
+                auth: {
+                    logout: {},
+                },
                 loadSession: true,
                 promptCapabilities: {
                     image: true
@@ -121,8 +124,10 @@ export class CodexAcpServer implements acp.Agent {
         switch (methodRequest.method) {
             case "authentication/status":
                 return await this.runWithProcessCheck(() => this.codexAcpClient.getAuthenticationStatus());
-            case "authentication/logout":
-                return await this.runWithProcessCheck(() => this.codexAcpClient.logout());
+            case "authentication/logout": {
+                await this.unstable_logout({});
+                return {};
+            }
         }
     }
 
@@ -268,6 +273,12 @@ export class CodexAcpServer implements acp.Agent {
         }
         logger.log("Authenticate request completed");
         return { };
+    }
+
+    async unstable_logout(_params: acp.LogoutRequest): Promise<void> {
+        logger.log("Logout request received");
+        await this.runWithProcessCheck(() => this.codexAcpClient.logout());
+        logger.log("Logout request completed");
     }
 
     async setSessionMode(

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -150,7 +150,7 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         const mockFixture = createCodexMockTestFixture();
         const codexAcpAgent = mockFixture.getCodexAcpAgent();
 
-        const logoutSpy = vi.spyOn(codexAcpAgent, "unstable_logout");
+        const logoutSpy = vi.spyOn(codexAcpAgent, "unstable_logout").mockResolvedValue();
 
         await expect(codexAcpAgent.extMethod("authentication/logout", {})).resolves.toEqual({});
         expect(logoutSpy).toHaveBeenCalledWith({});
@@ -575,7 +575,7 @@ describe('ACP server test', { timeout: 40_000 }, () => {
 
         const sessionState: SessionState = createTestSessionState();
 
-        const logoutSpy = vi.spyOn(mockFixture.getCodexAcpClient(), "logout");
+        const logoutSpy = vi.spyOn(mockFixture.getCodexAcpClient(), "logout").mockResolvedValue();
 
         // @ts-expect-error - exercising private helper
         const handled = await codexAcpAgent.availableCommands.handleCommand({ name: "logout", input: null }, sessionState);

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -103,7 +103,7 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         const authenticatedResponse = await keyFixture.getCodexAcpAgent().extMethod("authentication/status", {});
         expect(authenticatedResponse).toEqual({type: "api-key"});
 
-        await keyFixture.getCodexAcpAgent().extMethod("authentication/logout", {});
+        await keyFixture.getCodexAcpAgent().unstable_logout({});
         const logoutResponse = await keyFixture.getCodexAcpAgent().extMethod("authentication/status", {});
         expect(logoutResponse).toEqual({type: "unauthenticated"});
     });
@@ -145,6 +145,16 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         const newSessionResponse = await codexAcpAgent.newSession({cwd: "", mcpServers: []});
         expect(newSessionResponse.sessionId).toBeDefined()
     })
+
+    it('supports legacy authentication/logout ext method', async () => {
+        const mockFixture = createCodexMockTestFixture();
+        const codexAcpAgent = mockFixture.getCodexAcpAgent();
+
+        const logoutSpy = vi.spyOn(codexAcpAgent, "unstable_logout").mockResolvedValue({});
+
+        await expect(codexAcpAgent.extMethod("authentication/logout", {})).resolves.toEqual({});
+        expect(logoutSpy).toHaveBeenCalledWith({});
+    });
 
     it('prefetches session additional skill roots before thread start', async () => {
         const mockFixture = createCodexMockTestFixture();

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -150,7 +150,7 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         const mockFixture = createCodexMockTestFixture();
         const codexAcpAgent = mockFixture.getCodexAcpAgent();
 
-        const logoutSpy = vi.spyOn(codexAcpAgent, "unstable_logout").mockResolvedValue({});
+        const logoutSpy = vi.spyOn(codexAcpAgent, "unstable_logout");
 
         await expect(codexAcpAgent.extMethod("authentication/logout", {})).resolves.toEqual({});
         expect(logoutSpy).toHaveBeenCalledWith({});
@@ -575,7 +575,7 @@ describe('ACP server test', { timeout: 40_000 }, () => {
 
         const sessionState: SessionState = createTestSessionState();
 
-        const logoutSpy = vi.spyOn(mockFixture.getCodexAcpClient(), "logout").mockResolvedValue({});
+        const logoutSpy = vi.spyOn(mockFixture.getCodexAcpClient(), "logout");
 
         // @ts-expect-error - exercising private helper
         const handled = await codexAcpAgent.availableCommands.handleCommand({ name: "logout", input: null }, sessionState);

--- a/src/__tests__/CodexACPAgent/initialize.test.ts
+++ b/src/__tests__/CodexACPAgent/initialize.test.ts
@@ -32,6 +32,9 @@ describe('CodexACPAgent - initialize', () => {
         expect(result).toEqual({
             protocolVersion: acp.PROTOCOL_VERSION,
             agentCapabilities: {
+                auth: {
+                    logout: {},
+                },
                 loadSession: true,
                 promptCapabilities: {
                     image: true


### PR DESCRIPTION
Route logout through unstable ACP auth support while keeping the
legacy authentication/logout extension method as a compatibility
shim.
