### PR TITLE
chore: CI permissions

### DIFF
--- a/.github/workflows/codex-update.yml
+++ b/.github/workflows/codex-update.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 5 * * *' 
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: read
+
 env:
   CODEX_PACKAGE: '@openai/codex'
   CODEX_UPDATE_LABEL: 'codex-update'


### PR DESCRIPTION
Potential fix for [https://github.com/agentclientprotocol/codex-acp/security/code-scanning/14](https://github.com/agentclientprotocol/codex-acp/security/code-scanning/14)

Add an explicit `permissions` block to the workflow root in `.github/workflows/codex-update.yml` so all jobs have a least-privilege baseline.  
Best minimal safe fix (without changing behavior) is:

- `contents: read` (CodeQL-recommended baseline)
- `packages: read` (commonly needed for package metadata access patterns and aligns with GitHub read-only default set)

Since write operations here are performed with the generated GitHub App token, we should **not** grant broad write on `GITHUB_TOKEN`.  
Edit location: near the top of the file, after `workflow_dispatch:` and before `env:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
