### PR TITLE
Capitalize reasoning effort labels

### DIFF
--- a/src/ModelConfigOption.ts
+++ b/src/ModelConfigOption.ts
@@ -5,6 +5,10 @@ import type {Model, ReasoningEffortOption} from "./app-server/v2";
 export const MODEL_CONFIG_ID = "model";
 export const REASONING_EFFORT_CONFIG_ID = "reasoning_effort";
 
+function capitalize(value: string): string {
+    return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
 export function findSupportedEffort(
     options: ReadonlyArray<ReasoningEffortOption>,
     effort: string | undefined,
@@ -51,7 +55,7 @@ export function createReasoningEffortConfigOption(
         currentValue: currentEffort,
         options: supportedReasoningEfforts.map(option => ({
             value: option.reasoningEffort,
-            name: option.reasoningEffort,
+            name: capitalize(option.reasoningEffort),
             description: option.description,
         })),
     };

--- a/src/__tests__/CodexACPAgent/session-config-options.test.ts
+++ b/src/__tests__/CodexACPAgent/session-config-options.test.ts
@@ -74,9 +74,9 @@ describe("Session config options", () => {
             currentValue: "medium",
             type: "select",
             options: [
-                {value: "low", name: "low"},
-                {value: "medium", name: "medium"},
-                {value: "high", name: "high"},
+                {value: "low", name: "Low"},
+                {value: "medium", name: "Medium"},
+                {value: "high", name: "High"},
             ],
         });
 


### PR DESCRIPTION
## Summary
- Capitalize reasoning effort option labels in ACP session config
- Keep reasoning effort values lowercase for protocol/model behavior