### PR TITLE
feat: expose model config options

### DIFF
--- a/src/AgentMode.ts
+++ b/src/AgentMode.ts
@@ -1,5 +1,7 @@
 import type {AskForApproval, SandboxMode, SandboxPolicy} from "./app-server/v2";
-import type {SessionMode, SessionModeState} from "@agentclientprotocol/sdk";
+import type {SessionConfigOption, SessionMode, SessionModeState} from "@agentclientprotocol/sdk";
+
+export const MODE_CONFIG_ID = "mode";
 
 export class AgentMode {
     readonly id: string;
@@ -66,6 +68,22 @@ export class AgentMode {
         return {
             availableModes: AgentMode.all().map(mode => mode.toSessionMode()),
             currentModeId: this.id
+        };
+    }
+
+    toConfigOption(): SessionConfigOption {
+        return {
+            id: MODE_CONFIG_ID,
+            name: "Mode",
+            description: "Approval and sandboxing preset for the session",
+            category: "mode",
+            type: "select",
+            currentValue: this.id,
+            options: AgentMode.all().map(mode => ({
+                value: mode.id,
+                name: mode.name,
+                description: mode.description,
+            })),
         };
     }
 

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -19,7 +19,14 @@ import type {
 } from "./app-server/v2";
 import type {RateLimitsMap} from "./RateLimitsMap";
 import {ModelId} from "./ModelId";
-import {AgentMode} from "./AgentMode";
+import {AgentMode, MODE_CONFIG_ID} from "./AgentMode";
+import {
+    createModelConfigOption,
+    createReasoningEffortConfigOption,
+    findSupportedEffort,
+    MODEL_CONFIG_ID,
+    REASONING_EFFORT_CONFIG_ID,
+} from "./ModelConfigOption";
 import type {TokenCount} from "./TokenCount";
 import {toPromptUsage} from "./TokenCount";
 import {CodexCommands} from "./CodexCommands";
@@ -44,6 +51,7 @@ import {
 export interface SessionState {
     sessionId: string,
     currentModelId: string,
+    availableModels: Array<Model>,
     supportedReasoningEfforts: Array<ReasoningEffortOption>,
     supportedInputModalities: Array<InputModality>,
     agentMode: AgentMode,
@@ -177,6 +185,7 @@ export class CodexAcpServer implements acp.Agent {
         const sessionState: SessionState = {
             sessionId: sessionId,
             currentModelId: currentModelId,
+            availableModels: models,
             supportedReasoningEfforts: currentModel?.supportedReasoningEfforts ?? [],
             supportedInputModalities: currentModel?.inputModalities ?? ["text", "image"],
             agentMode: AgentMode.getInitialAgentMode(),
@@ -310,11 +319,7 @@ export class CodexAcpServer implements acp.Agent {
         const sessionState = this.sessions.get(_params.sessionId);
         if (!sessionState) throw new Error(`Session ${_params.sessionId} not found`);
 
-        const newMode = AgentMode.find(_params.modeId);
-        if (!newMode) {
-            throw RequestError.invalidParams();
-        }
-        sessionState.agentMode = newMode;
+        this.applyModeChange(sessionState, _params.modeId);
         return {};
     }
 
@@ -326,18 +331,73 @@ export class CodexAcpServer implements acp.Agent {
         const sessionState = this.sessions.get(params.sessionId);
         if (!sessionState) throw new Error(`Session ${params.sessionId} not found`);
 
-        if (params.configId !== FAST_MODE_CONFIG_ID || ("type" in params && params.type === "boolean")) {
+        if (typeof params.value !== "string") {
             throw RequestError.invalidParams();
         }
+        const value = params.value;
 
-        if (params.value !== FAST_MODE_ON && params.value !== FAST_MODE_OFF) {
-            throw RequestError.invalidParams();
+        switch (params.configId) {
+            case FAST_MODE_CONFIG_ID:
+                this.applyFastModeChange(sessionState, value);
+                break;
+            case MODE_CONFIG_ID:
+                this.applyModeChange(sessionState, value);
+                break;
+            case MODEL_CONFIG_ID:
+                this.applyModelChange(sessionState, value);
+                break;
+            case REASONING_EFFORT_CONFIG_ID:
+                this.applyReasoningEffortChange(sessionState, value);
+                break;
+            default:
+                throw RequestError.invalidParams();
         }
 
-        sessionState.fastModeEnabled = params.value === FAST_MODE_ON;
         return {
             configOptions: this.createSessionConfigOptions(sessionState),
         };
+    }
+
+    private applyFastModeChange(sessionState: SessionState, value: string): void {
+        if (value !== FAST_MODE_ON && value !== FAST_MODE_OFF) {
+            throw RequestError.invalidParams();
+        }
+        sessionState.fastModeEnabled = value === FAST_MODE_ON;
+    }
+
+    private applyModeChange(sessionState: SessionState, value: string): void {
+        const newMode = AgentMode.find(value);
+        if (!newMode) {
+            throw RequestError.invalidParams();
+        }
+        sessionState.agentMode = newMode;
+    }
+
+    private applyModelChange(sessionState: SessionState, value: string): void {
+        const model = sessionState.availableModels.find(m => m.id === value);
+        if (!model) {
+            throw RequestError.invalidParams();
+        }
+        const currentEffort = ModelId.fromString(sessionState.currentModelId).effort;
+        const effort = findSupportedEffort(model.supportedReasoningEfforts, currentEffort)
+            ?? model.defaultReasoningEffort;
+        this.applyModelAndEffort(sessionState, model, effort);
+    }
+
+    private applyReasoningEffortChange(sessionState: SessionState, value: string): void {
+        const effort = findSupportedEffort(sessionState.supportedReasoningEfforts, value);
+        if (!effort) {
+            throw RequestError.invalidParams();
+        }
+        const {model} = ModelId.fromString(sessionState.currentModelId);
+        sessionState.currentModelId = ModelId.create(model, effort).toString();
+    }
+
+    private applyModelAndEffort(sessionState: SessionState, model: Model, effort: ReasoningEffort): void {
+        sessionState.currentModelId = ModelId.fromComponents(model, effort).toString();
+        sessionState.supportedReasoningEfforts = model.supportedReasoningEfforts;
+        sessionState.supportedInputModalities = model.inputModalities;
+        sessionState.currentModelSupportsFast = modelSupportsFast(model);
     }
 
     async unstable_setSessionModel(params: acp.SetSessionModelRequest): Promise<acp.SetSessionModelResponse | void> {
@@ -348,40 +408,35 @@ export class CodexAcpServer implements acp.Agent {
         const sessionState = this.sessions.get(params.sessionId);
         if (!sessionState) throw new Error(`Session ${params.sessionId} not found`);
 
-        const requestedModelId= ModelId.fromString(params.modelId);
-        const requestedModelName = requestedModelId.model;
-        const requestedEffort = requestedModelId.effort;
+        const {model: requestedModelName, effort: requestedEffort} = ModelId.fromString(params.modelId);
 
         const models = await this.codexAcpClient.fetchAvailableModels();
         const model = models.find(m => m.id === requestedModelName);
         if (!model) throw new Error(`Unknown model ${params.modelId}`);
 
-        const requestedEffortValue = requestedEffort as ReasoningEffort | undefined;
         let reasoningEffort: ReasoningEffort;
-        if (requestedEffortValue) {
-            const matchedEffort = model.supportedReasoningEfforts.find(
-                (option) => option.reasoningEffort === requestedEffortValue
-            )?.reasoningEffort;
-
+        if (requestedEffort) {
+            const matchedEffort = findSupportedEffort(model.supportedReasoningEfforts, requestedEffort);
             if (!matchedEffort) {
-                throw new Error(`Unsupported reasoning effort ${requestedEffortValue} for model ${requestedModelName}`);
+                throw new Error(`Unsupported reasoning effort ${requestedEffort} for model ${requestedModelName}`);
             }
-
             reasoningEffort = matchedEffort;
         } else {
             reasoningEffort = model.defaultReasoningEffort;
         }
 
-        sessionState.currentModelId = ModelId.fromComponents(model, reasoningEffort).toString();
-        sessionState.supportedReasoningEfforts = model.supportedReasoningEfforts;
-        sessionState.supportedInputModalities = model.inputModalities;
-        sessionState.currentModelSupportsFast = modelSupportsFast(model);
+        sessionState.availableModels = models;
+        this.applyModelAndEffort(sessionState, model, reasoningEffort);
 
         return {};
     }
 
     private createSessionConfigOptions(sessionState: SessionState): Array<acp.SessionConfigOption> {
+        const currentModelId = ModelId.fromString(sessionState.currentModelId);
         return [
+            sessionState.agentMode.toConfigOption(),
+            createModelConfigOption(sessionState.availableModels, currentModelId.model),
+            createReasoningEffortConfigOption(sessionState.supportedReasoningEfforts, currentModelId.effort),
             createFastModeConfigOption(sessionState.fastModeEnabled),
         ];
     }
@@ -437,6 +492,7 @@ export class CodexAcpServer implements acp.Agent {
         const sessionState: SessionState = {
             sessionId: sessionId,
             currentModelId: currentModelId,
+            availableModels: models,
             supportedReasoningEfforts: currentModel?.supportedReasoningEfforts ?? [],
             supportedInputModalities: currentModel?.inputModalities ?? ["text", "image"],
             agentMode: AgentMode.getInitialAgentMode(),

--- a/src/ModelConfigOption.ts
+++ b/src/ModelConfigOption.ts
@@ -1,0 +1,49 @@
+import type {SessionConfigOption} from "@agentclientprotocol/sdk";
+import type {ReasoningEffort} from "./app-server";
+import type {Model, ReasoningEffortOption} from "./app-server/v2";
+
+export const MODEL_CONFIG_ID = "model";
+export const REASONING_EFFORT_CONFIG_ID = "reasoning_effort";
+
+export function findSupportedEffort(
+    options: ReadonlyArray<ReasoningEffortOption>,
+    effort: string | undefined,
+): ReasoningEffort | undefined {
+    if (!effort) return undefined;
+    return options.find(o => o.reasoningEffort === effort)?.reasoningEffort;
+}
+
+export function createModelConfigOption(availableModels: Array<Model>, currentBaseModelId: string): SessionConfigOption {
+    return {
+        id: MODEL_CONFIG_ID,
+        name: "Model",
+        description: "Model Codex uses for the session",
+        category: "model",
+        type: "select",
+        currentValue: currentBaseModelId,
+        options: availableModels.map(model => ({
+            value: model.id,
+            name: model.displayName,
+            description: model.description,
+        })),
+    };
+}
+
+export function createReasoningEffortConfigOption(
+    supportedReasoningEfforts: Array<ReasoningEffortOption>,
+    currentEffort: string,
+): SessionConfigOption {
+    return {
+        id: REASONING_EFFORT_CONFIG_ID,
+        name: "Reasoning effort",
+        description: "How much reasoning effort the model should use",
+        category: "thought_level",
+        type: "select",
+        currentValue: currentEffort,
+        options: supportedReasoningEfforts.map(option => ({
+            value: option.reasoningEffort,
+            name: option.reasoningEffort,
+            description: option.description,
+        })),
+    };
+}

--- a/src/__tests__/CodexACPAgent/fast-mode-config.test.ts
+++ b/src/__tests__/CodexACPAgent/fast-mode-config.test.ts
@@ -48,13 +48,13 @@ describe("Fast mode session config", () => {
     it("returns the Fast mode config option defaulted to Off for new sessions", async () => {
         const {response} = await createSession();
 
-        expect(response.configOptions).toEqual([createFastModeConfigOption(false)]);
+        expect(response.configOptions).toContainEqual(createFastModeConfigOption(false));
     });
 
     it("initializes Fast mode as On when the app-server session tier is fast", async () => {
         const {response, codexAcpAgent} = await createSession("fast");
 
-        expect(response.configOptions).toEqual([createFastModeConfigOption(true)]);
+        expect(response.configOptions).toContainEqual(createFastModeConfigOption(true));
         expect(codexAcpAgent.getSessionState("session-id").fastModeEnabled).toBe(true);
     });
 
@@ -66,7 +66,7 @@ describe("Fast mode session config", () => {
             configId: FAST_MODE_CONFIG_ID,
             value: FAST_MODE_ON,
         });
-        expect(onResponse.configOptions).toEqual([createFastModeConfigOption(true)]);
+        expect(onResponse.configOptions).toContainEqual(createFastModeConfigOption(true));
         expect(codexAcpAgent.getSessionState("session-id").fastModeEnabled).toBe(true);
 
         const offResponse = await codexAcpAgent.setSessionConfigOption({
@@ -74,7 +74,7 @@ describe("Fast mode session config", () => {
             configId: FAST_MODE_CONFIG_ID,
             value: FAST_MODE_OFF,
         });
-        expect(offResponse.configOptions).toEqual([createFastModeConfigOption(false)]);
+        expect(offResponse.configOptions).toContainEqual(createFastModeConfigOption(false));
         expect(codexAcpAgent.getSessionState("session-id").fastModeEnabled).toBe(false);
     });
 

--- a/src/__tests__/CodexACPAgent/session-config-options.test.ts
+++ b/src/__tests__/CodexACPAgent/session-config-options.test.ts
@@ -1,0 +1,214 @@
+import {describe, expect, it, vi} from "vitest";
+import {createCodexMockTestFixture, createTestModel} from "../acp-test-utils";
+import {AgentMode, MODE_CONFIG_ID} from "../../AgentMode";
+import {
+    MODEL_CONFIG_ID,
+    REASONING_EFFORT_CONFIG_ID,
+} from "../../ModelConfigOption";
+import type {Model, ReasoningEffortOption} from "../../app-server/v2";
+
+const lowEffort: ReasoningEffortOption = {reasoningEffort: "low", description: "Fast"};
+const mediumEffort: ReasoningEffortOption = {reasoningEffort: "medium", description: "Balanced"};
+const highEffort: ReasoningEffortOption = {reasoningEffort: "high", description: "Thorough"};
+
+function buildModels(): {fast: Model; slow: Model} {
+    const fast = createTestModel({
+        id: "fast-model",
+        displayName: "Fast model",
+        description: "Frontier",
+        supportedReasoningEfforts: [lowEffort, mediumEffort, highEffort],
+        defaultReasoningEffort: "medium",
+    });
+    const slow = createTestModel({
+        id: "slow-model",
+        displayName: "Slow model",
+        description: "Strong",
+        supportedReasoningEfforts: [lowEffort, mediumEffort],
+        defaultReasoningEffort: "low",
+    });
+    return {fast, slow};
+}
+
+async function createSession(currentModelId: string, availableModels: Array<Model>) {
+    const fixture = createCodexMockTestFixture();
+    const codexAcpAgent = fixture.getCodexAcpAgent();
+    const codexAcpClient = fixture.getCodexAcpClient();
+
+    vi.spyOn(codexAcpClient, "authRequired").mockResolvedValue(false);
+    vi.spyOn(codexAcpClient, "getAccount").mockResolvedValue({account: null, requiresOpenaiAuth: false});
+    vi.spyOn(codexAcpClient, "newSession").mockResolvedValue({
+        sessionId: "session-id",
+        currentModelId,
+        models: availableModels,
+    });
+
+    const response = await codexAcpAgent.newSession({cwd: "/test/cwd", mcpServers: []});
+    return {codexAcpAgent, response};
+}
+
+describe("Session config options", () => {
+    it("exposes mode, model, reasoning_effort and fast-mode in the new session response", async () => {
+        const {fast, slow} = buildModels();
+        const {response} = await createSession("fast-model[medium]", [fast, slow]);
+
+        const ids = response.configOptions?.map(o => o.id);
+        expect(ids).toEqual([MODE_CONFIG_ID, MODEL_CONFIG_ID, REASONING_EFFORT_CONFIG_ID, "fast-mode"]);
+
+        const modelOption = response.configOptions?.find(o => o.id === MODEL_CONFIG_ID);
+        expect(modelOption).toMatchObject({
+            category: "model",
+            currentValue: "fast-model",
+            type: "select",
+            options: [
+                {value: "fast-model", name: "Fast model", description: "Frontier"},
+                {value: "slow-model", name: "Slow model", description: "Strong"},
+            ],
+        });
+
+        const effortOption = response.configOptions?.find(o => o.id === REASONING_EFFORT_CONFIG_ID);
+        expect(effortOption).toMatchObject({
+            category: "thought_level",
+            currentValue: "medium",
+            type: "select",
+            options: [
+                {value: "low", name: "low"},
+                {value: "medium", name: "medium"},
+                {value: "high", name: "high"},
+            ],
+        });
+
+        const modeOption = response.configOptions?.find(o => o.id === MODE_CONFIG_ID);
+        expect(modeOption).toMatchObject({
+            category: "mode",
+            currentValue: AgentMode.DEFAULT_AGENT_MODE.id,
+            type: "select",
+        });
+        expect((modeOption as any).options.map((o: any) => o.value)).toEqual(
+            AgentMode.all().map(m => m.id)
+        );
+    });
+
+    it("keeps the legacy models list as combined model/effort entries", async () => {
+        const {fast, slow} = buildModels();
+        const {response} = await createSession("fast-model[medium]", [fast, slow]);
+
+        expect(response.models?.availableModels.map(m => m.modelId)).toEqual([
+            "fast-model[low]",
+            "fast-model[medium]",
+            "fast-model[high]",
+            "slow-model[low]",
+            "slow-model[medium]",
+        ]);
+        expect(response.models?.currentModelId).toBe("fast-model[medium]");
+    });
+
+    it("changes the agent mode via setSessionConfigOption", async () => {
+        const {fast} = buildModels();
+        const {codexAcpAgent} = await createSession("fast-model[medium]", [fast]);
+
+        const result = await codexAcpAgent.setSessionConfigOption({
+            sessionId: "session-id",
+            configId: MODE_CONFIG_ID,
+            value: AgentMode.ReadOnly.id,
+        });
+
+        expect(codexAcpAgent.getSessionState("session-id").agentMode).toBe(AgentMode.ReadOnly);
+        const modeOption = result.configOptions?.find(o => o.id === MODE_CONFIG_ID);
+        expect((modeOption as any).currentValue).toBe(AgentMode.ReadOnly.id);
+    });
+
+    it("changes the model and keeps the current reasoning effort when supported", async () => {
+        const {fast, slow} = buildModels();
+        const {codexAcpAgent} = await createSession("fast-model[medium]", [fast, slow]);
+
+        await codexAcpAgent.setSessionConfigOption({
+            sessionId: "session-id",
+            configId: MODEL_CONFIG_ID,
+            value: "slow-model",
+        });
+
+        expect(codexAcpAgent.getSessionState("session-id").currentModelId).toBe("slow-model[medium]");
+    });
+
+    it("falls back to the new model's default effort when the current effort is unsupported", async () => {
+        const {fast, slow} = buildModels();
+        const {codexAcpAgent} = await createSession("fast-model[high]", [fast, slow]);
+
+        await codexAcpAgent.setSessionConfigOption({
+            sessionId: "session-id",
+            configId: MODEL_CONFIG_ID,
+            value: "slow-model",
+        });
+
+        expect(codexAcpAgent.getSessionState("session-id").currentModelId).toBe("slow-model[low]");
+    });
+
+    it("changes only the reasoning effort", async () => {
+        const {fast} = buildModels();
+        const {codexAcpAgent} = await createSession("fast-model[medium]", [fast]);
+
+        await codexAcpAgent.setSessionConfigOption({
+            sessionId: "session-id",
+            configId: REASONING_EFFORT_CONFIG_ID,
+            value: "high",
+        });
+
+        expect(codexAcpAgent.getSessionState("session-id").currentModelId).toBe("fast-model[high]");
+    });
+
+    it("refreshes the cached model list when unstable_setSessionModel picks a freshly fetched model", async () => {
+        const fixture = createCodexMockTestFixture();
+        const codexAcpAgent = fixture.getCodexAcpAgent();
+        const codexAcpClient = fixture.getCodexAcpClient();
+        const {fast} = buildModels();
+
+        vi.spyOn(codexAcpClient, "authRequired").mockResolvedValue(false);
+        vi.spyOn(codexAcpClient, "getAccount").mockResolvedValue({account: null, requiresOpenaiAuth: false});
+        vi.spyOn(codexAcpClient, "newSession").mockResolvedValue({
+            sessionId: "session-id",
+            currentModelId: "fast-model[medium]",
+            models: [fast],
+        });
+        await codexAcpAgent.newSession({cwd: "/test/cwd", mcpServers: []});
+
+        const extraModel = createTestModel({
+            id: "extra-model",
+            displayName: "Extra model",
+            description: "Added after session start",
+            supportedReasoningEfforts: [mediumEffort],
+            defaultReasoningEffort: "medium",
+        });
+        vi.spyOn(codexAcpClient, "fetchAvailableModels").mockResolvedValue([fast, extraModel]);
+
+        await codexAcpAgent.unstable_setSessionModel({
+            sessionId: "session-id",
+            modelId: "extra-model[medium]",
+        });
+
+        const sessionState = codexAcpAgent.getSessionState("session-id");
+        expect(sessionState.availableModels.map(m => m.id)).toEqual(["fast-model", "extra-model"]);
+    });
+
+    it("rejects unknown model, effort, and mode values", async () => {
+        const {fast} = buildModels();
+        const {codexAcpAgent} = await createSession("fast-model[medium]", [fast]);
+
+        await expect(codexAcpAgent.setSessionConfigOption({
+            sessionId: "session-id",
+            configId: MODEL_CONFIG_ID,
+            value: "unknown-model",
+        })).rejects.toThrow();
+
+        await expect(codexAcpAgent.setSessionConfigOption({
+            sessionId: "session-id",
+            configId: REASONING_EFFORT_CONFIG_ID,
+            value: "wishful",
+        })).rejects.toThrow();
+
+        await expect(codexAcpAgent.setSessionConfigOption({
+            sessionId: "session-id",
+            configId: MODE_CONFIG_ID,
+            value: "no-such-mode",
+        })).rejects.toThrow();
+    });
+});

--- a/src/__tests__/acp-test-utils.ts
+++ b/src/__tests__/acp-test-utils.ts
@@ -320,6 +320,7 @@ export function createTestSessionState(overrides?: Partial<SessionState>): Sessi
         cwd: "/test/cwd",
         sessionId: "session-id",
         currentModelId: "model-id[effort]",
+        availableModels: [],
         supportedReasoningEfforts: [],
         supportedInputModalities: ["text", "image"],
         agentMode: AgentMode.DEFAULT_AGENT_MODE,


### PR DESCRIPTION
Add session config options for mode, model, and reasoning effort, and route session/set_config_option changes through the same session state used for prompts.

This mirrors what the old codex-acp adapter does. The "legacy" models are a combination of model + effort, but the config options expose those separately.

Assisted-by: GPT-5.5