### PR TITLE
fix: Ignore Guardian warning notifications

### DIFF
--- a/src/CodexEventHandler.ts
+++ b/src/CodexEventHandler.ts
@@ -14,7 +14,6 @@ import type {
     CommandExecutionOutputDeltaNotification,
     ConfigWarningNotification,
     ErrorNotification,
-    GuardianWarningNotification,
     ItemGuardianApprovalReviewCompletedNotification,
     ItemGuardianApprovalReviewStartedNotification,
     ItemCompletedNotification,
@@ -131,7 +130,7 @@ export class CodexEventHandler {
             case "warning":
                 return this.createWarningEvent(notification.params);
             case "guardianWarning":
-                return this.createGuardianWarningEvent(notification.params);
+                return null;
             case "item/autoApprovalReview/started":
                 return this.handleGuardianApprovalReviewStarted(notification.params);
             case "item/autoApprovalReview/completed":
@@ -233,16 +232,6 @@ export class CodexEventHandler {
             content: {
                 type: "text",
                 text: `Warning: ${event.message}\n\n`
-            }
-        };
-    }
-
-    private createGuardianWarningEvent(event: GuardianWarningNotification): UpdateSessionEvent {
-        return {
-            sessionUpdate: "agent_message_chunk",
-            content: {
-                type: "text",
-                text: `Guardian warning: ${event.message}\n\n`
             }
         };
     }

--- a/src/CodexToolCallMapper.ts
+++ b/src/CodexToolCallMapper.ts
@@ -321,6 +321,9 @@ function createGuardianApprovalReviewContent(
     if (review.riskLevel) {
         lines.push(`Risk: ${review.riskLevel}`);
     }
+    if (review.userAuthorization) {
+        lines.push(`Authorization: ${review.userAuthorization}`);
+    }
     if (review.rationale?.trim()) {
         lines.push(`Rationale: ${review.rationale}`);
     }

--- a/src/__tests__/CodexACPAgent/data/guardian-approval-review-completed-without-start.json
+++ b/src/__tests__/CodexACPAgent/data/guardian-approval-review-completed-without-start.json
@@ -14,7 +14,7 @@
             "type": "content",
             "content": {
               "type": "text",
-              "text": "Status: Denied\nAction: network access to api.example.com\nRisk: high\nRationale: The network target is not permitted."
+              "text": "Status: Denied\nAction: network access to api.example.com\nRisk: high\nAuthorization: low\nRationale: The network target is not permitted."
             }
           }
         ],

--- a/src/__tests__/CodexACPAgent/data/guardian-approval-review-flow.json
+++ b/src/__tests__/CodexACPAgent/data/guardian-approval-review-flow.json
@@ -14,7 +14,7 @@
             "type": "content",
             "content": {
               "type": "text",
-              "text": "Status: In progress\nAction: exec /bin/ls -l\nRisk: medium\nRationale: Checking whether this command should run automatically."
+              "text": "Status: In progress\nAction: exec /bin/ls -l\nRisk: medium\nAuthorization: unknown\nRationale: Checking whether this command should run automatically."
             }
           }
         ],
@@ -59,7 +59,7 @@
             "type": "content",
             "content": {
               "type": "text",
-              "text": "Status: Approved\nAction: exec /bin/ls -l\nRisk: low\nRationale: The command only lists files."
+              "text": "Status: Approved\nAction: exec /bin/ls -l\nRisk: low\nAuthorization: medium\nRationale: The command only lists files."
             }
           }
         ],

--- a/src/__tests__/CodexACPAgent/guardian-approval-review-events.test.ts
+++ b/src/__tests__/CodexACPAgent/guardian-approval-review-events.test.ts
@@ -73,10 +73,27 @@ describe("CodexEventHandler - Guardian approval review events", () => {
                 },
             },
         };
+        const duplicateWarning: ServerNotification = {
+            method: "guardianWarning",
+            params: {
+                threadId: sessionId,
+                message: "Automatic approval review approved (risk: low, authorization: medium): The command only lists files.",
+            },
+        };
 
-        await setupPromptAndSendNotifications(mockFixture, sessionId, sessionState, [started, completed]);
+        await setupPromptAndSendNotifications(mockFixture, sessionId, sessionState, [
+            started,
+            duplicateWarning,
+            completed,
+        ]);
 
-        await expect(mockFixture.getAcpConnectionDump([])).toMatchFileSnapshot(
+        const dump = mockFixture.getAcpConnectionDump([]);
+        expect(dump).not.toContain("agent_message_chunk");
+        expect(dump).not.toContain("Guardian warning");
+        expect(dump).not.toContain("Automatic approval review approved");
+        expect(dump).toContain("tool_call_update");
+        expect(dump).toContain("Authorization: medium");
+        await expect(dump).toMatchFileSnapshot(
             "data/guardian-approval-review-flow.json"
         );
     });
@@ -113,5 +130,22 @@ describe("CodexEventHandler - Guardian approval review events", () => {
         await expect(mockFixture.getAcpConnectionDump([])).toMatchFileSnapshot(
             "data/guardian-approval-review-completed-without-start.json"
         );
+    });
+
+    it("ignores Guardian warnings that are not approval review summaries", async () => {
+        const warning: ServerNotification = {
+            method: "guardianWarning",
+            params: {
+                threadId: sessionId,
+                message: "Automatic approval review rejected too many approval requests for this turn (3 consecutive, 5 in the last 10 reviews); interrupting the turn.",
+            },
+        };
+
+        vi.spyOn(mockFixture.getCodexAcpAgent(), "getSessionState").mockReturnValue(sessionState);
+        mockFixture.sendServerNotification(warning);
+        await mockFixture.getCodexAcpClient().waitForSessionNotifications(sessionId);
+
+        const dump = mockFixture.getAcpConnectionDump([]);
+        expect(dump).toBe("");
     });
 });


### PR DESCRIPTION
These ended up being quite noisy, the tool calls themselves already had
the correct information. I added both, but I think we just need the tool calls.
