### PR TITLE
Add session rename support

### DIFF
--- a/src/AcpExtensions.ts
+++ b/src/AcpExtensions.ts
@@ -7,6 +7,7 @@ import type {
 } from "@agentclientprotocol/sdk";
 
 export const LEGACY_SET_SESSION_MODEL_METHOD = "session/set_model";
+export const SET_SESSION_TITLE_METHOD = "session/setTitle";
 
 export type LegacySessionModel = {
     modelId: string;
@@ -26,6 +27,13 @@ export type LegacySetSessionModelRequest = {
 
 export type LegacySetSessionModelResponse = {}
 
+export type SetSessionTitleRequest = {
+    sessionId: SessionId;
+    title: string;
+}
+
+export type SetSessionTitleResponse = {}
+
 export type LegacyNewSessionResponse = NewSessionResponse & {
     models?: LegacySessionModelState | null;
 }
@@ -42,11 +50,13 @@ export type ExtMethodRequest =
     AuthenticationStatusRequest
     | AuthenticationLogoutRequest
     | LegacySetSessionModelExtRequest
+    | SetSessionTitleExtRequest
 
 export function isExtMethodRequest(request: { method: string, params: Record<string, unknown> }): request is ExtMethodRequest {
     return request.method === "authentication/status"
         || request.method === "authentication/logout"
-        || request.method === LEGACY_SET_SESSION_MODEL_METHOD;
+        || request.method === LEGACY_SET_SESSION_MODEL_METHOD
+        || request.method === SET_SESSION_TITLE_METHOD;
 }
 
 export type AuthenticationStatusRequest = { method: "authentication/status", params: {} }
@@ -58,6 +68,11 @@ export type AuthenticationLogoutResponse = {}
 export type LegacySetSessionModelExtRequest = {
     method: typeof LEGACY_SET_SESSION_MODEL_METHOD;
     params: LegacySetSessionModelRequest;
+}
+
+export type SetSessionTitleExtRequest = {
+    method: typeof SET_SESSION_TITLE_METHOD;
+    params: SetSessionTitleRequest;
 }
 
 export async function legacySetSessionModel(

--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -319,6 +319,13 @@ export class CodexAcpClient {
         await this.codexClient.threadArchive({threadId: sessionId});
     }
 
+    async setSessionTitle(sessionId: string, title: string): Promise<void> {
+        await this.codexClient.threadSetName({
+            threadId: sessionId,
+            name: title,
+        });
+    }
+
     async runReview(
         sessionId: string,
         target: ReviewTarget,

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -42,8 +42,11 @@ import {
     type LegacySessionModelState,
     type LegacySetSessionModelRequest,
     type LegacySetSessionModelResponse,
+    type SetSessionTitleRequest,
+    type SetSessionTitleResponse,
     isExtMethodRequest,
     LEGACY_SET_SESSION_MODEL_METHOD,
+    SET_SESSION_TITLE_METHOD,
 } from "./AcpExtensions";
 import {
     createCollabAgentToolCallUpdate,
@@ -193,6 +196,14 @@ export class CodexAcpServer {
         this.terminalOutputMode = resolveTerminalOutputMode(_params.clientCapabilities);
         this.booleanConfigOptionsSupported = clientSupportsBooleanConfigOptions(_params.clientCapabilities);
         await this.runWithProcessCheck(() => this.codexAcpClient.initialize(_params));
+        const sessionCapabilities = {
+            resume: { },
+            list: { },
+            close: { },
+            delete: { },
+            additionalDirectories: {},
+            setTitle: {},
+        };
         return {
             protocolVersion: acp.PROTOCOL_VERSION,
             agentInfo: {
@@ -209,13 +220,7 @@ export class CodexAcpServer {
                     embeddedContext: true,
                     image: true
                 },
-                sessionCapabilities: {
-                    resume: { },
-                    list: { },
-                    close: { },
-                    delete: { },
-                    additionalDirectories: {},
-                },
+                sessionCapabilities,
                 mcpCapabilities: {
                     acp: false,
                     http: true,
@@ -240,6 +245,8 @@ export class CodexAcpServer {
             }
             case LEGACY_SET_SESSION_MODEL_METHOD:
                 return await this.unstable_setSessionModel(this.parseLegacySetSessionModelParams(methodRequest.params));
+            case SET_SESSION_TITLE_METHOD:
+                return await this.setSessionTitle(this.parseSetSessionTitleParams(methodRequest.params));
         }
     }
 
@@ -689,6 +696,16 @@ export class CodexAcpServer {
         };
     }
 
+    async setSessionTitle(params: SetSessionTitleRequest): Promise<SetSessionTitleResponse> {
+        logger.log("Set session title requested", {
+            sessionId: params.sessionId,
+            titleLength: params.title.length,
+        });
+        await this.checkAuthorization();
+        await this.runWithProcessCheck(() => this.codexAcpClient.setSessionTitle(params.sessionId, params.title));
+        return {};
+    }
+
     private applyFastModeChange(sessionState: SessionState, params: acp.SetSessionConfigOptionRequest): void {
         const value = params.value;
         if (typeof value === "boolean") {
@@ -787,6 +804,18 @@ export class CodexAcpServer {
         return {
             sessionId: sessionId,
             modelId: modelId,
+        };
+    }
+
+    private parseSetSessionTitleParams(params: Record<string, unknown>): SetSessionTitleRequest {
+        const sessionId = params["sessionId"];
+        const title = params["title"];
+        if (typeof sessionId !== "string" || typeof title !== "string") {
+            throw RequestError.invalidParams();
+        }
+        return {
+            sessionId: sessionId,
+            title: title,
         };
     }
 

--- a/src/CodexAppServerClient.ts
+++ b/src/CodexAppServerClient.ts
@@ -47,6 +47,8 @@ import type {
     ThreadReadResponse,
     ThreadResumeParams,
     ThreadResumeResponse,
+    ThreadSetNameParams,
+    ThreadSetNameResponse,
     ThreadStartParams,
     ThreadStartResponse,
     ThreadUnsubscribeParams,
@@ -507,6 +509,10 @@ export class CodexAppServerClient {
 
     async threadArchive(params: ThreadArchiveParams): Promise<ThreadArchiveResponse> {
         return await this.sendRequest({ method: "thread/archive", params: params });
+    }
+
+    async threadSetName(params: ThreadSetNameParams): Promise<ThreadSetNameResponse> {
+        return await this.sendRequest({ method: "thread/name/set", params: params });
     }
 
     async threadUnsubscribe(params: ThreadUnsubscribeParams): Promise<ThreadUnsubscribeResponse> {

--- a/src/CodexCommands.ts
+++ b/src/CodexCommands.ts
@@ -110,6 +110,11 @@ export class CodexCommands {
                 input: null
             },
             {
+                name: "rename",
+                description: "Rename this session.",
+                input: { hint: "new session title" }
+            },
+            {
                 name: "review",
                 description: "Review uncommitted changes, or review with custom instructions.",
                 input: { hint: "optional review instructions" }
@@ -212,6 +217,19 @@ export class CodexCommands {
                 const session = new ACPSessionConnection(this.connection, sessionId);
                 const message = this.buildStatusMessage(sessionState);
                 await session.update(createAgentTextMessageChunk(message));
+                return { handled: true };
+            }
+            case "rename": {
+                if (command.rest.length === 0) {
+                    await this.sendCommandUsageMessage(commandName, "new session title", sessionId);
+                    return { handled: true };
+                }
+                await this.runWithProcessCheck(() => this.codexAcpClient.setSessionTitle(sessionId, command.rest));
+                const session = new ACPSessionConnection(this.connection, sessionId);
+                await session.update({
+                    sessionUpdate: "agent_message_chunk",
+                    content: { type: "text", text: `Renamed session to ${JSON.stringify(command.rest)}.` }
+                });
                 return { handled: true };
             }
             case "logout": {

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -16,6 +16,7 @@ import {AgentMode} from "../../AgentMode";
 import type {Model, ReviewStartResponse, ThreadGoal, TurnCompletedNotification, TurnStartParams} from "../../app-server/v2";
 import type {RateLimitsMap} from "../../RateLimitsMap";
 import {ModelId} from "../../ModelId";
+import {SET_SESSION_TITLE_METHOD} from "../../AcpExtensions";
 
 describe('ACP server test', { timeout: 40_000 }, () => {
 
@@ -1304,6 +1305,26 @@ describe('ACP server test', { timeout: 40_000 }, () => {
 
         await codexAcpAgent.prompt({ sessionId: "session-id", prompt: [{ type: "text", text: "/status" }] });
         await expect(mockFixture.getAcpConnectionDump([])).toMatchFileSnapshot("data/command-status.json");
+    });
+
+    it('handles rename slash command through Codex app server', async () => {
+        const { mockFixture, turnStartSpy } = setupPromptFixture();
+        const threadSetNameSpy = vi.spyOn(mockFixture.getCodexAppServerClient(), "threadSetName")
+            .mockResolvedValue({});
+
+        await mockFixture.getCodexAcpAgent().prompt({
+            sessionId: "session-id",
+            prompt: [{ type: "text", text: "/rename Quarterly review" }],
+        });
+
+        expect(threadSetNameSpy).toHaveBeenCalledWith({
+            threadId: "session-id",
+            name: "Quarterly review",
+        });
+        expect(turnStartSpy).not.toHaveBeenCalled();
+        const [event] = mockFixture.getAcpConnectionEvents([]);
+        expect(event).toBeDefined();
+        expect(event!.args[0].update.content.text).toBe('Renamed session to "Quarterly review".');
     });
 
     it('passes skill slash commands through to Codex', async () => {
@@ -2631,6 +2652,39 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         const [event] = mockFixture.getAcpConnectionEvents([]);
         expect(event).toBeDefined();
         expect(event!.args[0].update.content.text).toBe('Command "/review-branch" requires branch name.');
+    });
+
+    it('reports missing rename slash command input', async () => {
+        const { mockFixture } = setupPromptFixture();
+        const threadSetNameSpy = vi.spyOn(mockFixture.getCodexAppServerClient(), "threadSetName")
+            .mockResolvedValue({});
+
+        await mockFixture.getCodexAcpAgent().prompt({
+            sessionId: "session-id",
+            prompt: [{ type: "text", text: "/rename" }],
+        });
+
+        expect(threadSetNameSpy).not.toHaveBeenCalled();
+        const [event] = mockFixture.getAcpConnectionEvents([]);
+        expect(event).toBeDefined();
+        expect(event!.args[0].update.content.text).toBe('Command "/rename" requires new session title.');
+    });
+
+    it('handles session setTitle extension through Codex app server', async () => {
+        const mockFixture = createCodexMockTestFixture();
+        vi.spyOn(mockFixture.getCodexAcpClient(), "authRequired").mockResolvedValue(false);
+        const threadSetNameSpy = vi.spyOn(mockFixture.getCodexAppServerClient(), "threadSetName")
+            .mockResolvedValue({});
+
+        await expect(mockFixture.getCodexAcpAgent().extMethod(SET_SESSION_TITLE_METHOD, {
+            sessionId: "thread-id",
+            title: "Renamed from client",
+        })).resolves.toEqual({});
+
+        expect(threadSetNameSpy).toHaveBeenCalledWith({
+            threadId: "thread-id",
+            name: "Renamed from client",
+        });
     });
 
     it('handles logout command', async () => {

--- a/src/__tests__/CodexACPAgent/data/available-commands-build-in.json
+++ b/src/__tests__/CodexACPAgent/data/available-commands-build-in.json
@@ -22,6 +22,13 @@
             "input": null
           },
           {
+            "name": "rename",
+            "description": "Rename this session.",
+            "input": {
+              "hint": "new session title"
+            }
+          },
+          {
             "name": "review",
             "description": "Review uncommitted changes, or review with custom instructions.",
             "input": {

--- a/src/__tests__/CodexACPAgent/data/available-commands-skills.json
+++ b/src/__tests__/CodexACPAgent/data/available-commands-skills.json
@@ -22,6 +22,13 @@
             "input": null
           },
           {
+            "name": "rename",
+            "description": "Rename this session.",
+            "input": {
+              "hint": "new session title"
+            }
+          },
+          {
             "name": "review",
             "description": "Review uncommitted changes, or review with custom instructions.",
             "input": {

--- a/src/__tests__/CodexACPAgent/data/load-session-history.json
+++ b/src/__tests__/CodexACPAgent/data/load-session-history.json
@@ -22,6 +22,13 @@
             "input": null
           },
           {
+            "name": "rename",
+            "description": "Rename this session.",
+            "input": {
+              "hint": "new session title"
+            }
+          },
+          {
             "name": "review",
             "description": "Review uncommitted changes, or review with custom instructions.",
             "input": {

--- a/src/__tests__/CodexACPAgent/data/load-session-response-item-history-fallback.json
+++ b/src/__tests__/CodexACPAgent/data/load-session-response-item-history-fallback.json
@@ -22,6 +22,13 @@
             "input": null
           },
           {
+            "name": "rename",
+            "description": "Rename this session.",
+            "input": {
+              "hint": "new session title"
+            }
+          },
+          {
             "name": "review",
             "description": "Review uncommitted changes, or review with custom instructions.",
             "input": {

--- a/src/__tests__/CodexACPAgent/initialize.test.ts
+++ b/src/__tests__/CodexACPAgent/initialize.test.ts
@@ -52,6 +52,7 @@ describe('CodexACPAgent - initialize', () => {
                     close: {},
                     delete: {},
                     additionalDirectories: {},
+                    setTitle: {},
                 },
                 mcpCapabilities: {
                     acp: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import packageJson from "../package.json";
 import {logger} from "./Logger";
 import {runLoginCommand} from "./login";
 import {runCodexCli} from "./CodexCli";
-import {LEGACY_SET_SESSION_MODEL_METHOD} from "./AcpExtensions";
+import {LEGACY_SET_SESSION_MODEL_METHOD, SET_SESSION_TITLE_METHOD} from "./AcpExtensions";
 
 const emptyExtensionParamsParser = z.preprocess(
     (params) => params ?? {},
@@ -22,6 +22,11 @@ const emptyExtensionParamsParser = z.preprocess(
 const legacySetSessionModelParamsParser = z.object({
     sessionId: z.string(),
     modelId: z.string(),
+}).passthrough();
+
+const setSessionTitleParamsParser = z.object({
+    sessionId: z.string(),
+    title: z.string(),
 }).passthrough();
 
 if (process.argv.includes("--version")) {
@@ -129,5 +134,6 @@ function startAcpServer() {
         .onRequest("authentication/status", emptyExtensionParamsParser, (ctx) => getAgent().extMethod("authentication/status", ctx.params))
         .onRequest("authentication/logout", emptyExtensionParamsParser, (ctx) => getAgent().extMethod("authentication/logout", ctx.params))
         .onRequest(LEGACY_SET_SESSION_MODEL_METHOD, legacySetSessionModelParamsParser, (ctx) => getAgent().extMethod(LEGACY_SET_SESSION_MODEL_METHOD, ctx.params))
+        .onRequest(SET_SESSION_TITLE_METHOD, setSessionTitleParamsParser, (ctx) => getAgent().extMethod(SET_SESSION_TITLE_METHOD, ctx.params))
         .connect(acpJsonStream);
 }


### PR DESCRIPTION

## Summary
- advertise `sessionCapabilities.setTitle` and handle `session/setTitle` via the generated Codex app-server `thread/name/set` request
- add a `/rename` built-in slash command that renames the current session and publishes it in available commands
- cover the capability, extension request, slash command behavior, and updated command snapshots

## Notes
- `session/setTitle` is registered as an extension request until the ACP SDK exposes a typed method for it.

## Validation
- `npm run typecheck`
- `npm run build`
- `npm test`
