### PR TITLE
Cleanups

### DIFF
--- a/readme-dev.md
+++ b/readme-dev.md
@@ -31,7 +31,7 @@ Run from sources
 
 Run from binaries
 
-1. Download a `codex-acp-<platform>.zip` archive from https://github.com/agentclientprotocol/codex-acp/releases
+1. Download a `codex-acp-<platform>.zip` archive from https://github.com/agentclientprotocol/codex-acp/releases (`<platform>` is one of: `linux`, `darwin`, `win32`)
 2. Unzip the archive:
    ```bash
    unzip codex-acp-<platform>.zip
@@ -69,6 +69,6 @@ npm run package:all
 
 ### Update supported Codex version
 
-1. Update Codex dependency: `package.json`
+1. Update the `@openai/codex` version in `package.json` (under `dependencies`).
 2. Regenerate Codex types in `src/app-server/`: `npm run generate-types`
 3. Ensure there are no type errors or failed tests: `npm run typecheck` and `npm run test`

--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -107,7 +107,7 @@ export class CodexAcpClient {
             case "gateway":
                 if (!authRequest._meta) throw RequestError.invalidRequest();
 
-                const gatewaySettings = authRequest._meta["gateway"]
+                const gatewaySettings = authRequest._meta["gateway"];
                 if (!gatewaySettings) throw RequestError.invalidRequest();
 
                 const baseUrl = gatewaySettings.baseUrl;
@@ -127,7 +127,7 @@ export class CodexAcpClient {
                         http_headers: headers,
                         wire_api: "responses"
                     }
-                }
+                };
 
                 // Early return: model provider information will be sent to Codex later during the session creation
                 return true;

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -323,7 +323,7 @@ export class CodexAcpServer {
         let sessionMetadata: SessionMetadata;
         let resumeSubscribed = false;
         if ("sessionId" in request) {
-            logger.log(`Resume existing session: ${request.sessionId}...`)
+            logger.log(`Resume existing session: ${request.sessionId}...`);
             try {
                 sessionMetadata = await this.runWithProcessCheck(() =>
                     this.codexAcpClient.resumeSession(request, () => {
@@ -337,7 +337,7 @@ export class CodexAcpServer {
                 throw err;
             }
         } else {
-            logger.log(`Create new session...`)
+            logger.log(`Create new session...`);
             sessionMetadata = await this.runWithProcessCheck(() => this.codexAcpClient.newSession(request));
         }
 
@@ -378,7 +378,7 @@ export class CodexAcpServer {
             currentModelSupportsFast: currentModelSupportsFast,
             sessionMcpServers: sessionMcpServers,
             terminalOutputMode: this.terminalOutputMode,
-        }
+        };
         this.sessions.set(sessionId, sessionState);
         resumeSubscribed = false;
 
@@ -1318,7 +1318,7 @@ export class CodexAcpServer {
                         _meta: this.buildQuotaMeta(sessionState),
                     };
                 }
-                const error = eventHandler.getFailure()
+                const error = eventHandler.getFailure();
                 if (error) {
                     // noinspection ExceptionCaughtLocallyJS
                     throw error;
@@ -1420,7 +1420,7 @@ export class CodexAcpServer {
                 };
             }
 
-            const error = eventHandler.getFailure()
+            const error = eventHandler.getFailure();
             if (error) {
                 // noinspection ExceptionCaughtLocallyJS
                 throw error;

--- a/src/CodexEventHandler.ts
+++ b/src/CodexEventHandler.ts
@@ -4,7 +4,6 @@ import type {
     ServerNotification
 } from "./app-server";
 import type {SessionState} from "./CodexAcpServer";
-import * as acp from "@agentclientprotocol/sdk";
 import {type PlanEntry, RequestError} from "@agentclientprotocol/sdk";
 import {ACPSessionConnection, type AcpClientConnection, type UpdateSessionEvent} from "./ACPSessionConnection";
 import type {

--- a/src/CodexJsonRpcConnection.ts
+++ b/src/CodexJsonRpcConnection.ts
@@ -15,7 +15,7 @@ export interface CodexConnection {
 export function startCodexConnection(codexPath?: string, env?: NodeJS.ProcessEnv): CodexConnection {
     const spawnEnv = env ?? process.env;
 
-    let codex: ChildProcessWithoutNullStreams
+    let codex: ChildProcessWithoutNullStreams;
     if (codexPath) {
         codex = process.platform === 'win32'
             ? spawn(`"${codexPath}" app-server`, { shell: true, env: spawnEnv })

--- a/src/ResponseItemHistoryFallback.ts
+++ b/src/ResponseItemHistoryFallback.ts
@@ -975,8 +975,7 @@ function sedFileArguments(args: string[]): string[] {
 }
 
 function looksLikeSedRangeScript(arg: string): boolean {
-    return /^(\d+|\$)?(,(\d+|\$))?[pd]$/.test(arg)
-        || /^(\d+|\$)?(,(\d+|\$))?p$/.test(arg);
+    return /^(\d+|\$)?(,(\d+|\$))?[pd]$/.test(arg);
 }
 
 function headTailFileArguments(args: string[]): string[] {

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -56,10 +56,10 @@ describe('ACP server test', { timeout: 40_000 }, () => {
 
         keyFixture.clearCodexConnectionDump();
 
-        const authRequest: CodexAuthRequest = { methodId: "api-key", _meta: { "api-key": { apiKey: "TOKEN" }}}
+        const authRequest: CodexAuthRequest = { methodId: "api-key", _meta: { "api-key": { apiKey: "TOKEN" }}};
         await codexAcpAgent.authenticate(authRequest);
         const newSessionResponse = await codexAcpAgent.newSession({cwd: "", mcpServers: []});
-        expect(newSessionResponse.sessionId).toBeDefined()
+        expect(newSessionResponse.sessionId).toBeDefined();
 
         const transportEvents = keyFixture.getCodexConnectionEvents([...ignoredFields, "upgrade"]);
         const transportMethods = transportEvents.flatMap(event => "method" in event ? [event.method] : []);
@@ -149,8 +149,8 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         expect(authenticatedResponse).toEqual({type: "gateway", name: "custom-gateway"});
 
         const newSessionResponse = await codexAcpAgent.newSession({cwd: "", mcpServers: []});
-        expect(newSessionResponse.sessionId).toBeDefined()
-    })
+        expect(newSessionResponse.sessionId).toBeDefined();
+    });
 
     it('should show account in /status for api key auth and hide it for gateway auth', async () => {
         const authFixture = createTestFixture();

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ function startAcpServer() {
         stderr = (stderr + data.toString()).slice(-maxStderrTailChars);
     });
 
-    process.stdin.on("close", (chunk: Buffer) => {
+    process.stdin.on("close", () => {
         codexConnection.process.stdin.end();
         // Kill the codex process if it doesn't exit naturally
         setTimeout(() => {


### PR DESCRIPTION
Various cleanups in terms of formatting, unused things, and redundant code.

- **Add missing TypeScript semicolons**
- **Remove unused ACP namespace import**
- **Remove unused stdin close argument**
- **Clarify release archive and Codex update docs**
- **Remove duplicate sed range script pattern**
