### PR TITLE
fix: fall back to inline image data for internal URIs

### DIFF
--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -703,7 +703,8 @@ function buildPromptItems(prompt: acp.ContentBlock[]): UserInput[] {
             case "text":
                 return {type: "text", text: block.text, text_elements: []};
             case "image": {
-                const url = block.uri ?? `data:${block.mimeType};base64,${block.data}`;
+                const dataUrl = `data:${block.mimeType};base64,${block.data}`;
+                const url = isSupportedImageUrl(block.uri) ? block.uri : dataUrl;
                 return {type: "image", url};
             }
             case "resource_link":
@@ -731,6 +732,10 @@ function buildPromptItems(prompt: acp.ContentBlock[]): UserInput[] {
 
 function isImageMimeType(mimeType: string | null | undefined): mimeType is string {
     return mimeType?.startsWith("image/") ?? false;
+}
+
+function isSupportedImageUrl(uri: string | null | undefined): uri is string {
+    return typeof uri === "string" && /^(https?:|data:)/i.test(uri);
 }
 
 function formatUriAsLink(name: string | null | undefined, uri: string): string {

--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -703,8 +703,7 @@ function buildPromptItems(prompt: acp.ContentBlock[]): UserInput[] {
             case "text":
                 return {type: "text", text: block.text, text_elements: []};
             case "image": {
-                const dataUrl = `data:${block.mimeType};base64,${block.data}`;
-                const url = isSupportedImageUrl(block.uri) ? block.uri : dataUrl;
+                const url = isSupportedImageUrl(block.uri) ? block.uri : imageDataUrl(block);
                 return {type: "image", url};
             }
             case "resource_link":
@@ -730,12 +729,24 @@ function buildPromptItems(prompt: acp.ContentBlock[]): UserInput[] {
     }).filter((block): block is UserInput => block !== null);
 }
 
+function imageDataUrl(block: acp.ContentBlock & { type: "image" }): string {
+    return `data:${block.mimeType};base64,${block.data}`;
+}
+
 function isImageMimeType(mimeType: string | null | undefined): mimeType is string {
     return mimeType?.startsWith("image/") ?? false;
 }
 
 function isSupportedImageUrl(uri: string | null | undefined): uri is string {
-    return typeof uri === "string" && /^(https?:|data:)/i.test(uri);
+    if (!uri) {
+        return false;
+    }
+    try {
+        const protocol = new URL(uri).protocol;
+        return protocol === "http:" || protocol === "https:" || protocol === "data:";
+    } catch {
+        return false;
+    }
 }
 
 function formatUriAsLink(name: string | null | undefined, uri: string): string {

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -1432,6 +1432,42 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         }));
     });
 
+    it ('should use inline image data for local file image URIs', async () => {
+        const { mockFixture, turnStartSpy } = setupPromptFixture({
+            supportedInputModalities: ["text", "image"],
+        });
+
+        const prompt: acp.ContentBlock[] = [
+            { type: "image", mimeType: "image/png", data: "abc123", uri: "file:///Users/test/Desktop/Screenshot%201.png" },
+        ];
+
+        await mockFixture.getCodexAcpAgent().prompt({ sessionId: "id", prompt });
+
+        expect(turnStartSpy).toHaveBeenCalledWith(expect.objectContaining({
+            input: [
+                { type: "image", url: "data:image/png;base64,abc123" },
+            ]
+        }));
+    });
+
+    it ('should preserve data image URLs', async () => {
+        const { mockFixture, turnStartSpy } = setupPromptFixture({
+            supportedInputModalities: ["text", "image"],
+        });
+
+        const prompt: acp.ContentBlock[] = [
+            { type: "image", mimeType: "image/png", data: "fallback", uri: "data:image/png;base64,abc123" },
+        ];
+
+        await mockFixture.getCodexAcpAgent().prompt({ sessionId: "id", prompt });
+
+        expect(turnStartSpy).toHaveBeenCalledWith(expect.objectContaining({
+            input: [
+                { type: "image", url: "data:image/png;base64,abc123" },
+            ]
+        }));
+    });
+
     it ('should show rate limits from multiple sources in status', async () => {
         const rateLimits: RateLimitsMap = new Map();
         rateLimits.set("limit-1", {

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -1412,6 +1412,26 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         }));
     });
 
+    it ('should use inline image data for internal image URIs', async () => {
+        const { mockFixture, turnStartSpy } = setupPromptFixture({
+            supportedInputModalities: ["text", "image"],
+        });
+
+        const prompt: acp.ContentBlock[] = [
+            { type: "text", text: "Hello" },
+            { type: "image", mimeType: "image/png", data: "abc123", uri: "zed:///agent/pasted-image?name=Image" },
+        ];
+
+        await mockFixture.getCodexAcpAgent().prompt({ sessionId: "id", prompt });
+
+        expect(turnStartSpy).toHaveBeenCalledWith(expect.objectContaining({
+            input: [
+                { type: "text", text: "Hello", text_elements: [] },
+                { type: "image", url: "data:image/png;base64,abc123" },
+            ]
+        }));
+    });
+
     it ('should show rate limits from multiple sources in status', async () => {
         const rateLimits: RateLimitsMap = new Map();
         rateLimits.set("limit-1", {


### PR DESCRIPTION
## Summary

- Fall back to inline ACP image data when an image block carries an internal or otherwise non-fetchable URI.
- Keep existing behavior for `http:`, `https:`, and `data:` image URLs.
- Add a regression test covering `zed:///agent/pasted-image?...` input.

## Motivation

Some ACP clients attach pasted images with inline `data`/`mimeType` plus a client-internal `uri`. For example, Zed can send a pasted image URI such as `zed:///agent/pasted-image?name=Image`. The adapter currently forwards that URI to Codex as an image URL, which later becomes an OpenAI `image_url` value and is rejected because `zed:///...` is not a valid URL for the API.

Using the inline image payload for non-fetchable URI schemes preserves image input while still allowing real external URLs and already-inline `data:` URLs to pass through unchanged.

## Validation

- `npm test -- src/__tests__/CodexACPAgent/CodexAcpClient.test.ts`
- `npm run typecheck`