### PR TITLE
Gate gateway auth by client capabilities

### DIFF
--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -8,7 +8,7 @@ import {
 import {CodexEventHandler} from "./CodexEventHandler";
 import {CodexApprovalHandler} from "./CodexApprovalHandler";
 import {CodexElicitationHandler} from "./CodexElicitationHandler";
-import {CodexAuthMethods, type CodexAuthRequest} from "./CodexAuthMethod";
+import {getCodexAuthMethods, type CodexAuthRequest} from "./CodexAuthMethod";
 import {CodexAcpClient, type SessionMetadata, type SessionMetadataWithThread} from "./CodexAcpClient";
 import {ACPSessionConnection, type UpdateSessionEvent} from "./ACPSessionConnection";
 import type {McpStartupCompleteEvent, InputModality, ReasoningEffort} from "./app-server";
@@ -107,7 +107,7 @@ export class CodexAcpServer implements acp.Agent {
                     sse: false
                 }
             },
-            authMethods: CodexAuthMethods,
+            authMethods: getCodexAuthMethods(_params.clientCapabilities),
         };
     }
 

--- a/src/CodexAuthMethod.ts
+++ b/src/CodexAuthMethod.ts
@@ -1,5 +1,5 @@
 
-import type {AuthenticateRequest, AuthMethod} from "@agentclientprotocol/sdk";
+import type {AuthenticateRequest, AuthMethod, ClientCapabilities} from "@agentclientprotocol/sdk";
 
 const ApiKeyAuthMethod: AuthMethod = {
     id: "api-key",
@@ -54,7 +54,14 @@ export interface GatewayAuthRequest extends AuthenticateRequest {
     };
 }
 
-export const CodexAuthMethods: AuthMethod[] = [ApiKeyAuthMethod, ChatGptAuthMethod, GatewayAuthMethod];
+export function getCodexAuthMethods(clientCapabilities?: ClientCapabilities | null): AuthMethod[] {
+    const authMethods: AuthMethod[] = [ApiKeyAuthMethod, ChatGptAuthMethod];
+    const supportsGatewayAuth = clientCapabilities?.auth?._meta?.["gateway"] === true;
+    if (supportsGatewayAuth) {
+        authMethods.push(GatewayAuthMethod);
+    }
+    return authMethods;
+}
 
 export type CodexAuthRequest = ApiKeyAuthRequest | ChatGPTAuthRequest | GatewayAuthRequest;
 

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -112,7 +112,16 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         const gatewayFixture = createTestFixture();
         const codexAcpAgent = gatewayFixture.getCodexAcpAgent();
 
-        await codexAcpAgent.initialize({protocolVersion: 1});
+        await codexAcpAgent.initialize({
+            protocolVersion: 1,
+            clientCapabilities: {
+                auth: {
+                    _meta: {
+                        gateway: true,
+                    }
+                }
+            }
+        });
         await gatewayFixture.getCodexAcpClient().logout();
 
         const authRequest: CodexAuthRequest = {

--- a/src/__tests__/CodexACPAgent/initialize.test.ts
+++ b/src/__tests__/CodexACPAgent/initialize.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { CodexAcpServer } from '../../CodexAcpServer';
 import * as acp from '@agentclientprotocol/sdk';
 import { createMockConnections } from './test-utils';
-import {CodexAuthMethods} from "../../CodexAuthMethod";
+import {getCodexAuthMethods} from "../../CodexAuthMethod";
 import {CodexAcpClient} from "../../CodexAcpClient";
 import {CodexAppServerClient} from "../../CodexAppServerClient";
 
@@ -45,7 +45,28 @@ describe('CodexACPAgent - initialize', () => {
                     sse: false,
                 },
             },
-            authMethods: CodexAuthMethods,
+            authMethods: getCodexAuthMethods(),
         });
+    });
+
+    it('should advertise gateway auth when the client opts into gateway auth metadata', async () => {
+        const params: acp.InitializeRequest = {
+            protocolVersion: acp.PROTOCOL_VERSION,
+            clientCapabilities: {
+                auth: {
+                    _meta: {
+                        gateway: true,
+                    }
+                }
+            }
+        };
+
+        const result = await agent.initialize(params);
+
+        expect(result.authMethods).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                id: "gateway",
+            })
+        ]));
     });
 });


### PR DESCRIPTION
Only advertise the gateway auth method when the client opts in
via `clientCapabilities.auth._meta.gateway`.

Mirrors the setup we have in claude-agent-acp.
