### PR TITLE
Show skill reads as ACP read tool calls

### DIFF
--- a/src/CodexToolCallMapper.ts
+++ b/src/CodexToolCallMapper.ts
@@ -427,7 +427,23 @@ export function createCommandActionEvent(
 ): AcpToolCallEvent {
     const acpStatus = toAcpStatus(status);
     switch (commandAction.type) {
-        case "read":
+        case "read": {
+            const skillName = skillNameFromSkillPath(commandAction.path);
+            if (skillName) {
+                return {
+                    sessionUpdate: "tool_call",
+                    toolCallId: id,
+                    status: acpStatus,
+                    kind: "read",
+                    title: `Read ${formatSkillName(skillName)} skill`,
+                    locations: [{ path: commandAction.path }],
+                    rawInput: {
+                        type: "skill",
+                        name: skillName,
+                        path: commandAction.path,
+                    },
+                };
+            }
             return {
                 sessionUpdate: "tool_call",
                 toolCallId: id,
@@ -436,6 +452,7 @@ export function createCommandActionEvent(
                 title: `Read file '${commandAction.path}'`,
                 locations: [{ path: commandAction.path }],
             };
+        }
         case "search":
             return {
                 sessionUpdate: "tool_call",
@@ -469,6 +486,34 @@ export function createCommandActionEvent(
                 },
             }, id, cwd);
     }
+}
+
+function skillNameFromSkillPath(filePath: string): string | null {
+    const normalized = filePath.replace(/[\\/]+/g, "/");
+    const segments = normalized.split("/").filter(segment => segment.length > 0);
+    if (segments.at(-1) !== "SKILL.md") {
+        return null;
+    }
+
+    const skillDirectory = segments.at(-2);
+    if (!skillDirectory) {
+        return null;
+    }
+
+    const parent = segments.at(-3);
+    if (parent !== "skills") {
+        return null;
+    }
+
+    return skillDirectory;
+}
+
+function formatSkillName(skillName: string): string {
+    return skillName
+        .split(/[-_\s]+/g)
+        .filter(part => part.length > 0)
+        .map(part => part.length <= 3 ? part.toUpperCase() : `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`)
+        .join(" ");
 }
 
 export function commandExecutionUsesTerminalOutput(item: CommandExecutionItem): boolean {

--- a/src/__tests__/CodexACPAgent/command-action-events.test.ts
+++ b/src/__tests__/CodexACPAgent/command-action-events.test.ts
@@ -128,6 +128,43 @@ describe('CodexEventHandler - command action events', () => {
         );
     });
 
+    it('should render skill instruction reads as skill read tool calls', async () => {
+        const readSkillNotification: ServerNotification = {
+            method: 'item/started',
+            params: {
+                threadId: sessionId,
+                turnId: 'turn-1',
+                startedAtMs: 0,
+                item: {
+                    type: 'commandExecution',
+                    id: 'command-read-skill',
+                    command: "sed -n '1,240p' /test/project/.agents/skills/ui-accessibility/SKILL.md",
+                    cwd: '/test/project',
+                    processId: null,
+                    source: 'agent',
+                    status: 'inProgress',
+                    commandActions: [
+                        {
+                            type: 'read',
+                            command: "sed -n '1,240p' /test/project/.agents/skills/ui-accessibility/SKILL.md",
+                            name: 'SKILL.md',
+                            path: '/test/project/.agents/skills/ui-accessibility/SKILL.md',
+                        },
+                    ],
+                    aggregatedOutput: null,
+                    exitCode: null,
+                    durationMs: null,
+                },
+            },
+        };
+
+        await setupPromptAndSendNotifications(mockFixture, sessionId, sessionState, [readSkillNotification]);
+
+        await expect(mockFixture.getAcpConnectionDump([])).toMatchFileSnapshot(
+            'data/command-read-skill.json'
+        );
+    });
+
     it('should handle search command with query and path', async () => {
         const searchNotification: ServerNotification = {
             method: 'item/started',

--- a/src/__tests__/CodexACPAgent/data/command-read-skill.json
+++ b/src/__tests__/CodexACPAgent/data/command-read-skill.json
@@ -1,0 +1,25 @@
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "command-read-skill",
+        "status": "in_progress",
+        "kind": "read",
+        "title": "Read UI Accessibility skill",
+        "locations": [
+          {
+            "path": "/test/project/.agents/skills/ui-accessibility/SKILL.md"
+          }
+        ],
+        "rawInput": {
+          "type": "skill",
+          "name": "ui-accessibility",
+          "path": "/test/project/.agents/skills/ui-accessibility/SKILL.md"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Render Codex reads of skill instruction files as skill-specific ACP read tool calls.

## Before

- When the agent loaded/read a skill, Codex emitted a normal `commandExecution` item whose parsed `commandActions` contained a `read` action for a `.../skills/<skill>/SKILL.md` path.
- `codex-acp` mapped every read action the same way, so the UI only saw a generic title like `Read file '/path/to/SKILL.md'`.
- That made skill loading indistinguishable from ordinary file reads, even though the UI wants to show activity such as `Read UI Accessibility skill` separately.

## After

- `createCommandActionEvent()` detects read actions whose path points at a skill instruction file (`*/skills/<skill>/SKILL.md`).
- Those reads are still emitted as standard ACP read tool calls:
  - `sessionUpdate: "tool_call"`
  - `kind: "read"`
  - `title: "Read <skill> skill"`
  - `locations: [{ path: <SKILL.md path> }]`
  - `rawInput: { type: "skill", name: <skill directory>, path }`
- Ordinary file reads are unchanged.

## Why

The agent-side “loaded/read skill” activity is already present in Codex events as a parsed read command for `SKILL.md`; `codex-acp` just treated it like a generic file read. This keeps the ACP protocol shape unchanged while giving Codex-aware UIs a stable way to render skill loading separately from regular file reads (`rawInput.type === "skill"`).

## Tests

- `npx vitest run src/__tests__/CodexACPAgent/command-action-events.test.ts -u`
- `npm run typecheck`
- `npm test`
