### PR TITLE
Add ACP plan mode user input bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The adapter advertises ACP auth methods during initialization. Clients can authe
 - `CODEX_CONFIG` - JSON object merged into the Codex session config.
 - `MODEL_PROVIDER` - model provider to pass to Codex for new sessions.
 - `DEFAULT_AUTH_REQUEST` - ACP auth request JSON used when Codex requires authentication.
-- `INITIAL_AGENT_MODE` - initial mode id: `read-only`, `agent`, or `agent-full-access`.
+- `INITIAL_AGENT_MODE` - initial mode id: `read-only`, `agent`, `agent-full-access`, or `plan`.
 - `NO_BROWSER` - hide browser-based ChatGPT auth when set.
 - `APP_SERVER_LOGS` - directory for adapter logs.
 

--- a/readme-dev.md
+++ b/readme-dev.md
@@ -9,7 +9,7 @@ Set `CODEX_PATH` to run a different Codex binary; versions other than the one sp
 - `CODEX_CONFIG` - JSON object merged into the Codex session config.
 - `MODEL_PROVIDER` - model provider to pass to Codex for new sessions.
 - `DEFAULT_AUTH_REQUEST` - ACP auth request JSON used when Codex requires authentication.
-- `INITIAL_AGENT_MODE` - initial mode id: `read-only`, `agent`, or `agent-full-access`.
+- `INITIAL_AGENT_MODE` - initial mode id: `read-only`, `agent`, `agent-full-access`, or `plan`.
 - `NO_BROWSER` - hide browser-based ChatGPT auth when set.
 - `APP_SERVER_LOGS` - directory for adapter logs.
 

--- a/src/AgentMode.ts
+++ b/src/AgentMode.ts
@@ -1,5 +1,6 @@
 import type {AskForApproval, SandboxMode, SandboxPolicy} from "./app-server/v2";
 import type {SessionConfigOption, SessionMode, SessionModeState} from "@agentclientprotocol/sdk";
+import type {ModeKind} from "./app-server";
 
 export const MODE_CONFIG_ID = "mode";
 
@@ -10,14 +11,24 @@ export class AgentMode {
     readonly approvalPolicy: AskForApproval;
     readonly sandboxPolicy: SandboxPolicy;
     readonly sandboxMode: SandboxMode;
+    readonly collaborationMode: ModeKind;
 
-    private constructor(id: string, name: string, description: string, approval: AskForApproval, sandbox: SandboxPolicy, sandboxMode: SandboxMode) {
+    private constructor(
+        id: string,
+        name: string,
+        description: string,
+        approval: AskForApproval,
+        sandbox: SandboxPolicy,
+        sandboxMode: SandboxMode,
+        collaborationMode: ModeKind = "default",
+    ) {
         this.id = id;
         this.name = name;
         this.description = description;
         this.approvalPolicy = approval;
         this.sandboxPolicy = sandbox;
         this.sandboxMode = sandboxMode; // same as sandboxPolicy, need to look for
+        this.collaborationMode = collaborationMode;
     }
 
     static readonly ReadOnly = new AgentMode(
@@ -53,6 +64,15 @@ export class AgentMode {
         {"type": "dangerFullAccess"},
         "danger-full-access"
     );
+    static readonly Plan = new AgentMode(
+        "plan",
+        "Plan",
+        "Codex collaborates in plan mode and asks before moving forward.",
+        AgentMode.Agent.approvalPolicy,
+        AgentMode.Agent.sandboxPolicy,
+        AgentMode.Agent.sandboxMode,
+        "plan",
+    );
 
     static DEFAULT_AGENT_MODE = AgentMode.Agent;
 
@@ -75,7 +95,7 @@ export class AgentMode {
         return {
             id: MODE_CONFIG_ID,
             name: "Mode",
-            description: "Approval and sandboxing preset for the session",
+            description: "Approval, sandboxing, and collaboration preset for the session",
             category: "mode",
             type: "select",
             currentValue: this.id,
@@ -88,7 +108,7 @@ export class AgentMode {
     }
 
     static all(): AgentMode[] {
-        return [AgentMode.ReadOnly, AgentMode.Agent, AgentMode.AgentFullAccess];
+        return [AgentMode.ReadOnly, AgentMode.Agent, AgentMode.AgentFullAccess, AgentMode.Plan];
     }
 
     static find(modeId: string): AgentMode | null {

--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -7,11 +7,14 @@ import type {
     CodexAppServerClient,
     ElicitationHandler,
     McpStartupResult,
+    UserInputHandler,
 } from "./CodexAppServerClient";
 import open from "open";
 import type {Disposable} from "vscode-jsonrpc";
 import type {
     ClientInfo,
+    CollaborationMode,
+    ModeKind,
     ReasoningEffort,
     ServiceTier,
     ServerNotification
@@ -36,6 +39,7 @@ import type {
     ThreadGoalStatus,
     ThreadSourceKind,
     TurnCompletedNotification,
+    TurnStartParams,
     UserInput,
 } from "./app-server/v2";
 import packageJson from "../package.json";
@@ -69,7 +73,10 @@ export class CodexAcpClient {
 
     async initialize(request: acp.InitializeRequest): Promise<void> {
         await this.codexClient.initialize({
-            capabilities: null,
+            capabilities: {
+                experimentalApi: true,
+                requestAttestation: false,
+            },
             clientInfo: {
                 name: request.clientInfo?.name ?? this.defaultClientInfo.name,
                 version: request.clientInfo?.version ?? this.defaultClientInfo.version,
@@ -241,6 +248,7 @@ export class CodexAcpClient {
             modelProvider: await this.getResumeModelProvider(),
             threadId: request.sessionId,
         });
+        await this.syncInitialCollaborationMode(response.thread.id, response.model, response.reasoningEffort);
         onSubscribed?.();
         const codexModels = await this.fetchAvailableModels();
         const currentModelId = this.createModelId(codexModels, response.model, response.reasoningEffort).toString();
@@ -264,6 +272,7 @@ export class CodexAcpClient {
             modelProvider: await this.getResumeModelProvider(),
             threadId: request.sessionId,
         });
+        await this.syncInitialCollaborationMode(response.thread.id, response.model, response.reasoningEffort);
         onSubscribed?.();
         const historyResponse = await this.codexClient.threadRead({
             threadId: response.thread.id,
@@ -291,6 +300,7 @@ export class CodexAcpClient {
             modelProvider: this.getModelProvider(),
             cwd: request.cwd,
         });
+        await this.syncInitialCollaborationMode(response.thread.id, response.model, response.reasoningEffort);
 
         const codexModels = await this.fetchAvailableModels();
         if (codexModels.length === 0) {
@@ -413,6 +423,21 @@ export class CodexAcpClient {
         };
     }
 
+    private async syncInitialCollaborationMode(
+        threadId: string,
+        model: string,
+        reasoningEffort: ReasoningEffort | null,
+    ): Promise<void> {
+        const initialMode = AgentMode.getInitialAgentMode();
+        if (initialMode.collaborationMode !== "plan") {
+            return;
+        }
+        await this.codexClient.threadSettingsUpdate({
+            threadId,
+            collaborationMode: createCollaborationMode(initialMode.collaborationMode, model, reasoningEffort),
+        });
+    }
+
     private async getConfigMcpServerNames(projectPath: string): Promise<Set<string>> {
         const response = await this.codexClient.configRead({ includeLayers: true, cwd: projectPath });
         const mcpServers = response?.config?.["mcp_servers"];
@@ -510,7 +535,8 @@ export class CodexAcpClient {
         sessionId: string,
         eventHandler: (result: ServerNotification) => void | Promise<void>,
         approvalHandler: ApprovalHandler,
-        elicitationHandler: ElicitationHandler
+        elicitationHandler: ElicitationHandler,
+        userInputHandler?: UserInputHandler,
     ) {
         this.codexClient.onServerNotification(sessionId, (event) => {
             this.enqueueSessionNotification(sessionId, () => eventHandler(event));
@@ -535,6 +561,14 @@ export class CodexAcpClient {
                 return await elicitationHandler.handleElicitation(params);
             },
         });
+        if (userInputHandler) {
+            this.codexClient.onUserInputRequest(sessionId, {
+                handleUserInput: async (params) => {
+                    await this.waitForSessionNotifications(sessionId);
+                    return await userInputHandler.handleUserInput(params);
+                },
+            });
+        }
     }
 
     async waitForSessionNotifications(sessionId: string): Promise<void> {
@@ -581,7 +615,7 @@ export class CodexAcpClient {
         if (shouldCancel?.()) {
             return null;
         }
-        return await this.codexClient.runTurn({
+        const turnParams: TurnStartParams & { collaborationMode: CollaborationMode } = {
             threadId: request.sessionId,
             input: input,
             approvalPolicy: agentMode.approvalPolicy,
@@ -590,7 +624,20 @@ export class CodexAcpClient {
             effort: effort,
             model: modelId.model,
             serviceTier: serviceTier,
-        }, onTurnStarted);
+            collaborationMode: createCollaborationMode(agentMode.collaborationMode, modelId.model, effort),
+        };
+        return await this.codexClient.runTurn(turnParams, onTurnStarted);
+    }
+
+    async setCollaborationMode(
+        threadId: string,
+        mode: ModeKind,
+        modelId: ModelId,
+    ): Promise<void> {
+        await this.codexClient.threadSettingsUpdate({
+            threadId,
+            collaborationMode: createCollaborationMode(mode, modelId.model, modelId.effort as ReasoningEffort | null),
+        });
     }
 
     resolveTurnInterrupted(params: { threadId: string, turnId: string }): void {
@@ -845,6 +892,21 @@ interface GatewayConfig {
         http_headers: Record<string, string>,
         wire_api: "responses"
     }
+}
+
+function createCollaborationMode(
+    mode: ModeKind,
+    model: string,
+    reasoningEffort: ReasoningEffort | null,
+): CollaborationMode {
+    return {
+        mode,
+        settings: {
+            model,
+            reasoning_effort: reasoningEffort,
+            developer_instructions: null,
+        },
+    };
 }
 
 function readMetaAdditionalRoots(meta?: Record<string, unknown> | null): string[] | undefined {

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -3,6 +3,7 @@ import {RequestError, type SessionId, type SessionModeState} from "@agentclientp
 import {CodexEventHandler} from "./CodexEventHandler";
 import {CodexApprovalHandler} from "./CodexApprovalHandler";
 import {CodexElicitationHandler} from "./CodexElicitationHandler";
+import {CodexUserInputHandler} from "./CodexUserInputHandler";
 import {type CodexAuthRequest, getCodexAuthMethods, isCodexAuthRequest} from "./CodexAuthMethod";
 import {CodexAcpClient, type SessionMetadata, type SessionMetadataWithThread} from "./CodexAcpClient";
 import type {McpStartupResult} from "./CodexAppServerClient";
@@ -656,7 +657,7 @@ export class CodexAcpServer {
         const sessionState = this.sessions.get(_params.sessionId);
         if (!sessionState) throw new Error(`Session ${_params.sessionId} not found`);
 
-        this.applyModeChange(sessionState, _params.modeId);
+        await this.applyModeChange(sessionState, _params.modeId);
         return {};
     }
 
@@ -673,7 +674,7 @@ export class CodexAcpServer {
                 this.applyFastModeChange(sessionState, params);
                 break;
             case MODE_CONFIG_ID:
-                this.applyModeChange(sessionState, this.stringConfigValue(params));
+                await this.applyModeChange(sessionState, this.stringConfigValue(params));
                 break;
             case MODEL_CONFIG_ID:
                 this.applyModelChange(sessionState, this.stringConfigValue(params));
@@ -709,10 +710,18 @@ export class CodexAcpServer {
         return params.value;
     }
 
-    private applyModeChange(sessionState: SessionState, value: string): void {
+    private async applyModeChange(sessionState: SessionState, value: string): Promise<void> {
         const newMode = AgentMode.find(value);
         if (!newMode) {
             throw RequestError.invalidParams();
+        }
+        const previousMode = sessionState.agentMode;
+        if (previousMode.collaborationMode !== newMode.collaborationMode) {
+            await this.codexAcpClient.setCollaborationMode(
+                sessionState.sessionId,
+                newMode.collaborationMode,
+                ModelId.fromString(sessionState.currentModelId),
+            );
         }
         sessionState.agentMode = newMode;
     }
@@ -1442,13 +1451,15 @@ export class CodexAcpServer {
             const eventHandler = new CodexEventHandler(this.connection, sessionState);
             const approvalHandler = new CodexApprovalHandler(this.connection, sessionState, activePrompt.signal);
             const elicitationHandler = new CodexElicitationHandler(this.connection, sessionState, activePrompt.signal);
+            const userInputHandler = new CodexUserInputHandler(this.connection, sessionState, activePrompt.signal);
             await this.codexAcpClient.subscribeToSessionEvents(params.sessionId,
                 (event) => {
                     elicitationHandler.handleNotification(event);
                     return eventHandler.handleNotification(event);
                 },
                 approvalHandler,
-                elicitationHandler);
+                elicitationHandler,
+                userInputHandler);
 
             if (activePrompt.signal.aborted) {
                 return this.cancelledPromptResponse(sessionState);

--- a/src/CodexAppServerClient.ts
+++ b/src/CodexAppServerClient.ts
@@ -1,5 +1,6 @@
 import {type MessageConnection, RequestType} from "vscode-jsonrpc/node";
 import type {
+    CollaborationMode,
     ClientRequest,
     InitializeParams,
     InitializeResponse,
@@ -63,6 +64,8 @@ import type {
     PermissionsRequestApprovalParams,
     PermissionsRequestApprovalResponse,
     ItemCompletedNotification,
+    ToolRequestUserInputParams,
+    ToolRequestUserInputResponse,
 } from "./app-server/v2";
 
 export interface ApprovalHandler {
@@ -75,6 +78,10 @@ export interface ElicitationHandler {
     handleElicitation(params: McpServerElicitationRequestParams): Promise<McpServerElicitationRequestResponse>;
 }
 
+export interface UserInputHandler {
+    handleUserInput(params: ToolRequestUserInputParams): Promise<ToolRequestUserInputResponse>;
+}
+
 export type McpStartupFailure = {
     server: string;
     error: string;
@@ -84,6 +91,11 @@ export type McpStartupResult = {
     ready: Array<string>;
     failed: Array<McpStartupFailure>;
     cancelled: Array<string>;
+};
+
+export type ThreadSettingsUpdateParams = {
+    threadId: string;
+    collaborationMode?: CollaborationMode | null;
 };
 
 const CommandExecutionApprovalRequest = new RequestType<
@@ -104,6 +116,12 @@ const PermissionsApprovalRequest = new RequestType<
     void
 >('item/permissions/requestApproval');
 
+const ToolRequestUserInputRequest = new RequestType<
+    ToolRequestUserInputParams,
+    ToolRequestUserInputResponse,
+    void
+>('item/tool/requestUserInput');
+
 const McpServerElicitationRequest = new RequestType<
     McpServerElicitationRequestParams,
     McpServerElicitationRequestResponse,
@@ -120,6 +138,7 @@ export class CodexAppServerClient {
     readonly connection: MessageConnection;
     private approvalHandlers = new Map<string, ApprovalHandler>();
     private elicitationHandlers = new Map<string, ElicitationHandler>();
+    private userInputHandlers = new Map<string, UserInputHandler>();
     private mcpServerStartupVersion = 0;
     private readonly mcpServerStartupStates = new Map<string, McpServerStartupSnapshot>();
     private readonly mcpServerStartupResolvers: Array<McpServerStartupResolver> = [];
@@ -207,6 +226,17 @@ export class CodexAppServerClient {
             return await handler.handlePermissionsRequest(params);
         });
 
+        this.connection.onRequest(ToolRequestUserInputRequest, async (params) => {
+            if (this.isStaleTurn(params.threadId, params.turnId)) {
+                return { answers: {} };
+            }
+            const handler = this.userInputHandlers.get(params.threadId);
+            if (!handler) {
+                throw new Error(`No request_user_input handler registered for thread ${params.threadId}`);
+            }
+            return await handler.handleUserInput(params);
+        });
+
         this.connection.onRequest(McpServerElicitationRequest, async (params) => {
             if (this.isStaleTurn(params.threadId, params.turnId)) {
                 return { action: "cancel", content: null, _meta: null };
@@ -227,10 +257,15 @@ export class CodexAppServerClient {
         this.elicitationHandlers.set(threadId, handler);
     }
 
+    onUserInputRequest(threadId: string, handler: UserInputHandler): void {
+        this.userInputHandlers.set(threadId, handler);
+    }
+
     clearThreadHandlers(threadId: string): void {
         this.notificationHandlers.delete(threadId);
         this.approvalHandlers.delete(threadId);
         this.elicitationHandlers.delete(threadId);
+        this.userInputHandlers.delete(threadId);
     }
 
     async initialize(params: InitializeParams): Promise<InitializeResponse> {
@@ -523,6 +558,13 @@ export class CodexAppServerClient {
 
     async threadGoalClear(params: ThreadGoalClearParams): Promise<ThreadGoalClearResponse> {
         return await this.sendRequest({ method: "thread/goal/clear", params: params });
+    }
+
+    async threadSettingsUpdate(params: ThreadSettingsUpdateParams): Promise<void> {
+        return await this.sendRequest({
+            method: "thread/settings/update",
+            params,
+        } as unknown as ClientRequest);
     }
 
     async listMcpServerStatus(params: ListMcpServerStatusParams): Promise<ListMcpServerStatusResponse> {

--- a/src/CodexUserInputHandler.ts
+++ b/src/CodexUserInputHandler.ts
@@ -1,0 +1,180 @@
+import * as acp from "@agentclientprotocol/sdk";
+import type {SessionState} from "./CodexAcpServer";
+import type {UserInputHandler} from "./CodexAppServerClient";
+import type {
+    ToolRequestUserInputOption,
+    ToolRequestUserInputParams,
+    ToolRequestUserInputQuestion,
+    ToolRequestUserInputResponse,
+} from "./app-server/v2";
+import type {AcpClientConnection} from "./ACPSessionConnection";
+import {logger} from "./Logger";
+
+type UserInputOption = {
+    option: acp.PermissionOption;
+    answer: string;
+};
+
+export class CodexUserInputHandler implements UserInputHandler {
+    private readonly connection: AcpClientConnection;
+    private readonly sessionState: SessionState;
+    private readonly cancellationSignal: AbortSignal | undefined;
+
+    constructor(
+        connection: AcpClientConnection,
+        sessionState: SessionState,
+        cancellationSignal?: AbortSignal,
+    ) {
+        this.connection = connection;
+        this.sessionState = sessionState;
+        this.cancellationSignal = cancellationSignal;
+    }
+
+    async handleUserInput(params: ToolRequestUserInputParams): Promise<ToolRequestUserInputResponse> {
+        const question = this.singleOptionQuestion(params);
+        const options = this.buildOptions(question);
+        const response = await this.connection.request(
+            acp.methods.client.session.requestPermission,
+            this.buildPermissionRequest(params, question, options),
+            this.requestOptions(),
+        );
+        return this.convertResponse(question, options, response);
+    }
+
+    private requestOptions(): acp.SendRequestOptions | undefined {
+        return this.cancellationSignal ? {cancellationSignal: this.cancellationSignal} : undefined;
+    }
+
+    private singleOptionQuestion(params: ToolRequestUserInputParams): ToolRequestUserInputQuestion {
+        if (params.questions.length !== 1) {
+            throw new Error(`Unsupported request_user_input shape: expected exactly one question, got ${params.questions.length}`);
+        }
+        const question = params.questions[0];
+        if (!question) {
+            throw new Error("Unsupported request_user_input shape: expected a question");
+        }
+        if (question.options === null || question.options.length === 0) {
+            throw new Error(`Unsupported request_user_input shape for question ${question.id}: options are required`);
+        }
+        if (question.isSecret) {
+            throw new Error(`Unsupported request_user_input shape for question ${question.id}: secret answers are not supported`);
+        }
+        return question;
+    }
+
+    private buildPermissionRequest(
+        params: ToolRequestUserInputParams,
+        question: ToolRequestUserInputQuestion,
+        options: UserInputOption[],
+    ): acp.RequestPermissionRequest {
+        return {
+            sessionId: this.sessionState.sessionId,
+            toolCall: {
+                toolCallId: params.itemId,
+                kind: "other",
+                status: "pending",
+                title: this.title(question),
+                rawInput: params,
+                content: [{ type: "content", content: { type: "text", text: this.content(question) } }],
+            },
+            options: options.map(({option}) => option),
+            _meta: {
+                codex: {
+                    request_user_input: {
+                        threadId: params.threadId,
+                        turnId: params.turnId,
+                        itemId: params.itemId,
+                        autoResolutionMs: params.autoResolutionMs,
+                    },
+                },
+            },
+        };
+    }
+
+    private convertResponse(
+        question: ToolRequestUserInputQuestion,
+        options: UserInputOption[],
+        response: acp.RequestPermissionResponse,
+    ): ToolRequestUserInputResponse {
+        if (response.outcome.outcome === "cancelled") {
+            return { answers: {} };
+        }
+        const optionId = "optionId" in response.outcome ? response.outcome.optionId : null;
+        const selected = options.find(({option}) => option.optionId === optionId);
+        if (!selected) {
+            logger.error("Unknown request_user_input option selected", {
+                optionId,
+                questionId: question.id,
+            });
+            return { answers: {} };
+        }
+        return {
+            answers: {
+                [question.id]: {
+                    answers: [selected.answer],
+                },
+            },
+        };
+    }
+
+    private buildOptions(question: ToolRequestUserInputQuestion): UserInputOption[] {
+        return question.options!.map((questionOption, index) => {
+            const optionId = `${question.id}:${index}`;
+            return {
+                option: {
+                    optionId,
+                    name: questionOption.label,
+                    kind: this.optionKind(questionOption),
+                    _meta: {
+                        codex: {
+                            questionId: question.id,
+                            optionIndex: index,
+                            label: questionOption.label,
+                            description: questionOption.description,
+                        },
+                    },
+                },
+                answer: questionOption.label,
+            };
+        });
+    }
+
+    private title(question: ToolRequestUserInputQuestion): string {
+        const header = question.header.trim();
+        return header.length > 0 ? header : "Request input";
+    }
+
+    private content(question: ToolRequestUserInputQuestion): string {
+        const lines = [question.question];
+        for (const option of question.options ?? []) {
+            const description = option.description.trim();
+            lines.push(description.length > 0 ? `${option.label}: ${description}` : option.label);
+        }
+        return lines.join("\n");
+    }
+
+    private optionKind(option: ToolRequestUserInputOption): acp.PermissionOptionKind {
+        const label = option.label.toLowerCase();
+        if (
+            label.includes("remember") ||
+            label.includes("always") ||
+            label.includes("don't ask") ||
+            label.includes("dont ask") ||
+            label.includes("for this session")
+        ) {
+            return "allow_always";
+        }
+        if (
+            label.includes("cancel") ||
+            label.includes("reject") ||
+            label.includes("deny") ||
+            label.includes("decline") ||
+            label === "no" ||
+            label.startsWith("no,") ||
+            label.startsWith("no ")
+        ) {
+            return "reject_once";
+        }
+        return "allow_once";
+    }
+}

--- a/src/__tests__/CodexACPAgent/approval-events.test.ts
+++ b/src/__tests__/CodexACPAgent/approval-events.test.ts
@@ -3,6 +3,7 @@ import type {
     CommandExecutionRequestApprovalParams,
     FileChangeRequestApprovalParams,
     PermissionsRequestApprovalParams,
+    ToolRequestUserInputParams,
 } from '../../app-server/v2';
 import { createCodexMockTestFixture, createTestSessionState, type CodexMockTestFixture } from '../acp-test-utils';
 import type { SessionState } from '../../CodexAcpServer';
@@ -51,6 +52,135 @@ describe('Approval Events', () => {
             })
         };
     }
+
+    describe('request_user_input approval bridge', () => {
+        it('maps a selected ACP permission option back to a Codex user input answer', async () => {
+            const { promptPromise, completeTurn } = setupSessionWithPendingPrompt();
+            fixture.setPermissionResponse({
+                outcome: { outcome: 'selected', optionId: 'approval:1' }
+            });
+
+            const params: ToolRequestUserInputParams = {
+                threadId: sessionId,
+                turnId: 'turn-1',
+                itemId: 'request-user-input-1',
+                autoResolutionMs: 60000,
+                questions: [{
+                    id: 'approval',
+                    header: 'Approve app tool call?',
+                    question: 'Allow this action?',
+                    isOther: false,
+                    isSecret: false,
+                    options: [
+                        { label: 'Allow', description: 'Run the tool and continue.' },
+                        { label: 'Cancel', description: 'Cancel this tool call.' },
+                    ],
+                }],
+            };
+
+            const response = await fixture.sendServerRequest(
+                'item/tool/requestUserInput',
+                params
+            );
+
+            expect(response).toEqual({
+                answers: {
+                    approval: {
+                        answers: ['Cancel'],
+                    },
+                },
+            });
+
+            const requestEvent = fixture.getAcpConnectionEvents([])[0];
+            expect(requestEvent).toBeDefined();
+            const request = requestEvent!.args[0];
+            expect(request.toolCall).toMatchObject({
+                toolCallId: 'request-user-input-1',
+                kind: 'other',
+                status: 'pending',
+                title: 'Approve app tool call?',
+            });
+            expect(request.options).toEqual([
+                expect.objectContaining({ optionId: 'approval:0', name: 'Allow', kind: 'allow_once' }),
+                expect.objectContaining({ optionId: 'approval:1', name: 'Cancel', kind: 'reject_once' }),
+            ]);
+
+            completeTurn();
+            await promptPromise;
+        });
+
+        it('accepts native Codex option questions that include an Other affordance', async () => {
+            const { promptPromise, completeTurn } = setupSessionWithPendingPrompt();
+            fixture.setPermissionResponse({
+                outcome: { outcome: 'selected', optionId: 'approval:0' }
+            });
+
+            const params: ToolRequestUserInputParams = {
+                threadId: sessionId,
+                turnId: 'turn-1',
+                itemId: 'request-user-input-1',
+                autoResolutionMs: null,
+                questions: [{
+                    id: 'approval',
+                    header: 'Confirm',
+                    question: 'Proceed with the plan?',
+                    isOther: true,
+                    isSecret: false,
+                    options: [
+                        { label: 'Yes (Recommended)', description: 'Continue the current plan.' },
+                        { label: 'No', description: 'Stop and revisit the approach.' },
+                    ],
+                }],
+            };
+
+            const response = await fixture.sendServerRequest(
+                'item/tool/requestUserInput',
+                params
+            );
+
+            expect(response).toEqual({
+                answers: {
+                    approval: {
+                        answers: ['Yes (Recommended)'],
+                    },
+                },
+            });
+            expect(fixture.getAcpConnectionEvents([])[0]?.args[0].options).toEqual([
+                expect.objectContaining({ optionId: 'approval:0', name: 'Yes (Recommended)', kind: 'allow_once' }),
+                expect.objectContaining({ optionId: 'approval:1', name: 'No', kind: 'reject_once' }),
+            ]);
+
+            completeTurn();
+            await promptPromise;
+        });
+
+        it('fails closed for request_user_input questions without selectable options', async () => {
+            const { promptPromise, completeTurn } = setupSessionWithPendingPrompt();
+            const params: ToolRequestUserInputParams = {
+                threadId: sessionId,
+                turnId: 'turn-1',
+                itemId: 'request-user-input-no-options',
+                autoResolutionMs: null,
+                questions: [{
+                    id: 'approval',
+                    header: 'Need input',
+                    question: 'Type a value',
+                    isOther: false,
+                    isSecret: false,
+                    options: null,
+                }],
+            };
+
+            await expect(fixture.sendServerRequest(
+                'item/tool/requestUserInput',
+                params
+            )).rejects.toThrow('options are required');
+            expect(fixture.getAcpConnectionEvents([])).toEqual([]);
+
+            completeTurn();
+            await promptPromise;
+        });
+    });
 
     describe('Command execution approval', () => {
         const commandApprovalCases = [

--- a/src/__tests__/CodexACPAgent/data/send-attachments-turn-start.json
+++ b/src/__tests__/CodexACPAgent/data/send-attachments-turn-start.json
@@ -57,7 +57,15 @@
     "summary": "auto",
     "effort": "effort",
     "model": "model",
-    "serviceTier": null
+    "serviceTier": null,
+    "collaborationMode": {
+      "mode": "default",
+      "settings": {
+        "model": "model",
+        "reasoning_effort": "effort",
+        "developer_instructions": null
+      }
+    }
   }
 }
 {

--- a/src/__tests__/CodexACPAgent/plan-mode.test.ts
+++ b/src/__tests__/CodexACPAgent/plan-mode.test.ts
@@ -1,0 +1,28 @@
+import {describe, expect, it} from "vitest";
+import {AgentMode} from "../../AgentMode";
+import {setupPromptTestSession} from "../acp-test-utils";
+
+describe("Plan mode", () => {
+    it("passes Codex plan collaboration mode on turn/start", async () => {
+        const {mockFixture, turnStartSpy} = setupPromptTestSession({
+            agentMode: AgentMode.Plan,
+            currentModelId: "model-id[medium]",
+        });
+
+        await mockFixture.getCodexAcpAgent().prompt({
+            sessionId: "session-id",
+            prompt: [{type: "text", text: "Plan this change"}],
+        });
+
+        expect(turnStartSpy).toHaveBeenCalledWith(expect.objectContaining({
+            collaborationMode: {
+                mode: "plan",
+                settings: {
+                    model: "model-id",
+                    reasoning_effort: "medium",
+                    developer_instructions: null,
+                },
+            },
+        }));
+    });
+});

--- a/src/__tests__/CodexACPAgent/session-config-options.test.ts
+++ b/src/__tests__/CodexACPAgent/session-config-options.test.ts
@@ -149,6 +149,38 @@ describe("Session config options", () => {
         expect((modeOption as any).currentValue).toBe(AgentMode.ReadOnly.id);
     });
 
+    it("switches Codex collaboration mode when entering and leaving plan mode", async () => {
+        const {fast} = buildModels();
+        const {codexAcpAgent, codexAcpClient} = await createSession("fast-model[medium]", [fast]);
+        const setCollaborationMode = vi
+            .spyOn(codexAcpClient, "setCollaborationMode")
+            .mockResolvedValue(undefined);
+
+        await codexAcpAgent.setSessionMode({
+            sessionId: "session-id",
+            modeId: AgentMode.Plan.id,
+        });
+
+        expect(setCollaborationMode).toHaveBeenLastCalledWith(
+            "session-id",
+            "plan",
+            expect.objectContaining({model: "fast-model", effort: "medium"}),
+        );
+        expect(codexAcpAgent.getSessionState("session-id").agentMode).toBe(AgentMode.Plan);
+
+        await codexAcpAgent.setSessionMode({
+            sessionId: "session-id",
+            modeId: AgentMode.Agent.id,
+        });
+
+        expect(setCollaborationMode).toHaveBeenLastCalledWith(
+            "session-id",
+            "default",
+            expect.objectContaining({model: "fast-model", effort: "medium"}),
+        );
+        expect(codexAcpAgent.getSessionState("session-id").agentMode).toBe(AgentMode.Agent);
+    });
+
     it("changes the model and keeps the current reasoning effort when supported", async () => {
         const {fast, slow} = buildModels();
         const {codexAcpAgent} = await createSession("fast-model[medium]", [fast, slow]);


### PR DESCRIPTION
## Summary

Adds ACP-native plan mode support for Codex ACP sessions.

- Advertises a fourth ACP mode, `plan`, alongside `read-only`, `agent`, and `agent-full-access`.
- Maps ACP plan mode to Codex app-server `collaborationMode: { mode: "plan" }`, including initial mode sync and later `session/set_mode` / mode config changes.
- Switches non-plan ACP modes back to Codex default/code collaboration mode while preserving their existing approval and sandbox presets.
- Bridges Codex app-server `item/tool/requestUserInput` server requests into ACP `session/request_permission` prompts and returns the selected option as `ToolRequestUserInputResponse`.

## Root Cause

The adapter previously treated ACP modes only as approval/sandbox presets, so ACP clients could not enter Codex core's real plan collaboration mode. After adding the bridge, real Codex exposed `request_user_input`, but native requests still failed to surface because Codex normalizes option-based questions with `isOther: true`; the adapter initially rejected that shape before sending ACP permission prompts.

This PR accepts option-based native questions even when `isOther` is true, while still failing closed for unsupported shapes such as missing options or secret answers.

## Verification

- `npm run typecheck`
- `npm run test`
- Real Codex app-server probe with `INITIAL_AGENT_MODE=plan` verified the outbound model request includes `request_user_input` in the `tools` array with Plan-mode availability text.
- Forced real app-server `request_user_input` function-call probe verified ACP emits `session/request_permission` and sends the selected option back to Codex as `function_call_output`.
- Rebuilt the Darwin arm64 sidecar and reran Melonite's real gpt-5.5 E2E. The trace now reaches a native prompt as a `permission_request` titled `QA` with yes/no options. The Melonite test still waits for `workflow_request`, so that remaining failure is on the Melonite-side expectation/routing rather than Codex ACP tool registration.
