### PR TITLE
Fix reasoning thought chunk formatting as plain text

### DIFF
--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -35,6 +35,7 @@ import type {QuotaMeta} from "./QuotaMeta";
 import {logger} from "./Logger";
 import {sanitizeMcpServerName} from "./McpServerName";
 import {createResponseItemHistoryFallbackUpdates} from "./ResponseItemHistoryFallback";
+import {normalizeReasoningSummary} from "./ReasoningText";
 import {
     type LegacyLoadSessionResponse,
     type LegacyNewSessionResponse,
@@ -1043,10 +1044,15 @@ export class CodexAcpServer {
         return updates;
     }
 
+    // Keep restored reasoning consistent with live output.
     private createReasoningUpdates(item: ThreadItem & { type: "reasoning" }): UpdateSessionEvent[] {
         const parts = item.summary.length > 0 ? item.summary : item.content;
         const messageId = item.id;
-        return parts.map((text) => createAgentTextThoughtChunk(text, messageId));
+        const text = parts
+            .map(normalizeReasoningSummary)
+            .filter(text => text.length > 0)
+            .join("\n");
+        return text.length > 0 ? [createAgentTextThoughtChunk(text, messageId)] : [];
     }
 
     private createWebSearchUpdate(

--- a/src/CodexEventHandler.ts
+++ b/src/CodexEventHandler.ts
@@ -60,6 +60,7 @@ import {
     createAgentTextMessageChunk,
     createAgentTextThoughtChunk,
 } from "./ContentChunks";
+import {normalizeReasoningSummary} from "./ReasoningText";
 
 export { stripShellPrefix };
 
@@ -72,7 +73,9 @@ export class CodexEventHandler {
     private readonly activeGuardianApprovalReviews = new Set<string>();
     private readonly activeImageGenerationItems = new Set<string>();
     private readonly emittedImageViewItems = new Set<string>();
-    private readonly seenReasoningDeltaItemIds = new Set<string>();
+    private readonly pendingReasoningSummaryParts = new Map<string, string>();
+    private readonly emittedReasoningSummaryItemIds = new Set<string>();
+    private readonly seenReasoningTextDeltaItemIds = new Set<string>();
     private readonly terminalCommandIds = new Set<string>();
     private readonly terminalCommandOutputIds = new Set<string>();
     private readonly agentMessagePhases = new Map<string, string | null>();
@@ -162,11 +165,11 @@ export class CodexEventHandler {
             case "thread/compacted":
                 return this.createContextCompactedEvent();
             case "item/reasoning/summaryTextDelta":
-                return this.createReasoningDeltaEvent(notification.params);
+                return this.createReasoningSummaryDeltaEvent(notification.params);
             case "item/reasoning/textDelta":
-                return this.createReasoningDeltaEvent(notification.params);
+                return this.createReasoningTextDeltaEvent(notification.params);
             case "item/reasoning/summaryPartAdded":
-                return this.createReasoningSectionBreakEvent(notification.params);
+                return this.createReasoningSummaryPartEvent(notification.params);
             case "model/rerouted":
                 return this.createModelReroutedEvent(notification.params);
             case "fuzzyFileSearch/sessionUpdated":
@@ -291,20 +294,49 @@ export class CodexEventHandler {
             && left.tokenBudget === right.tokenBudget;
     }
 
-    private createReasoningDeltaEvent(
-        event: ReasoningSummaryTextDeltaNotification | ReasoningTextDeltaNotification
-    ): UpdateSessionEvent {
-        this.seenReasoningDeltaItemIds.add(event.itemId);
+    // Buffer complete parts because formatting can span deltas.
+    private createReasoningSummaryDeltaEvent(event: ReasoningSummaryTextDeltaNotification): null {
+        const pendingText = this.pendingReasoningSummaryParts.get(event.itemId) ?? "";
+        this.pendingReasoningSummaryParts.set(event.itemId, pendingText + event.delta);
+        return null;
+    }
+
+    private createReasoningTextDeltaEvent(event: ReasoningTextDeltaNotification): UpdateSessionEvent {
+        this.seenReasoningTextDeltaItemIds.add(event.itemId);
         return this.createAgentThoughtEvent(event.delta, event.itemId);
     }
 
-    private createReasoningSectionBreakEvent(event: ReasoningSummaryPartAddedNotification): UpdateSessionEvent {
-        this.seenReasoningDeltaItemIds.add(event.itemId);
-        return this.createAgentThoughtEvent("\n\n", event.itemId);
+    private createReasoningSummaryPartEvent(
+        event: ReasoningSummaryPartAddedNotification
+    ): UpdateSessionEvent | null {
+        const previousPart = this.takeReasoningSummaryPart(event.itemId);
+        this.pendingReasoningSummaryParts.set(event.itemId, "");
+        return this.createNormalizedReasoningSummaryEvent(previousPart, event.itemId);
     }
 
     private createAgentThoughtEvent(text: string, messageId: string): UpdateSessionEvent {
         return createAgentTextThoughtChunk(text, messageId);
+    }
+
+    private takeReasoningSummaryPart(itemId: string): string | null {
+        const text = this.pendingReasoningSummaryParts.get(itemId);
+        if (text === undefined) {
+            return null;
+        }
+        this.pendingReasoningSummaryParts.delete(itemId);
+        return normalizeReasoningSummary(text);
+    }
+
+    private createNormalizedReasoningSummaryEvent(
+        text: string | null,
+        messageId: string
+    ): UpdateSessionEvent | null {
+        if (!text) {
+            return null;
+        }
+        const prefix = this.emittedReasoningSummaryItemIds.has(messageId) ? "\n" : "";
+        this.emittedReasoningSummaryItemIds.add(messageId);
+        return this.createAgentThoughtEvent(prefix + text, messageId);
     }
 
     private async createItemEvent(event: ItemStartedNotification): Promise<UpdateSessionEvent | null> {
@@ -379,11 +411,20 @@ export class CodexEventHandler {
                     return createImageGenerationCompleteUpdate(event.item);
                 }
                 return createImageGenerationUpdate(event.item, { terminalStatus: true });
-            case "reasoning":
-                if (this.seenReasoningDeltaItemIds.delete(event.item.id)) {
+            case "reasoning": {
+                const pendingSummary = this.takeReasoningSummaryPart(event.item.id);
+                const streamedRawText = this.seenReasoningTextDeltaItemIds.delete(event.item.id);
+                if (pendingSummary !== null) {
+                    const update = this.createNormalizedReasoningSummaryEvent(pendingSummary, event.item.id);
+                    this.emittedReasoningSummaryItemIds.delete(event.item.id);
+                    return update;
+                }
+                this.emittedReasoningSummaryItemIds.delete(event.item.id);
+                if (streamedRawText) {
                     return null;
                 }
                 return this.createCompletedReasoningEvent(event.item);
+            }
             case "webSearch":
                 return createWebSearchCompleteUpdate(event.item);
             case "collabAgentToolCall":
@@ -411,9 +452,13 @@ export class CodexEventHandler {
         this.agentMessagePhases.set(item.id, item.phase);
     }
 
+    // Keep completed reasoning consistent with streamed output.
     private createCompletedReasoningEvent(item: ThreadItem & { type: "reasoning" }): UpdateSessionEvent | null {
         const parts = item.summary.length > 0 ? item.summary : item.content;
-        const text = parts.filter(part => part.length > 0).join("\n\n");
+        const text = parts
+            .map(normalizeReasoningSummary)
+            .filter(part => part.length > 0)
+            .join("\n");
         if (text.length === 0) {
             return null;
         }

--- a/src/ReasoningText.ts
+++ b/src/ReasoningText.ts
@@ -1,0 +1,10 @@
+// Strip Codex summary formatting before emitting ACP text.
+export function normalizeReasoningSummary(text: string): string {
+    return text
+        .replace(/\r\n/g, "\n")
+        .replace(/<!--\s*-->/g, "")
+        .replace(/\*\*([^*\n]+)\*\*/g, "$1")
+        .replace(/[ \t]+\n/g, "\n")
+        .replace(/\n{2,}/g, "\n")
+        .trim();
+}

--- a/src/ResponseItemHistoryFallback.ts
+++ b/src/ResponseItemHistoryFallback.ts
@@ -7,6 +7,7 @@ import type { CommandAction, Thread, ThreadItem } from "./app-server/v2";
 import { createCommandActionEvent } from "./CodexToolCallMapper";
 import { createTerminalOutputMeta, type TerminalOutputMode } from "./TerminalOutputMode";
 import { createAgentMessageChunk, createCodexMessagePhaseMeta } from "./ContentChunks";
+import { normalizeReasoningSummary } from "./ReasoningText";
 
 type JsonRecord = Record<string, unknown>;
 type AcpToolCallEvent = Extract<UpdateSessionEvent, { sessionUpdate: "tool_call" }>;
@@ -278,13 +279,18 @@ function createUserMessageEventUpdates(payload: JsonRecord): UpdateSessionEvent[
 
 function createAgentReasoningEventUpdates(payload: JsonRecord): UpdateSessionEvent[] {
     const text = stringValue(payload["text"]);
-    if (text === null || text.length === 0) {
+    if (text === null) {
+        return [];
+    }
+
+    const normalizedText = normalizeReasoningSummary(text);
+    if (normalizedText.length === 0) {
         return [];
     }
 
     return [{
         sessionUpdate: "agent_thought_chunk",
-        content: { type: "text", text },
+        content: { type: "text", text: normalizedText },
     }];
 }
 
@@ -329,16 +335,24 @@ function contentBlocksFromResponseContent(content: unknown): ContentBlock[] {
     });
 }
 
+// Keep legacy reasoning history consistent with live output.
 function createReasoningUpdates(item: JsonRecord): UpdateSessionEvent[] {
     const parts = textParts(item["summary"]);
     if (parts.length === 0) {
         parts.push(...textParts(item["content"]));
     }
 
-    return parts.map((text) => ({
-        sessionUpdate: "agent_thought_chunk",
-        content: { type: "text", text },
-    }));
+    const text = parts
+        .map(normalizeReasoningSummary)
+        .filter(text => text.length > 0)
+        .join("\n");
+
+    return text.length > 0
+        ? [{
+            sessionUpdate: "agent_thought_chunk",
+            content: { type: "text", text },
+        }]
+        : [];
 }
 
 function textParts(value: unknown): string[] {

--- a/src/__tests__/CodexACPAgent/data/reasoning-completed-parts.json
+++ b/src/__tests__/CodexACPAgent/data/reasoning-completed-parts.json
@@ -8,7 +8,7 @@
         "messageId": "reasoning-2",
         "content": {
           "type": "text",
-          "text": "First summary\n\nSecond summary"
+          "text": "First summary\nSecond summary"
         }
       }
     }

--- a/src/__tests__/CodexACPAgent/data/reasoning-deltas-and-section-break.json
+++ b/src/__tests__/CodexACPAgent/data/reasoning-deltas-and-section-break.json
@@ -24,7 +24,7 @@
         "messageId": "reasoning-1",
         "content": {
           "type": "text",
-          "text": "\n\n"
+          "text": "\nSecond thought"
         }
       }
     }
@@ -37,7 +37,7 @@
       "sessionId": "test-session-id",
       "update": {
         "sessionUpdate": "agent_thought_chunk",
-        "messageId": "reasoning-1",
+        "messageId": "reasoning-raw",
         "content": {
           "type": "text",
           "text": "Raw reasoning detail"

--- a/src/__tests__/CodexACPAgent/reasoning-events.test.ts
+++ b/src/__tests__/CodexACPAgent/reasoning-events.test.ts
@@ -24,8 +24,18 @@ describe("CodexEventHandler - reasoning events", () => {
         agentMode: AgentMode.DEFAULT_AGENT_MODE
     });
 
-    it("streams reasoning deltas and section breaks without duplicating the completed item", async () => {
+    // Reproduce Codex part ordering and split summary markup.
+    it("normalizes streamed summaries and preserves raw reasoning without duplicates", async () => {
         const notifications: ServerNotification[] = [
+            {
+                method: "item/reasoning/summaryPartAdded",
+                params: {
+                    threadId: sessionId,
+                    turnId: "turn-1",
+                    itemId: "reasoning-1",
+                    summaryIndex: 0,
+                },
+            },
             {
                 method: "item/reasoning/summaryTextDelta",
                 params: {
@@ -33,7 +43,17 @@ describe("CodexEventHandler - reasoning events", () => {
                     turnId: "turn-1",
                     itemId: "reasoning-1",
                     summaryIndex: 0,
-                    delta: "First thought",
+                    delta: "**First thought**\n\n<!--",
+                },
+            },
+            {
+                method: "item/reasoning/summaryTextDelta",
+                params: {
+                    threadId: sessionId,
+                    turnId: "turn-1",
+                    itemId: "reasoning-1",
+                    summaryIndex: 0,
+                    delta: " -->",
                 },
             },
             {
@@ -46,11 +66,35 @@ describe("CodexEventHandler - reasoning events", () => {
                 },
             },
             {
-                method: "item/reasoning/textDelta",
+                method: "item/reasoning/summaryTextDelta",
                 params: {
                     threadId: sessionId,
                     turnId: "turn-1",
                     itemId: "reasoning-1",
+                    summaryIndex: 1,
+                    delta: "**Second thought**\n\n<!-- -->",
+                },
+            },
+            {
+                method: "item/completed",
+                params: {
+                    threadId: sessionId,
+                    turnId: "turn-1",
+                    completedAtMs: 0,
+                    item: {
+                        type: "reasoning",
+                        id: "reasoning-1",
+                        summary: ["**First thought**\n\n<!-- -->", "**Second thought**\n\n<!-- -->"],
+                        content: [],
+                    },
+                },
+            },
+            {
+                method: "item/reasoning/textDelta",
+                params: {
+                    threadId: sessionId,
+                    turnId: "turn-1",
+                    itemId: "reasoning-raw",
                     contentIndex: 0,
                     delta: "Raw reasoning detail",
                 },
@@ -63,9 +107,42 @@ describe("CodexEventHandler - reasoning events", () => {
                     completedAtMs: 0,
                     item: {
                         type: "reasoning",
-                        id: "reasoning-1",
-                        summary: ["Completed summary should not duplicate"],
-                        content: ["Completed content should not duplicate"],
+                        id: "reasoning-raw",
+                        summary: [],
+                        content: ["Raw reasoning detail"],
+                    },
+                },
+            },
+            {
+                method: "item/reasoning/summaryPartAdded",
+                params: {
+                    threadId: sessionId,
+                    turnId: "turn-1",
+                    itemId: "reasoning-empty",
+                    summaryIndex: 0,
+                },
+            },
+            {
+                method: "item/reasoning/summaryTextDelta",
+                params: {
+                    threadId: sessionId,
+                    turnId: "turn-1",
+                    itemId: "reasoning-empty",
+                    summaryIndex: 0,
+                    delta: "\n\n<!-- -->",
+                },
+            },
+            {
+                method: "item/completed",
+                params: {
+                    threadId: sessionId,
+                    turnId: "turn-1",
+                    completedAtMs: 0,
+                    item: {
+                        type: "reasoning",
+                        id: "reasoning-empty",
+                        summary: ["\n\n<!-- -->"],
+                        content: [],
                     },
                 },
             },


### PR DESCRIPTION
Codex reasoning summaries leaked Markdown markers and redundant blank lines into ACP thought chunks.
This fix buffers complete summary parts, normalizes them to plain text, and keeps live and restored reasoning output consistent.
<img width="537" height="143" alt="image" src="https://github.com/user-attachments/assets/e500dc5e-77dc-4ce0-9ae3-950aa75034fa" />
