### PR TITLE
Pass skill slash commands through to Codex

### DIFF
--- a/src/CodexCommands.ts
+++ b/src/CodexCommands.ts
@@ -106,8 +106,9 @@ export class CodexCommands {
     }
 
     async tryHandleCommand(prompt: acp.ContentBlock[], sessionState: SessionState): Promise<boolean> {
-        const commandName = this.getCommandName(prompt)
+        const commandName = this.getCommandName(prompt);
         if (commandName === null) return false;
+        if (commandName.startsWith("$")) return false;
 
         const sessionId = sessionState.sessionId;
         switch (commandName) {

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -740,6 +740,24 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         await expect(mockFixture.getAcpConnectionDump([])).toMatchFileSnapshot("data/command-status.json");
     });
 
+    it('passes skill slash commands through to Codex', async () => {
+        const { mockFixture, turnStartSpy } = setupPromptFixture();
+
+        await mockFixture.getCodexAcpAgent().prompt({
+            sessionId: "session-id",
+            prompt: [{ type: "text", text: "/$imagegen create a hero image" }],
+        });
+
+        expect(turnStartSpy).toHaveBeenCalledWith(expect.objectContaining({
+            input: [{
+                type: "text",
+                text: "/$imagegen create a hero image",
+                text_elements: []
+            }]
+        }));
+        expect(mockFixture.getAcpConnectionDump([])).toBe("");
+    });
+
     it('handles logout command', async () => {
         const codexAcpAgent = fixture.getCodexAcpAgent();
         await codexAcpAgent.initialize({protocolVersion: 1});


### PR DESCRIPTION
Skill commands are advertised with a `$` prefix, such as `/$imagegen`, but ACP-local slash command handling was intercepting them and reporting them as unknown commands. Treat `$` commands as normal prompt input so Codex can resolve the referenced skill.

Not sure if we should strip the slash from `/$skill ...` when forwarding to Codex.