### PR TITLE
fix: recover agent message text from item/completed when deltas are missing

### DIFF
--- a/src/CodexEventHandler.ts
+++ b/src/CodexEventHandler.ts
@@ -72,6 +72,7 @@ export class CodexEventHandler {
     private readonly activeImageGenerationItems = new Set<string>();
     private readonly emittedImageViewItems = new Set<string>();
     private readonly seenReasoningDeltaItemIds = new Set<string>();
+    private readonly seenAgentMessageDeltaItemIds = new Set<string>();
     private readonly terminalCommandIds = new Set<string>();
     private readonly terminalCommandOutputIds = new Set<string>();
 
@@ -230,6 +231,7 @@ export class CodexEventHandler {
     }
 
     private async createTextEvent(event: AgentMessageDeltaNotification): Promise<UpdateSessionEvent> {
+        this.seenAgentMessageDeltaItemIds.add(event.itemId);
         return createAgentTextMessageChunk(event.delta, event.itemId);
     }
 
@@ -387,12 +389,21 @@ export class CodexEventHandler {
                 return this.createExitedReviewModeEvent(event.item);
             case "contextCompaction":
                 return this.createContextCompactedEvent();
+            case "agentMessage": {
+                if (this.seenAgentMessageDeltaItemIds.delete(event.item.id)) {
+                    return null;
+                }
+                const text = event.item.text;
+                if (text.length > 0) {
+                    return createAgentTextMessageChunk(text, event.item.id);
+                }
+                return null;
+            }
             //ignored types
             case "subAgentActivity":
             case "sleep":
             case "userMessage":
             case "hookPrompt":
-            case "agentMessage":
             case "enteredReviewMode":
             case "plan":
                 return null;

--- a/src/__tests__/CodexACPAgent/agent-message-fallback.test.ts
+++ b/src/__tests__/CodexACPAgent/agent-message-fallback.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ServerNotification } from "../../app-server";
+import type { SessionState } from "../../CodexAcpServer";
+import { AgentMode } from "../../AgentMode";
+import {
+    createCodexMockTestFixture,
+    createTestSessionState,
+    setupPromptAndSendNotifications,
+    type CodexMockTestFixture
+} from "../acp-test-utils";
+
+describe("CodexEventHandler - agent message fallback", () => {
+    let mockFixture: CodexMockTestFixture;
+    const sessionId = "test-session-id";
+
+    beforeEach(() => {
+        mockFixture = createCodexMockTestFixture();
+        vi.clearAllMocks();
+    });
+
+    const sessionState: SessionState = createTestSessionState({
+        sessionId,
+        currentModelId: "model-id[effort]",
+        agentMode: AgentMode.DEFAULT_AGENT_MODE
+    });
+
+    it("emits agent message text from item/completed when no deltas streamed", async () => {
+        const notifications: ServerNotification[] = [
+            {
+                method: "item/completed",
+                params: {
+                    threadId: sessionId,
+                    turnId: "turn-1",
+                    completedAtMs: 0,
+                    item: {
+                        type: "agentMessage",
+                        id: "msg-1",
+                        text: "Hello!",
+                        phase: null,
+                        memoryCitation: null,
+                    },
+                },
+            },
+        ];
+
+        await setupPromptAndSendNotifications(mockFixture, sessionId, sessionState, notifications);
+
+        await expect(mockFixture.getAcpConnectionDump([])).toMatchFileSnapshot(
+            "data/agent-message-completed-fallback.json"
+        );
+    });
+
+    it("does not duplicate agent message when deltas were streamed", async () => {
+        const notifications: ServerNotification[] = [
+            {
+                method: "item/agentMessage/delta",
+                params: {
+                    threadId: sessionId,
+                    turnId: "turn-1",
+                    itemId: "msg-2",
+                    delta: "Hel",
+                },
+            },
+            {
+                method: "item/agentMessage/delta",
+                params: {
+                    threadId: sessionId,
+                    turnId: "turn-1",
+                    itemId: "msg-2",
+                    delta: "lo!",
+                },
+            },
+            {
+                method: "item/completed",
+                params: {
+                    threadId: sessionId,
+                    turnId: "turn-1",
+                    completedAtMs: 0,
+                    item: {
+                        type: "agentMessage",
+                        id: "msg-2",
+                        text: "Hello!",
+                        phase: null,
+                        memoryCitation: null,
+                    },
+                },
+            },
+        ];
+
+        await setupPromptAndSendNotifications(mockFixture, sessionId, sessionState, notifications);
+
+        await expect(mockFixture.getAcpConnectionDump([])).toMatchFileSnapshot(
+            "data/agent-message-deltas-no-duplicate.json"
+        );
+    });
+});

--- a/src/__tests__/CodexACPAgent/data/agent-message-completed-fallback.json
+++ b/src/__tests__/CodexACPAgent/data/agent-message-completed-fallback.json
@@ -1,0 +1,16 @@
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
+        "sessionUpdate": "agent_message_chunk",
+        "messageId": "msg-1",
+        "content": {
+          "type": "text",
+          "text": "Hello!"
+        }
+      }
+    }
+  ]
+}

--- a/src/__tests__/CodexACPAgent/data/agent-message-deltas-no-duplicate.json
+++ b/src/__tests__/CodexACPAgent/data/agent-message-deltas-no-duplicate.json
@@ -1,0 +1,32 @@
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
+        "sessionUpdate": "agent_message_chunk",
+        "messageId": "msg-2",
+        "content": {
+          "type": "text",
+          "text": "Hel"
+        }
+      }
+    }
+  ]
+}
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
+        "sessionUpdate": "agent_message_chunk",
+        "messageId": "msg-2",
+        "content": {
+          "type": "text",
+          "text": "lo!"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

Some Responses API providers (e.g. **Volcengine Ark / 火山方舟**) emit reasoning items in `output_item.added` without the `content`/`summary` array fields that Codex's internal active-item state machine expects. When this happens, the state machine fails to register an active item, and all subsequent streaming deltas — including `output_text.delta` — are silently dropped with errors like:

```
ERROR codex_core::util: OutputTextDelta without active item
```

The model **does** generate text (confirmed by `outputTokens` in usage), and Codex successfully surfaces it via the `item/completed` notification. However, codex-acp **ignored** `agentMessage` items in `completeItemEvent` (`return null`), so the text was lost entirely. Users on affected providers only saw the reasoning/thinking content, with no actual assistant reply.

## Root Cause (confirmed via logs)

| Layer | TUI mode (codex CLI) | app-server mode (codex-acp) |
|---|---|---|
| `stream_events_utils` (SSE parsing) | ✅ works | ✅ works |
| `codex_core::util` (active-item state machine) | not used | ❌ fails on providers with non-standard reasoning items |

The TUI mode bypasses the state machine, so `codex` CLI works fine. The app-server mode uses it and drops deltas — but the full text is still available in `item/completed`.

## Fix

Mirror the existing **reasoning** fallback pattern for **agentMessage**:

1. Track item IDs that received `item/agentMessage/delta` in a new `seenAgentMessageDeltaItemIds` set (in `createTextEvent`)
2. In `completeItemEvent`, if no deltas were seen for the `agentMessage` item, emit `item.text` as an `agent_message_chunk`
3. If deltas **were** seen, return `null` (no duplication)

This mirrors exactly how `reasoning` items are already handled (`seenReasoningDeltaItemIds` + `createCompletedReasoningEvent`).

## Impact

- **Providers with correct streaming** (OpenAI, etc.): **zero impact** — `seenAgentMessageDeltaItemIds` contains the item ID, so the completed event returns `null` as before
- **Providers with missing deltas** (Volcengine Ark, potentially others): text is recovered from `item/completed` instead of being lost

## Testing

Added `agent-message-fallback.test.ts` with two cases:
- "emits agent message text from item/completed when no deltas streamed" — verifies the fallback fires
- "does not duplicate agent message when deltas were streamed" — verifies no duplication for standard providers

All 280 existing tests still pass.

## Reproduction

Provider config (Volcengine Ark):
```toml
model = "doubao-seed-2.0-lite"
model_provider = "volcengine-coding-plan"
model_supports_reasoning_summaries = true

[model_providers.volcengine-coding-plan]
base_url = "https://ark.cn-beijing.volces.com/api/coding/v3"
env_key = "ARK_API_KEY"
wire_api = "responses"
```

With this config, `codex` CLI (TUI) outputs text correctly, but any ACP client using codex-acp sees only thinking content and no assistant reply.
