### PR TITLE
Add /review command support

### DIFF
--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -28,6 +28,7 @@ import type {
     GetAccountResponse,
     ListMcpServerStatusResponse,
     Model,
+    ReviewTarget,
     SkillsListParams,
     SkillsListResponse,
     Thread,
@@ -472,6 +473,14 @@ export class CodexAcpClient {
 
     markTurnStale(params: { threadId: string, turnId: string }): void {
         this.codexClient.markTurnStale(params.threadId, params.turnId);
+    }
+
+    async runReview(threadId: string, target: ReviewTarget): Promise<TurnCompletedNotification> {
+        return await this.codexClient.runReview({
+            threadId,
+            target,
+            delivery: "inline",
+        });
     }
 
     async listSkills(params?: SkillsListParams): Promise<SkillsListResponse> {

--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -475,12 +475,16 @@ export class CodexAcpClient {
         this.codexClient.markTurnStale(params.threadId, params.turnId);
     }
 
-    async runReview(threadId: string, target: ReviewTarget): Promise<TurnCompletedNotification> {
+    async runReview(
+        threadId: string,
+        target: ReviewTarget,
+        onTurnStarted?: (turnId: string) => void
+    ): Promise<TurnCompletedNotification> {
         return await this.codexClient.runReview({
             threadId,
             target,
             delivery: "inline",
-        });
+        }, onTurnStarted);
     }
 
     async listSkills(params?: SkillsListParams): Promise<SkillsListResponse> {

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -1223,8 +1223,20 @@ export class CodexAcpServer implements acp.Agent {
                 approvalHandler,
                 elicitationHandler);
 
-            if (await this.availableCommands.tryHandleCommand(params.prompt, sessionState)) {
+            const commandResult = await this.availableCommands.tryHandleCommand(params.prompt, sessionState);
+            if (commandResult.handled) {
                 logger.log("Prompt handled by a command");
+                if (commandResult.turnCompleted) {
+                    await this.codexAcpClient.waitForSessionNotifications(params.sessionId);
+                    if (commandResult.turnCompleted.turn.status === "interrupted") {
+                        return await this.createInterruptedPromptResponse(params.sessionId, sessionState);
+                    }
+                    const error = eventHandler.getFailure()
+                    if (error) {
+                        // noinspection ExceptionCaughtLocallyJS
+                        throw error;
+                    }
+                }
                 return {
                     stopReason: "end_turn",
                     usage: this.buildPromptUsage(sessionState.lastTokenUsage),
@@ -1302,23 +1314,7 @@ export class CodexAcpServer implements acp.Agent {
 
             // Check if turn was interrupted (cancelled)
             if (turnCompleted.turn.status === "interrupted") {
-                if (!this.sessionIsClosing(params.sessionId) && this.sessions.has(params.sessionId)) {
-                    await this.connection.sessionUpdate({
-                        sessionId: params.sessionId,
-                        update: {
-                            sessionUpdate: "agent_message_chunk",
-                            content: {
-                                type: "text",
-                                text: "*Conversation interrupted*"
-                            }
-                        }
-                    });
-                }
-                return {
-                    stopReason: "cancelled",
-                    usage: this.buildPromptUsage(sessionState.lastTokenUsage),
-                    _meta: this.buildQuotaMeta(sessionState),
-                };
+                return await this.createInterruptedPromptResponse(params.sessionId, sessionState);
             }
 
             const error = eventHandler.getFailure()
@@ -1344,6 +1340,29 @@ export class CodexAcpServer implements acp.Agent {
             pendingTurnStart?.resolve(null);
             activePrompt.complete();
         }
+    }
+
+    private async createInterruptedPromptResponse(
+        sessionId: string,
+        sessionState: SessionState
+    ): Promise<acp.PromptResponse> {
+        if (!this.sessionIsClosing(sessionId) && this.sessions.has(sessionId)) {
+            await this.connection.sessionUpdate({
+                sessionId,
+                update: {
+                    sessionUpdate: "agent_message_chunk",
+                    content: {
+                        type: "text",
+                        text: "*Conversation interrupted*"
+                    }
+                }
+            });
+        }
+        return {
+            stopReason: "cancelled",
+            usage: this.buildPromptUsage(sessionState.lastTokenUsage),
+            _meta: this.buildQuotaMeta(sessionState),
+        };
     }
 
     private buildQuotaMeta(sessionState: SessionState): { quota: QuotaMeta } {

--- a/src/CodexAppServerClient.ts
+++ b/src/CodexAppServerClient.ts
@@ -21,6 +21,8 @@ import type {
     McpServerStatusUpdatedNotification,
     ModelListParams,
     ModelListResponse,
+    ReviewStartParams,
+    ReviewStartResponse,
     SkillsExtraRootsSetParams,
     SkillsListParams,
     SkillsListResponse,
@@ -189,6 +191,10 @@ export class CodexAppServerClient {
         return await this.sendRequest({ method: "turn/start", params: params });
     }
 
+    async reviewStart(params: ReviewStartParams): Promise<ReviewStartResponse> {
+        return await this.sendRequest({ method: "review/start", params: params });
+    }
+
     async runTurn(params: TurnStartParams, onTurnStarted?: (turnId: string) => void): Promise<TurnCompletedNotification> {
         const capturedCompletions: Array<TurnCompletedNotification> = [];
         const releaseCapture = this.captureTurnCompletions(params.threadId, (event) => {
@@ -206,6 +212,31 @@ export class CodexAppServerClient {
             // Wait for turn completion
             // If turnInterrupt() was called, Codex will send turn/completed event with status "interrupted"
             return await this.awaitTurnCompleted(params.threadId, turnStarted.turn.id);
+        } finally {
+            releaseCapture();
+        }
+    }
+
+    async runReview(params: ReviewStartParams): Promise<TurnCompletedNotification> {
+        if (params.delivery === "detached") {
+            throw new Error("runReview only supports inline review delivery");
+        }
+        const capturedCompletions: Array<TurnCompletedNotification> = [];
+        const releaseCapture = this.captureTurnCompletions(params.threadId, (event) => {
+            capturedCompletions.push(event);
+        });
+
+        try {
+            const reviewStarted = await this.reviewStart(params);
+            const earlyCompletion = capturedCompletions.find(event =>
+                event.threadId === reviewStarted.reviewThreadId
+                && event.turn.id === reviewStarted.turn.id
+            );
+            releaseCapture();
+            if (earlyCompletion) {
+                return earlyCompletion;
+            }
+            return await this.awaitTurnCompleted(reviewStarted.reviewThreadId, reviewStarted.turn.id);
         } finally {
             releaseCapture();
         }

--- a/src/CodexAppServerClient.ts
+++ b/src/CodexAppServerClient.ts
@@ -217,7 +217,10 @@ export class CodexAppServerClient {
         }
     }
 
-    async runReview(params: ReviewStartParams): Promise<TurnCompletedNotification> {
+    async runReview(
+        params: ReviewStartParams,
+        onTurnStarted?: (turnId: string) => void
+    ): Promise<TurnCompletedNotification> {
         if (params.delivery === "detached") {
             throw new Error("runReview only supports inline review delivery");
         }
@@ -228,6 +231,7 @@ export class CodexAppServerClient {
 
         try {
             const reviewStarted = await this.reviewStart(params);
+            onTurnStarted?.(reviewStarted.turn.id);
             const earlyCompletion = capturedCompletions.find(event =>
                 event.threadId === reviewStarted.reviewThreadId
                 && event.turn.id === reviewStarted.turn.id

--- a/src/CodexCommands.ts
+++ b/src/CodexCommands.ts
@@ -192,7 +192,9 @@ export class CodexCommands {
                 }
                 const target: ReviewTarget = {type: "uncommittedChanges"};
                 const turnCompleted = await this.runWithProcessCheck(() =>
-                    this.codexAcpClient.runReview(sessionId, target)
+                    this.codexAcpClient.runReview(sessionId, target, (turnId) => {
+                        sessionState.currentTurnId = turnId;
+                    })
                 );
                 return {handled: true, turnCompleted};
             }

--- a/src/CodexCommands.ts
+++ b/src/CodexCommands.ts
@@ -2,11 +2,15 @@ import type * as acp from "@agentclientprotocol/sdk";
 import type {AgentSideConnection, AvailableCommand} from "@agentclientprotocol/sdk";
 import {ACPSessionConnection} from "./ACPSessionConnection";
 import type {CodexAcpClient} from "./CodexAcpClient";
-import type {RateLimitSnapshot, SkillsListEntry} from "./app-server/v2";
+import type {RateLimitSnapshot, ReviewTarget, SkillsListEntry, TurnCompletedNotification} from "./app-server/v2";
 import type {SessionState} from "./CodexAcpServer";
 import type {RateLimitsMap} from "./RateLimitsMap";
 import type {TokenCount} from "./TokenCount";
 import {logger} from "./Logger";
+
+type CommandHandlingResult =
+    | { handled: false }
+    | { handled: true; turnCompleted?: TurnCompletedNotification };
 
 export class CodexCommands {
     private readonly connection: AgentSideConnection;
@@ -74,6 +78,11 @@ export class CodexCommands {
                 input: null
             },
             {
+                name: "review",
+                description: "Review uncommitted changes.",
+                input: null
+            },
+            {
                 name: "skills",
                 description: "List available skills.",
                 input: null
@@ -91,7 +100,7 @@ export class CodexCommands {
         ];
     }
 
-    private getCommandName(prompt: acp.ContentBlock[]): string | null {
+    private parseCommand(prompt: acp.ContentBlock[]): ParsedCommand | null {
         const firstBlock = prompt[0];
         if (!firstBlock || firstBlock.type != "text") return null;
 
@@ -101,17 +110,25 @@ export class CodexCommands {
         const commandText = text.slice(1).trim();
         if (commandText.length === 0) return null;
 
-        const [name] = commandText.split(/\s+/);
-        return name?.toLowerCase() ?? null;
+        const separatorIndex = commandText.search(/\s/);
+        if (separatorIndex === -1) {
+            return {name: commandText.toLowerCase(), input: null};
+        }
+        const name = commandText.slice(0, separatorIndex).toLowerCase();
+        const input = commandText.slice(separatorIndex).trim();
+        return {name, input: input.length > 0 ? input : null};
     }
 
-    async tryHandleCommand(prompt: acp.ContentBlock[], sessionState: SessionState): Promise<boolean> {
-        const commandName = this.getCommandName(prompt);
-        if (commandName === null) return false;
-        if (commandName.startsWith("$")) return false;
+    async tryHandleCommand(
+        prompt: acp.ContentBlock[],
+        sessionState: SessionState
+    ): Promise<CommandHandlingResult> {
+        const command = this.parseCommand(prompt);
+        if (command === null) return {handled: false};
+        if (command.name.startsWith("$")) return {handled: false};
 
         const sessionId = sessionState.sessionId;
-        switch (commandName) {
+        switch (command.name) {
             case "status": {
                 const session = new ACPSessionConnection(this.connection, sessionId);
                 const message = this.buildStatusMessage(sessionState);
@@ -119,7 +136,7 @@ export class CodexCommands {
                     sessionUpdate: "agent_message_chunk",
                     content: { type: "text", text: message }
                 });
-                return true;
+                return {handled: true};
             }
             case "logout": {
                 await this.runWithProcessCheck(() => this.codexAcpClient.logout());
@@ -128,7 +145,7 @@ export class CodexCommands {
                     sessionUpdate: "agent_message_chunk",
                     content: { type: "text", text: "Logged out from Codex account." }
                 });
-                return true;
+                return {handled: true};
             }
             case "skills": {
                 const response = await this.runWithProcessCheck(() => this.codexAcpClient.listSkills());
@@ -145,7 +162,7 @@ export class CodexCommands {
                     sessionUpdate: "agent_message_chunk",
                     content: { type: "text", text }
                 });
-                return true;
+                return {handled: true};
             }
             case "mcp": {
                 const servers = await this.runWithProcessCheck(() => this.codexAcpClient.listMcpServers());
@@ -166,12 +183,31 @@ export class CodexCommands {
                     sessionUpdate: "agent_message_chunk",
                     content: { type: "text", text }
                 });
-                return true;
+                return {handled: true};
+            }
+            case "review": {
+                if (command.input !== null) {
+                    await this.sendCommandMessage(sessionId, "/review does not accept arguments yet.");
+                    return {handled: true};
+                }
+                const target: ReviewTarget = {type: "uncommittedChanges"};
+                const turnCompleted = await this.runWithProcessCheck(() =>
+                    this.codexAcpClient.runReview(sessionId, target)
+                );
+                return {handled: true, turnCompleted};
             }
             default:
-                await this.sendUnknownCommandMessage(commandName, sessionId);
-                return true;
+                await this.sendUnknownCommandMessage(command.name, sessionId);
+                return {handled: true};
         }
+    }
+
+    private async sendCommandMessage(sessionId: string, text: string): Promise<void> {
+        const session = new ACPSessionConnection(this.connection, sessionId);
+        await session.update({
+            sessionUpdate: "agent_message_chunk",
+            content: {type: "text", text}
+        });
     }
 
     private async sendUnknownCommandMessage(name: string, sessionId: string): Promise<void> {
@@ -343,4 +379,7 @@ export class CodexCommands {
     }
 }
 
-type ParsedCommand = { name: string; };
+type ParsedCommand = {
+    name: string;
+    input: string | null;
+};

--- a/src/CodexEventHandler.ts
+++ b/src/CodexEventHandler.ts
@@ -255,6 +255,8 @@ export class CodexEventHandler {
                 return await createMcpToolCallUpdate(event.item);
             case "dynamicToolCall":
                 return await createDynamicToolCallUpdate(event.item);
+            case "enteredReviewMode":
+                return this.createReviewModeEvent(event.item, true);
             case "collabAgentToolCall":
             case "userMessage":
             case "hookPrompt":
@@ -263,7 +265,6 @@ export class CodexEventHandler {
             case "webSearch":
             case "imageView":
             case "imageGeneration":
-            case "enteredReviewMode":
             case "exitedReviewMode":
             case "contextCompaction":
             case "plan":
@@ -308,11 +309,29 @@ export class CodexEventHandler {
             case "imageView":
             case "imageGeneration":
             case "enteredReviewMode":
+                return null;
             case "exitedReviewMode":
+                return this.createReviewModeEvent(event.item, false);
             case "contextCompaction":
             case "plan":
                 return null;
         }
+    }
+
+    private createReviewModeEvent(
+        item: ThreadItem & { type: "enteredReviewMode" | "exitedReviewMode" },
+        entered: boolean
+    ): UpdateSessionEvent {
+        const text = entered
+            ? "Code review started: current changes"
+            : `${item.review}\n\nCode review finished`;
+        return {
+            sessionUpdate: "agent_message_chunk",
+            content: {
+                type: "text",
+                text: `${text}\n\n`,
+            },
+        };
     }
 
     private createCommandOutputDeltaEvent(event: CommandExecutionOutputDeltaNotification): UpdateSessionEvent {

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -13,7 +13,7 @@ import {
 import type {ServerNotification} from "../../app-server";
 import type {SessionState} from "../../CodexAcpServer";
 import {AgentMode} from "../../AgentMode";
-import type {Model, TurnStartParams} from "../../app-server/v2";
+import type {Model, TurnCompletedNotification, TurnStartParams} from "../../app-server/v2";
 import type {RateLimitsMap} from "../../RateLimitsMap";
 import {ModelId} from "../../ModelId";
 
@@ -910,6 +910,122 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         await codexAcpAgent.prompt({sessionId: newSessionResponse.sessionId, prompt: prompt });
         const transportDump = fixture.getAcpConnectionDump([]);
         expect(transportDump).contain(`**Session:** \`${newSessionResponse.sessionId}\``);
+    });
+
+    it('handles review command', async () => {
+        const mockFixture = createCodexMockTestFixture();
+        const codexAcpAgent = mockFixture.getCodexAcpAgent();
+        const sessionState: SessionState = createTestSessionState({sessionId: "session-id"});
+        const turnCompleted: TurnCompletedNotification = {
+            threadId: "session-id",
+            turn: {
+                id: "review-turn",
+                items: [],
+                itemsView: "full",
+                status: "completed",
+                error: null,
+                startedAt: null,
+                completedAt: null,
+                durationMs: null
+            }
+        };
+        const reviewSpy = vi.spyOn(mockFixture.getCodexAcpClient(), "runReview").mockResolvedValue(turnCompleted);
+        vi.spyOn(codexAcpAgent, "getSessionState").mockReturnValue(sessionState);
+
+        const response = await codexAcpAgent.prompt({
+            sessionId: "session-id",
+            prompt: [{type: "text", text: "/review"}]
+        });
+
+        expect(response.stopReason).toBe("end_turn");
+        expect(reviewSpy).toHaveBeenCalledWith("session-id", {type: "uncommittedChanges"});
+    });
+
+    it('rejects review command arguments', async () => {
+        const mockFixture = createCodexMockTestFixture();
+        const codexAcpAgent = mockFixture.getCodexAcpAgent();
+        const sessionState: SessionState = createTestSessionState({sessionId: "session-id"});
+        const reviewSpy = vi.spyOn(mockFixture.getCodexAcpClient(), "runReview");
+        vi.spyOn(codexAcpAgent, "getSessionState").mockReturnValue(sessionState);
+
+        const response = await codexAcpAgent.prompt({
+            sessionId: "session-id",
+            prompt: [{type: "text", text: "/review check race conditions"}]
+        });
+
+        expect(response.stopReason).toBe("end_turn");
+        expect(reviewSpy).not.toHaveBeenCalled();
+        await expect(mockFixture.getAcpConnectionDump([])).toMatchFileSnapshot("data/command-review-arguments.json");
+    });
+
+    it('returns cancelled when review command is interrupted', async () => {
+        const mockFixture = createCodexMockTestFixture();
+        const codexAcpAgent = mockFixture.getCodexAcpAgent();
+        const sessionState: SessionState = createTestSessionState({sessionId: "session-id"});
+        vi.spyOn(mockFixture.getCodexAcpClient(), "runReview").mockResolvedValue({
+            threadId: "session-id",
+            turn: {
+                id: "review-turn",
+                items: [],
+                itemsView: "full",
+                status: "interrupted",
+                error: null,
+                startedAt: null,
+                completedAt: null,
+                durationMs: null
+            }
+        });
+        vi.spyOn(codexAcpAgent, "getSessionState").mockReturnValue(sessionState);
+        // @ts-expect-error - exercising interruption behavior for a registered session
+        codexAcpAgent.sessions.set("session-id", sessionState);
+
+        const response = await codexAcpAgent.prompt({
+            sessionId: "session-id",
+            prompt: [{type: "text", text: "/review"}]
+        });
+
+        expect(response.stopReason).toBe("cancelled");
+        expect(mockFixture.getAcpConnectionDump([])).toContain("*Conversation interrupted*");
+    });
+
+    it('propagates review command event handler failures', async () => {
+        const mockFixture = createCodexMockTestFixture();
+        const codexAcpAgent = mockFixture.getCodexAcpAgent();
+        const sessionState: SessionState = createTestSessionState({sessionId: "session-id"});
+        vi.spyOn(mockFixture.getCodexAcpClient(), "runReview").mockImplementation(async () => {
+            mockFixture.sendServerNotification({
+                method: "error",
+                params: {
+                    threadId: "session-id",
+                    turnId: "review-turn",
+                    willRetry: false,
+                    error: {
+                        message: "auth failed",
+                        codexErrorInfo: "unauthorized",
+                        additionalDetails: null
+                    }
+                }
+            });
+            return {
+                threadId: "session-id",
+                turn: {
+                    id: "review-turn",
+                    items: [],
+                    itemsView: "full",
+                    status: "completed",
+                    error: null,
+                    startedAt: null,
+                    completedAt: null,
+                    durationMs: null
+                }
+            };
+        });
+        vi.spyOn(codexAcpAgent, "getSessionState").mockReturnValue(sessionState);
+
+        await expect(codexAcpAgent.prompt({
+            sessionId: "session-id",
+            prompt: [{type: "text", text: "/review"}]
+        })).rejects.toBeTruthy();
     });
 
     const mockModels: Model[] = [

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -938,7 +938,11 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         });
 
         expect(response.stopReason).toBe("end_turn");
-        expect(reviewSpy).toHaveBeenCalledWith("session-id", {type: "uncommittedChanges"});
+        expect(reviewSpy).toHaveBeenCalledWith(
+            "session-id",
+            {type: "uncommittedChanges"},
+            expect.any(Function)
+        );
     });
 
     it('rejects review command arguments', async () => {
@@ -986,6 +990,64 @@ describe('ACP server test', { timeout: 40_000 }, () => {
 
         expect(response.stopReason).toBe("cancelled");
         expect(mockFixture.getAcpConnectionDump([])).toContain("*Conversation interrupted*");
+    });
+
+    it('interrupts an active review command when cancelled', async () => {
+        const mockFixture = createCodexMockTestFixture();
+        const codexAcpAgent = mockFixture.getCodexAcpAgent();
+        const sessionState: SessionState = createTestSessionState({sessionId: "session-id"});
+        vi.spyOn(codexAcpAgent, "getSessionState").mockReturnValue(sessionState);
+        // @ts-expect-error - exercising cancellation for a registered session
+        codexAcpAgent.sessions.set("session-id", sessionState);
+
+        const reviewStartSpy = vi.spyOn(mockFixture.getCodexAppServerClient(), "reviewStart").mockResolvedValue({
+            reviewThreadId: "session-id",
+            turn: {
+                id: "review-turn",
+                items: [],
+                itemsView: "full",
+                status: "inProgress",
+                error: null,
+                startedAt: null,
+                completedAt: null,
+                durationMs: null
+            }
+        });
+        let completeReview: (value: TurnCompletedNotification) => void = () => {};
+        const reviewCompleted = new Promise<TurnCompletedNotification>((resolve) => {
+            completeReview = resolve;
+        });
+        vi.spyOn(mockFixture.getCodexAppServerClient(), "awaitTurnCompleted").mockReturnValue(reviewCompleted);
+        const turnInterruptSpy = vi.spyOn(mockFixture.getCodexAcpClient(), "turnInterrupt").mockResolvedValue();
+
+        const promptPromise = codexAcpAgent.prompt({
+            sessionId: "session-id",
+            prompt: [{type: "text", text: "/review"}]
+        });
+        await vi.waitFor(() => {
+            expect(reviewStartSpy).toHaveBeenCalled();
+        });
+
+        await codexAcpAgent.cancel({sessionId: "session-id"});
+        completeReview({
+            threadId: "session-id",
+            turn: {
+                id: "review-turn",
+                items: [],
+                itemsView: "full",
+                status: "interrupted",
+                error: null,
+                startedAt: null,
+                completedAt: null,
+                durationMs: null
+            }
+        });
+        await expect(promptPromise).resolves.toMatchObject({stopReason: "cancelled"});
+
+        expect(turnInterruptSpy).toHaveBeenCalledWith({
+            threadId: "session-id",
+            turnId: "review-turn"
+        });
     });
 
     it('propagates review command event handler failures', async () => {

--- a/src/__tests__/CodexACPAgent/data/available-commands-build-in.json
+++ b/src/__tests__/CodexACPAgent/data/available-commands-build-in.json
@@ -12,6 +12,11 @@
             "input": null
           },
           {
+            "name": "review",
+            "description": "Review uncommitted changes.",
+            "input": null
+          },
+          {
             "name": "skills",
             "description": "List available skills.",
             "input": null

--- a/src/__tests__/CodexACPAgent/data/available-commands-skills.json
+++ b/src/__tests__/CodexACPAgent/data/available-commands-skills.json
@@ -12,6 +12,11 @@
             "input": null
           },
           {
+            "name": "review",
+            "description": "Review uncommitted changes.",
+            "input": null
+          },
+          {
             "name": "skills",
             "description": "List available skills.",
             "input": null

--- a/src/__tests__/CodexACPAgent/data/command-review-arguments.json
+++ b/src/__tests__/CodexACPAgent/data/command-review-arguments.json
@@ -1,0 +1,15 @@
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "session-id",
+      "update": {
+        "sessionUpdate": "agent_message_chunk",
+        "content": {
+          "type": "text",
+          "text": "/review does not accept arguments yet."
+        }
+      }
+    }
+  ]
+}

--- a/src/__tests__/CodexACPAgent/data/load-session-history.json
+++ b/src/__tests__/CodexACPAgent/data/load-session-history.json
@@ -12,6 +12,11 @@
             "input": null
           },
           {
+            "name": "review",
+            "description": "Review uncommitted changes.",
+            "input": null
+          },
+          {
             "name": "skills",
             "description": "List available skills.",
             "input": null

--- a/src/__tests__/CodexACPAgent/data/review-entered.json
+++ b/src/__tests__/CodexACPAgent/data/review-entered.json
@@ -1,0 +1,15 @@
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
+        "sessionUpdate": "agent_message_chunk",
+        "content": {
+          "type": "text",
+          "text": "Code review started: current changes\n\n"
+        }
+      }
+    }
+  ]
+}

--- a/src/__tests__/CodexACPAgent/data/review-exited.json
+++ b/src/__tests__/CodexACPAgent/data/review-exited.json
@@ -1,0 +1,15 @@
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
+        "sessionUpdate": "agent_message_chunk",
+        "content": {
+          "type": "text",
+          "text": "No findings.\n\nCode review finished\n\n"
+        }
+      }
+    }
+  ]
+}

--- a/src/__tests__/CodexACPAgent/review-events.test.ts
+++ b/src/__tests__/CodexACPAgent/review-events.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { SessionState } from "../../CodexAcpServer";
+import type { ServerNotification } from "../../app-server";
+import {
+    createCodexMockTestFixture,
+    createTestSessionState,
+    setupPromptAndSendNotifications,
+    type CodexMockTestFixture
+} from "../acp-test-utils";
+import { AgentMode } from "../../AgentMode";
+
+describe("CodexEventHandler - review events", () => {
+    let mockFixture: CodexMockTestFixture;
+    const sessionId = "test-session-id";
+
+    beforeEach(() => {
+        mockFixture = createCodexMockTestFixture();
+        vi.clearAllMocks();
+    });
+
+    const sessionState: SessionState = createTestSessionState({
+        sessionId,
+        currentModelId: "model-id[effort]",
+        agentMode: AgentMode.DEFAULT_AGENT_MODE
+    });
+
+    it("renders entered review mode", async () => {
+        const notification: ServerNotification = {
+            method: "item/started",
+            params: {
+                threadId: sessionId,
+                turnId: "review-turn",
+                startedAtMs: 0,
+                item: {
+                    type: "enteredReviewMode",
+                    id: "review-turn",
+                    review: "uncommitted changes",
+                },
+            },
+        };
+
+        await setupPromptAndSendNotifications(mockFixture, sessionId, sessionState, [notification]);
+
+        await expect(mockFixture.getAcpConnectionDump([])).toMatchFileSnapshot("data/review-entered.json");
+    });
+
+    it("renders exited review mode", async () => {
+        const notification: ServerNotification = {
+            method: "item/completed",
+            params: {
+                threadId: sessionId,
+                turnId: "review-turn",
+                completedAtMs: 0,
+                item: {
+                    type: "exitedReviewMode",
+                    id: "review-turn",
+                    review: "No findings.",
+                },
+            },
+        };
+
+        await setupPromptAndSendNotifications(mockFixture, sessionId, sessionState, [notification]);
+
+        await expect(mockFixture.getAcpConnectionDump([])).toMatchFileSnapshot("data/review-exited.json");
+    });
+});

--- a/src/__tests__/CodexAppServerClient/review.test.ts
+++ b/src/__tests__/CodexAppServerClient/review.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+import type { MessageConnection } from "vscode-jsonrpc/node";
+import { CodexAppServerClient } from "../../CodexAppServerClient";
+import type { ServerNotification } from "../../app-server";
+
+describe("CodexAppServerClient review support", () => {
+    function createClient(
+        sendRequest: (request: unknown) => Promise<unknown>
+    ): { client: CodexAppServerClient; sendNotification: (notification: ServerNotification) => void } {
+        let unhandledNotificationHandler: ((notification: ServerNotification) => void) | null = null;
+        const connection = {
+            sendRequest: vi.fn(sendRequest),
+            onUnhandledNotification: vi.fn((handler: (notification: ServerNotification) => void) => {
+                unhandledNotificationHandler = handler;
+            }),
+            onRequest: vi.fn(),
+        } as unknown as MessageConnection;
+
+        return {
+            client: new CodexAppServerClient(connection),
+            sendNotification(notification: ServerNotification): void {
+                if (!unhandledNotificationHandler) {
+                    throw new Error("No notification handler registered");
+                }
+                unhandledNotificationHandler(notification);
+            },
+        };
+    }
+
+    it("sends review/start with typed params", async () => {
+        const sendRequest = vi.fn().mockResolvedValue({
+            turn: {
+                id: "review-turn",
+                items: [],
+                itemsView: "full",
+                status: "inProgress",
+                error: null,
+                startedAt: null,
+                completedAt: null,
+                durationMs: null,
+            },
+            reviewThreadId: "session-id",
+        });
+        const { client } = createClient(sendRequest);
+
+        await client.reviewStart({
+            threadId: "session-id",
+            target: { type: "uncommittedChanges" },
+            delivery: "inline",
+        });
+
+        expect(sendRequest).toHaveBeenCalledWith("review/start", {
+            threadId: "session-id",
+            target: { type: "uncommittedChanges" },
+            delivery: "inline",
+        });
+    });
+
+    it("returns an early review completion observed before review/start resolves", async () => {
+        let fixture!: ReturnType<typeof createClient>;
+        const earlyCompletion: ServerNotification = {
+            method: "turn/completed",
+            params: {
+                threadId: "session-id",
+                turn: {
+                    id: "review-turn",
+                    items: [],
+                    itemsView: "full",
+                    status: "completed",
+                    error: null,
+                    startedAt: null,
+                    completedAt: null,
+                    durationMs: null,
+                },
+            },
+        };
+
+        fixture = createClient(async () => {
+            fixture.sendNotification(earlyCompletion);
+            return {
+                turn: {
+                    id: "review-turn",
+                    items: [],
+                    itemsView: "full",
+                    status: "inProgress",
+                    error: null,
+                    startedAt: null,
+                    completedAt: null,
+                    durationMs: null,
+                },
+                reviewThreadId: "session-id",
+            };
+        });
+
+        const completed = await fixture.client.runReview({
+            threadId: "session-id",
+            target: { type: "uncommittedChanges" },
+            delivery: "inline",
+        });
+
+        expect(completed).toEqual(earlyCompletion.params);
+    });
+
+    it("rejects detached review delivery without starting review", async () => {
+        const sendRequest = vi.fn();
+        const { client } = createClient(sendRequest);
+
+        await expect(client.runReview({
+            threadId: "session-id",
+            target: { type: "uncommittedChanges" },
+            delivery: "detached",
+        })).rejects.toThrow("runReview only supports inline review delivery");
+
+        expect(sendRequest).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary

This adds no-argument `/review` support to the ACP adapter using Codex app-server `review/start`.

The command starts a review of uncommitted changes in the current Codex session:

```text
/review
```

This intentionally does not add `/review <custom instructions>`, branch review, commit review, or detached review threads yet. Existing ACP built-in commands currently advertise `input: null`, so accepting ad hoc arguments for `/review` would create a mismatch between typed prompt input and command UI metadata. Custom review instructions can be added later once command input UX is clarified.

## What changed

- Added app-server client support for `review/start`.
- Added an ACP client helper that starts reviews in the current Codex thread.
- Published `/review` as a built-in ACP command.
- Mapped `/review` to `ReviewTarget: { type: "uncommittedChanges" }`.
- Rejected `/review <anything>` with a short usage message:

  ```text
  /review does not accept arguments yet.
  ```

- Tracked the active review turn ID so ACP cancellation and session close can interrupt an in-progress review.
- Rendered live review-mode events:
  - `enteredReviewMode` -> `Code review started: current changes`
  - `exitedReviewMode` -> review text followed by `Code review finished`

- Kept history replay formatting consistent with live review event rendering.
- Added tests for app-server review wiring, command behavior, active review cancellation, prompt-level cancellation/error propagation, and review event rendering.

Implementation note: the adapter passes `delivery: "inline"` to `review/start`, which is the app-server mode for running the review in the current thread. When `review/start` returns, its turn ID is stored as the session's current turn until the prompt completes, matching the lifecycle used by normal prompt turns.

## Why the command result type changed

Before this PR, command handling returned a boolean:

```ts
true  // handled as a command
false // not a command
```

That was enough for local commands like `/status`, `/skills`, `/mcp`, and `/logout`.

`/review` is different: it is a slash command, but it also starts a real Codex turn through `review/start`. After that turn completes, the ACP server needs to know whether it was interrupted so it can return the same `cancelled` response used by normal prompt turns.

So command handling now returns a small typed result:

```ts
type CommandHandlingResult =
  | { handled: false }
  | { handled: true; turnCompleted?: TurnCompletedNotification };
```

Existing commands still return `{ handled: true }`, preserving their behavior. `/review` returns `{ handled: true, turnCompleted }`, allowing `CodexAcpServer.prompt()` to propagate interruption and event-handler failures correctly.

This keeps the turn-specific behavior explicit without special-casing `/review` outside the command layer.

## Out of scope

- `/review <custom instructions>`
- branch or commit review selection
- detached review threads
- ACP-native review UI
- regenerating or modifying `src/app-server` protocol types

## Verified

- `npm run typecheck`
- `npm test` (176 passed, 27 skipped)
- `npm run build`
- Manual IntelliJ ACP smoke test:
  - verified `/review` appears and runs against uncommitted changes
  - verified review output is rendered in chat
