### PR TITLE
Fix stale file read after patch causing empty diff content

### DIFF
--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -384,11 +384,18 @@ export class CodexAcpClient {
 
     async subscribeToSessionEvents(
         sessionId: string,
-        eventHandler: (result: ServerNotification) => void,
+        eventHandler: (result: ServerNotification) => void | Promise<void>,
         approvalHandler: ApprovalHandler,
         elicitationHandler: ElicitationHandler
     ) {
-        this.codexClient.onServerNotification(sessionId, eventHandler);
+        let notificationQueue = Promise.resolve();
+        this.codexClient.onServerNotification(sessionId, (event) => {
+            notificationQueue = notificationQueue
+                .then(() => eventHandler(event))
+                .catch((error) => {
+                    logger.error("Error handling Codex session notification", error);
+                });
+        });
         this.codexClient.onApprovalRequest(sessionId, approvalHandler);
         this.codexClient.onElicitationRequest(sessionId, elicitationHandler);
     }

--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -49,6 +49,7 @@ export class CodexAcpClient {
     private gatewayConfig: GatewayConfig | null;
     private pendingLoginCompleted: Promise<AccountLoginCompletedNotification> | null = null;
     private pendingAccountUpdated: Promise<AccountUpdatedNotification> | null = null;
+    private readonly sessionNotificationQueues = new Map<string, Promise<void>>();
 
 
     constructor(codexClient: CodexAppServerClient, codexConfig?: JsonObject, modelProvider?: string) {
@@ -388,16 +389,52 @@ export class CodexAcpClient {
         approvalHandler: ApprovalHandler,
         elicitationHandler: ElicitationHandler
     ) {
-        let notificationQueue = Promise.resolve();
         this.codexClient.onServerNotification(sessionId, (event) => {
-            notificationQueue = notificationQueue
-                .then(() => eventHandler(event))
-                .catch((error) => {
-                    logger.error("Error handling Codex session notification", error);
-                });
+            this.enqueueSessionNotification(sessionId, () => eventHandler(event));
         });
-        this.codexClient.onApprovalRequest(sessionId, approvalHandler);
-        this.codexClient.onElicitationRequest(sessionId, elicitationHandler);
+        this.codexClient.onApprovalRequest(sessionId, {
+            handleCommandExecution: async (params) => {
+                await this.waitForSessionNotifications(sessionId);
+                return await approvalHandler.handleCommandExecution(params);
+            },
+            handleFileChange: async (params) => {
+                await this.waitForSessionNotifications(sessionId);
+                return await approvalHandler.handleFileChange(params);
+            },
+        });
+        this.codexClient.onElicitationRequest(sessionId, {
+            handleElicitation: async (params) => {
+                await this.waitForSessionNotifications(sessionId);
+                return await elicitationHandler.handleElicitation(params);
+            },
+        });
+    }
+
+    async waitForSessionNotifications(sessionId: string): Promise<void> {
+        while (true) {
+            const queue = this.sessionNotificationQueues.get(sessionId);
+            if (!queue) return;
+            await queue;
+        }
+    }
+
+    private enqueueSessionNotification(sessionId: string, operation: () => void | Promise<void>): void {
+        const run = async () => {
+            try {
+                await operation();
+            } catch (error) {
+                logger.error("Error handling Codex session notification", error);
+            }
+        };
+
+        const previous = this.sessionNotificationQueues.get(sessionId);
+        const next = previous ? previous.then(run, run) : run();
+        this.sessionNotificationQueues.set(sessionId, next);
+        void next.finally(() => {
+            if (this.sessionNotificationQueues.get(sessionId) === next) {
+                this.sessionNotificationQueues.delete(sessionId);
+            }
+        });
     }
 
     async sendPrompt(

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -1222,6 +1222,8 @@ export class CodexAcpServer implements acp.Agent {
                 };
             }
 
+            await this.codexAcpClient.waitForSessionNotifications(params.sessionId);
+
             // Check if turn was interrupted (cancelled)
             if (turnCompleted.turn.status === "interrupted") {
                 if (!this.sessionIsClosing(params.sessionId) && this.sessions.has(params.sessionId)) {

--- a/src/CodexToolCallMapper.ts
+++ b/src/CodexToolCallMapper.ts
@@ -294,7 +294,18 @@ async function createUpdateFileContent(change: FileUpdateChange): Promise<ToolCa
     const oldContent = await readFileContent(change.path);
     if (oldContent !== null) {
         const patchedContent = applyPatch(oldContent, unifiedDiff);
-        if (patchedContent === false) return null;
+        if (patchedContent === false) {
+            // If Codex runs in full access mode, the file might already be patched.
+            // we can verify this by checking if the reverted patch applies.
+            const revertedPatch = revertPatch(unifiedDiff);
+            if (revertedPatch) {
+                const revertedContent = applyPatch(oldContent, revertedPatch);
+                if (revertedContent !== false) {
+                    return createUpdateDiffContent(change.path, revertedContent, oldContent);
+                }
+            }
+            return null;
+        }
         return createUpdateDiffContent(movePath ?? change.path, oldContent, patchedContent);
     }
 

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -1154,6 +1154,7 @@ describe('ACP server test', { timeout: 40_000 }, () => {
                 }
             }
         });
+        await mockFixture.getCodexAcpClient().waitForSessionNotifications(sessionId);
 
         expect(sessionState.rateLimits).not.toBeNull();
         expect(sessionState.rateLimits!.size).toBe(2);

--- a/src/__tests__/CodexACPAgent/data/mcp-tool-completed-with-logs.json
+++ b/src/__tests__/CodexACPAgent/data/mcp-tool-completed-with-logs.json
@@ -4,6 +4,34 @@
     {
       "sessionId": "test-session-id",
       "update": {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "call-id",
+        "kind": "execute",
+        "title": "mcp.ijproxy.read_file",
+        "status": "in_progress",
+        "rawInput": {
+          "server": "ijproxy",
+          "tool": "read_file",
+          "arguments": {
+            "file_path": ".ai/local.md",
+            "mode": "slice",
+            "start_line": 1,
+            "max_lines": 200
+          }
+        },
+        "_meta": {
+          "is_mcp_tool_call": true
+        }
+      }
+    }
+  ]
+}
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
         "sessionUpdate": "tool_call_update",
         "toolCallId": "call-id",
         "_meta": {
@@ -39,34 +67,6 @@
           "error": {
             "message": "File /Users/aleksandr.slapoguzov/Projects/ultimate/.ai/local.md doesn't exist or can't be opened"
           }
-        }
-      }
-    }
-  ]
-}
-{
-  "method": "sessionUpdate",
-  "args": [
-    {
-      "sessionId": "test-session-id",
-      "update": {
-        "sessionUpdate": "tool_call",
-        "toolCallId": "call-id",
-        "kind": "execute",
-        "title": "mcp.ijproxy.read_file",
-        "status": "in_progress",
-        "rawInput": {
-          "server": "ijproxy",
-          "tool": "read_file",
-          "arguments": {
-            "file_path": ".ai/local.md",
-            "mode": "slice",
-            "start_line": 1,
-            "max_lines": 200
-          }
-        },
-        "_meta": {
-          "is_mcp_tool_call": true
         }
       }
     }

--- a/src/__tests__/CodexACPAgent/data/mcp-tool-repeated-progress.json
+++ b/src/__tests__/CodexACPAgent/data/mcp-tool-repeated-progress.json
@@ -4,6 +4,31 @@
     {
       "sessionId": "test-session-id",
       "update": {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "call-id",
+        "kind": "execute",
+        "title": "mcp.server-name.tool-name",
+        "status": "in_progress",
+        "rawInput": {
+          "server": "server-name",
+          "tool": "tool-name",
+          "arguments": {
+            "argument": "example"
+          }
+        },
+        "_meta": {
+          "is_mcp_tool_call": true
+        }
+      }
+    }
+  ]
+}
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
         "sessionUpdate": "tool_call_update",
         "toolCallId": "call-id",
         "_meta": {
@@ -53,31 +78,6 @@
           "error": {
             "message": "Polling for status"
           }
-        }
-      }
-    }
-  ]
-}
-{
-  "method": "sessionUpdate",
-  "args": [
-    {
-      "sessionId": "test-session-id",
-      "update": {
-        "sessionUpdate": "tool_call",
-        "toolCallId": "call-id",
-        "kind": "execute",
-        "title": "mcp.server-name.tool-name",
-        "status": "in_progress",
-        "rawInput": {
-          "server": "server-name",
-          "tool": "tool-name",
-          "arguments": {
-            "argument": "example"
-          }
-        },
-        "_meta": {
-          "is_mcp_tool_call": true
         }
       }
     }

--- a/src/__tests__/CodexACPAgent/data/terminal-full-flow.json
+++ b/src/__tests__/CodexACPAgent/data/terminal-full-flow.json
@@ -4,6 +4,37 @@
     {
       "sessionId": "test-session-id",
       "update": {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "command-flow",
+        "kind": "execute",
+        "title": "echo hello",
+        "status": "in_progress",
+        "content": [
+          {
+            "type": "terminal",
+            "terminalId": "command-flow"
+          }
+        ],
+        "rawInput": {
+          "command": "echo hello",
+          "cwd": "/test/project"
+        },
+        "_meta": {
+          "terminal_info": {
+            "cwd": "/test/project",
+            "terminal_id": "command-flow"
+          }
+        }
+      }
+    }
+  ]
+}
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
         "sessionUpdate": "tool_call_update",
         "toolCallId": "command-flow",
         "_meta": {
@@ -33,37 +64,6 @@
           "terminal_exit": {
             "exit_code": 0,
             "signal": null,
-            "terminal_id": "command-flow"
-          }
-        }
-      }
-    }
-  ]
-}
-{
-  "method": "sessionUpdate",
-  "args": [
-    {
-      "sessionId": "test-session-id",
-      "update": {
-        "sessionUpdate": "tool_call",
-        "toolCallId": "command-flow",
-        "kind": "execute",
-        "title": "echo hello",
-        "status": "in_progress",
-        "content": [
-          {
-            "type": "terminal",
-            "terminalId": "command-flow"
-          }
-        ],
-        "rawInput": {
-          "command": "echo hello",
-          "cwd": "/test/project"
-        },
-        "_meta": {
-          "terminal_info": {
-            "cwd": "/test/project",
             "terminal_id": "command-flow"
           }
         }

--- a/src/__tests__/CodexACPAgent/elicitation-events.test.ts
+++ b/src/__tests__/CodexACPAgent/elicitation-events.test.ts
@@ -288,6 +288,7 @@ describe('Elicitation Events', () => {
 
             fixture.sendServerNotification(startedNotification);
             fixture.sendServerNotification(completedNotification);
+            await fixture.getCodexAcpClient().waitForSessionNotifications(sessionId);
             fixture.clearAcpConnectionDump();
 
             const params: McpServerElicitationRequestParams = {
@@ -340,6 +341,7 @@ describe('Elicitation Events', () => {
 
             fixture.sendServerNotification(startedNotification);
             fixture.sendServerNotification(resolvedNotification);
+            await fixture.getCodexAcpClient().waitForSessionNotifications(sessionId);
             fixture.clearAcpConnectionDump();
 
             const params: McpServerElicitationRequestParams = {

--- a/src/__tests__/CodexACPAgent/file-change-events.test.ts
+++ b/src/__tests__/CodexACPAgent/file-change-events.test.ts
@@ -6,23 +6,33 @@ import type { ThreadItem } from '../../app-server/v2';
 import { createCodexMockTestFixture, createTestSessionState, setupPromptAndSendNotifications, type CodexMockTestFixture } from '../acp-test-utils';
 import {AgentMode} from "../../AgentMode";
 
-const { mockFiles, mockFileContent, removeMockFile, clearMockFiles } = vi.hoisted(() => {
+const { mockFiles, mockReadDelays, mockFileContent, delayMockFileRead, removeMockFile, clearMockFiles } = vi.hoisted(() => {
     const files = new Map<string, string>();
+    const readDelays = new Map<string, Promise<void>>();
     return {
         mockFiles: files,
+        mockReadDelays: readDelays,
         mockFileContent: (path: string, content: string) => files.set(path, content),
+        delayMockFileRead: (path: string, delay: Promise<void>) => readDelays.set(path, delay),
         removeMockFile: (path: string) => files.delete(path),
-        clearMockFiles: () => files.clear(),
+        clearMockFiles: () => {
+            files.clear();
+            readDelays.clear();
+        },
     };
 });
 
 vi.mock('node:fs/promises', () => ({
-    readFile: (path: string) => {
+    readFile: async (path: string) => {
+        const delay = mockReadDelays.get(path);
+        if (delay) {
+            await delay;
+        }
         const content = mockFiles.get(path);
         if (content !== undefined) {
-            return Promise.resolve(content);
+            return content;
         }
-        return Promise.reject(new Error(`ENOENT: no such file or directory, open '${path}'`));
+        throw new Error(`ENOENT: no such file or directory, open '${path}'`);
     },
 }));
 
@@ -274,6 +284,153 @@ describe('CodexEventHandler - file change events', () => {
         expect(updateEvent).toMatchObject({
             content: [],
         });
+    });
+
+    it('should handle update diffs when the file was already patched', async () => {
+        mockFileContent('/test/project/OldFile.kt', 'package test.project\n\nclass UpdatedFile {}\n');
+
+        const updateFileNotification: ServerNotification = {
+            method: 'item/started',
+            params: {
+                threadId: sessionId,
+                turnId: 'turn-1',
+                item: {
+                    type: 'fileChange',
+                    id: 'file-change-already-patched',
+                    changes: [
+                        {
+                            path: '/test/project/OldFile.kt',
+                            kind: { type: 'update', move_path: null },
+                            diff:
+`@@ -1,3 +1,3 @@
+ package test.project
+ 
+-class OldFile {}
++class UpdatedFile {}
+`,
+                        },
+                    ],
+                    status: 'completed',
+                },
+            },
+        };
+
+        await setupPromptAndSendNotifications(mockFixture, sessionId, sessionState, [updateFileNotification]);
+
+        const updates = mockFixture.getAcpConnectionEvents(['id']).map((event) => event.args[0].update);
+        expect(updates).toMatchObject([
+            {
+                sessionUpdate: 'tool_call',
+                toolCallId: 'file-change-already-patched',
+                status: 'completed',
+                content: [
+                    {
+                        oldText: 'package test.project\n\nclass OldFile {}\n',
+                        newText: 'package test.project\n\nclass UpdatedFile {}\n',
+                        path: '/test/project/OldFile.kt',
+                    },
+                ],
+            },
+        ]);
+    });
+
+    it('should not emit completion before a slow file-change start event', async () => {
+        mockFileContent('/test/project/OldFile.kt', 'package test.project\n\nclass OldFile {}\n');
+
+        let releaseRead = () => {};
+        const blockedRead = new Promise<void>((resolve) => {
+            releaseRead = resolve;
+        });
+        delayMockFileRead('/test/project/OldFile.kt', blockedRead);
+
+        const fileChange = {
+            type: 'fileChange',
+            id: 'file-change-slow-start',
+            changes: [
+                {
+                    path: '/test/project/OldFile.kt',
+                    kind: { type: 'update', move_path: null },
+                    diff:
+`@@ -1,3 +1,3 @@
+ package test.project
+ 
+-class OldFile {}
++class UpdatedFile {}
+`,
+                },
+            ],
+        } satisfies Omit<ThreadItem & { type: 'fileChange' }, 'status'>;
+
+        const fileChangeStarted: ServerNotification = {
+            method: 'item/started',
+            params: {
+                threadId: sessionId,
+                turnId: 'turn-1',
+                item: {
+                    ...fileChange,
+                    status: 'inProgress',
+                },
+            },
+        };
+        const fileChangeCompleted: ServerNotification = {
+            method: 'item/completed',
+            params: {
+                threadId: sessionId,
+                turnId: 'turn-1',
+                item: {
+                    ...fileChange,
+                    status: 'completed',
+                },
+            },
+        };
+
+        const codexAcpAgent = mockFixture.getCodexAcpAgent();
+        const codexAppServerClient = mockFixture.getCodexAppServerClient();
+        const turn = { id: 'turn-id', items: [], status: 'inProgress' as const, error: null };
+        codexAppServerClient.turnStart = vi.fn().mockResolvedValue({ turn });
+        codexAppServerClient.awaitTurnCompleted = vi.fn().mockResolvedValue({
+            threadId: sessionId,
+            turn: { ...turn, status: 'completed' },
+        });
+        vi.spyOn(codexAcpAgent, 'getSessionState').mockReturnValue(sessionState);
+
+        await codexAcpAgent.prompt({
+            sessionId,
+            prompt: [{ type: 'text', text: 'test prompt' }],
+        });
+
+        mockFixture.clearAcpConnectionDump();
+        mockFixture.sendServerNotification(fileChangeStarted);
+        mockFixture.sendServerNotification(fileChangeCompleted);
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(mockFixture.getAcpConnectionEvents([])).toEqual([]);
+
+        releaseRead();
+        await vi.waitFor(() => {
+            expect(mockFixture.getAcpConnectionEvents([])).toHaveLength(2);
+        });
+
+        const updates = mockFixture.getAcpConnectionEvents([]).map((event) => event.args[0].update);
+        expect(updates).toMatchObject([
+            {
+                sessionUpdate: 'tool_call',
+                toolCallId: 'file-change-slow-start',
+                status: 'in_progress',
+                content: [
+                    {
+                        oldText: 'package test.project\n\nclass OldFile {}\n',
+                        newText: 'package test.project\n\nclass UpdatedFile {}\n',
+                        path: '/test/project/OldFile.kt',
+                    },
+                ],
+            },
+            {
+                sessionUpdate: 'tool_call_update',
+                toolCallId: 'file-change-slow-start',
+                status: 'completed',
+            },
+        ]);
     });
 
     it('should parse update diffs with move metadata appended', async () => {

--- a/src/__tests__/acp-test-utils.ts
+++ b/src/__tests__/acp-test-utils.ts
@@ -440,6 +440,7 @@ export async function setupPromptAndSendNotifications(
     for (const notification of notifications) {
         fixture.sendServerNotification(notification);
     }
+    await fixture.getCodexAcpClient().waitForSessionNotifications(sessionId);
 
     await vi.waitFor(() => {
         const dump = fixture.getAcpConnectionDump([]);


### PR DESCRIPTION
Also ensure events are always handled in order.

https://github.com/agentclientprotocol/codex-acp/pull/167 fixed some diff errors, but there was still a race condition when using codex in full access mode, where the file was already updated when codex-acp read it, making the patch fail to apply and returning empty content:

https://github.com/agentclientprotocol/codex-acp/blob/e698674ae835d80fdfe5dbffa1eaae9db549ba11/src/CodexToolCallMapper.ts#L294-L297

Additionally, because each event was processed individually, the `await readFile` could cause the `item/completed` event to be processed and sent as `tool_call_update` via ACP before the initial `tool_call` was sent.