### PR TITLE
Upgrade vscode-jsonrpc to v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@openai/codex": "^0.142.5",
         "diff": "^9.0.0",
         "open": "^11.0.0",
-        "vscode-jsonrpc": "^8.2.1",
+        "vscode-jsonrpc": "^9.0.1",
         "zod": "^4.0.0"
       },
       "bin": {
@@ -3777,9 +3777,9 @@
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
-      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+      "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@openai/codex": "^0.142.5",
     "diff": "^9.0.0",
     "open": "^11.0.0",
-    "vscode-jsonrpc": "^8.2.1",
+    "vscode-jsonrpc": "^9.0.1",
     "zod": "^4.0.0"
   }
 }

--- a/src/StdUtils.ts
+++ b/src/StdUtils.ts
@@ -1,7 +1,6 @@
 import {Readable, Writable} from "node:stream";
-import {Disposable} from "vscode-jsonrpc";
-import {Emitter, Message, MessageReader, MessageWriter} from "vscode-jsonrpc/node";
-import type {DataCallback, PartialMessageInfo} from "vscode-jsonrpc/node";
+import {Emitter} from "vscode-jsonrpc/node";
+import type {DataCallback, Disposable, Message, MessageReader, MessageWriter, PartialMessageInfo} from "vscode-jsonrpc/node";
 import * as acp from "@agentclientprotocol/sdk";
 
 //TODO ask to include proper jsonrpc field and remove


### PR DESCRIPTION
Noticed we were behind a version, seems fairly trivial to upgrade if we want
