### PR TITLE
Fix duplicate model & effort configuration in ACP session responses

### DIFF
--- a/src/AcpExtensions.ts
+++ b/src/AcpExtensions.ts
@@ -1,23 +1,9 @@
 import type {
     ClientContext,
-    LoadSessionResponse,
-    NewSessionResponse,
-    ResumeSessionResponse,
     SessionId,
 } from "@agentclientprotocol/sdk";
 
 export const LEGACY_SET_SESSION_MODEL_METHOD = "session/set_model";
-
-export type LegacySessionModel = {
-    modelId: string;
-    name: string;
-    description?: string | null;
-}
-
-export type LegacySessionModelState = {
-    availableModels: Array<LegacySessionModel>;
-    currentModelId: string;
-}
 
 export type LegacySetSessionModelRequest = {
     sessionId: SessionId;
@@ -25,18 +11,6 @@ export type LegacySetSessionModelRequest = {
 }
 
 export type LegacySetSessionModelResponse = {}
-
-export type LegacyNewSessionResponse = NewSessionResponse & {
-    models?: LegacySessionModelState | null;
-}
-
-export type LegacyLoadSessionResponse = LoadSessionResponse & {
-    models?: LegacySessionModelState | null;
-}
-
-export type LegacyResumeSessionResponse = ResumeSessionResponse & {
-    models?: LegacySessionModelState | null;
-}
 
 export type ExtMethodRequest =
     AuthenticationStatusRequest

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -36,10 +36,6 @@ import {logger} from "./Logger";
 import {sanitizeMcpServerName} from "./McpServerName";
 import {createResponseItemHistoryFallbackUpdates} from "./ResponseItemHistoryFallback";
 import {
-    type LegacyLoadSessionResponse,
-    type LegacyNewSessionResponse,
-    type LegacyResumeSessionResponse,
-    type LegacySessionModelState,
     type LegacySetSessionModelRequest,
     type LegacySetSessionModelResponse,
     isExtMethodRequest,
@@ -132,12 +128,6 @@ interface ActivePrompt {
 }
 
 export class CodexAcpServer {
-    private static readonly MODEL_NAME_TOKEN_OVERRIDES: Record<string, string> = {
-        gpt: "GPT",
-        mini: "Mini",
-        codex: "Codex",
-    };
-
     private readonly codexAcpClient: CodexAcpClient;
     private readonly connection: AcpClientConnection;
     private readonly defaultAuthRequest: CodexAuthRequest | null;
@@ -264,7 +254,7 @@ export class CodexAcpServer {
         }
     }
 
-    async getOrCreateSession(request: acp.NewSessionRequest | acp.ResumeSessionRequest): Promise<[SessionId, LegacySessionModelState, SessionModeState]> {
+    async getOrCreateSession(request: acp.NewSessionRequest | acp.ResumeSessionRequest): Promise<[SessionId, SessionModeState]> {
         try {
             return await this.tryCreateSession(request);
         } catch (e) {
@@ -345,7 +335,7 @@ export class CodexAcpServer {
         return generation;
     }
 
-    async tryCreateSession(request: acp.NewSessionRequest | acp.ResumeSessionRequest): Promise<[SessionId, LegacySessionModelState, SessionModeState]> {
+    async tryCreateSession(request: acp.NewSessionRequest | acp.ResumeSessionRequest): Promise<[SessionId, SessionModeState]> {
         const requestedSessionGeneration = "sessionId" in request
             ? this.beginSessionOpen(request.sessionId)
             : null;
@@ -429,10 +419,9 @@ export class CodexAcpServer {
         }
 
         this.publishAvailableCommandsAsync(sessionState);
-        const sessionModelState: LegacySessionModelState = this.createModelState(models, currentModelId);
         const sessionModeState: SessionModeState = sessionState.agentMode.toSessionModeState();
 
-        return [sessionId, sessionModelState, sessionModeState];
+        return [sessionId, sessionModeState];
     }
 
     private async getAuthStateForProvider(authProvider: string | null): Promise<ActiveAuthState> {
@@ -467,42 +456,43 @@ export class CodexAcpServer {
         return null;
     }
 
-    async loadSession(params: acp.LoadSessionRequest): Promise<LegacyLoadSessionResponse> {
+    // Model and reasoning controls are exposed through ACP config options.
+    async loadSession(params: acp.LoadSessionRequest): Promise<acp.LoadSessionResponse> {
         logger.log("Loading session...", {sessionId: params.sessionId});
         const {
             sessionId,
-            modelState,
             modeState,
             thread,
         } = await this.getOrCreateSessionWithHistory(params);
 
         await this.streamThreadHistory(sessionId, thread);
+        const sessionState = this.getSessionState(sessionId);
 
         logger.log("Session loaded", {
             sessionId: sessionId,
-            modelId: modelState.currentModelId,
-            availableModelCount: modelState.availableModels.length
+            modelId: sessionState.currentModelId,
+            availableModelCount: sessionState.availableModels.length
         });
         return {
-            models: modelState,
             modes: modeState,
-            ...this.createSessionConfigOptionsResponse(this.getSessionState(sessionId)),
+            ...this.createSessionConfigOptionsResponse(sessionState),
         };
     }
 
-    async resumeSession(params: acp.ResumeSessionRequest): Promise<LegacyResumeSessionResponse> {
+    // Model and reasoning controls are exposed through ACP config options.
+    async resumeSession(params: acp.ResumeSessionRequest): Promise<acp.ResumeSessionResponse> {
         logger.log("Resuming session...", {sessionId: params.sessionId});
-        const [sessionId, modelState, modeState] = await this.getOrCreateSession(params);
+        const [sessionId, modeState] = await this.getOrCreateSession(params);
+        const sessionState = this.getSessionState(sessionId);
 
         logger.log("Session resumed", {
             sessionId: sessionId,
-            modelId: modelState.currentModelId,
-            availableModelCount: modelState.availableModels.length
+            modelId: sessionState.currentModelId,
+            availableModelCount: sessionState.availableModels.length
         });
         return {
-            models: modelState,
             modes: modeState,
-            ...this.createSessionConfigOptionsResponse(this.getSessionState(sessionId)),
+            ...this.createSessionConfigOptionsResponse(sessionState),
         };
     }
 
@@ -594,23 +584,24 @@ export class CodexAcpServer {
         return this.sessionOpenGenerations.get(sessionId) === this.getSessionGeneration(sessionId);
     }
 
+    // Model and reasoning controls are exposed through ACP config options.
     async newSession(
         params: acp.NewSessionRequest,
-    ): Promise<LegacyNewSessionResponse> {
+    ): Promise<acp.NewSessionResponse> {
         logger.log("Starting new session...");
-        const [sessionId, modelState, modeState] = await this.getOrCreateSession(params);
+        const [sessionId, modeState] = await this.getOrCreateSession(params);
+        const sessionState = this.getSessionState(sessionId);
 
         logger.log("New session created", {
             sessionId: sessionId,
-            modelId: modelState.currentModelId,
-            availableModelCount: modelState.availableModels.length
+            modelId: sessionState.currentModelId,
+            availableModelCount: sessionState.availableModels.length
         });
 
         return {
             sessionId: sessionId,
-            models: modelState,
             modes: modeState,
-            ...this.createSessionConfigOptionsResponse(this.getSessionState(sessionId)),
+            ...this.createSessionConfigOptionsResponse(sessionState),
         };
     }
 
@@ -839,33 +830,10 @@ export class CodexAcpServer {
         return models.find(m => m.id === modelId.model);
     }
 
-    private normalizeModelDisplayName(displayName: string): string {
-        return displayName
-            .split("-")
-            .map((token) => CodexAcpServer.MODEL_NAME_TOKEN_OVERRIDES[token.toLowerCase()] ?? token)
-            .join("-");
-    }
-
-    private createModelState(availableModels: Model[], selectedModelId: string): LegacySessionModelState {
-        const allowedModels = availableModels
-            .flatMap((model) =>
-                model.supportedReasoningEfforts.map((effort) => ({
-                    modelId: ModelId.fromComponents(model, effort.reasoningEffort).toString(),
-                    name: `${this.normalizeModelDisplayName(model.displayName)} (${effort.reasoningEffort})`,
-                    description: `${model.description} ${effort.description}`,
-                }))
-            );
-        return {
-            availableModels: allowedModels,
-            currentModelId: selectedModelId,
-        }
-    }
-
     private async getOrCreateSessionWithHistory(
         request: acp.LoadSessionRequest
     ): Promise<{
         sessionId: SessionId;
-        modelState: LegacySessionModelState;
         modeState: SessionModeState;
         thread: Thread;
     }> {
@@ -944,12 +912,10 @@ export class CodexAcpServer {
         }
 
         await this.availableCommands.publish(sessionState);
-        const sessionModelState: LegacySessionModelState = this.createModelState(models, currentModelId);
         const sessionModeState: SessionModeState = sessionState.agentMode.toSessionModeState();
 
         return {
             sessionId: sessionId,
-            modelState: sessionModelState,
             modeState: sessionModeState,
             thread: thread,
         };

--- a/src/__tests__/CodexACPAgent/data/model-filtering.json
+++ b/src/__tests__/CodexACPAgent/data/model-filtering.json
@@ -1,37 +1,32 @@
 [
   {
-    "modelId": "gpt-5.2[medium]",
-    "name": "GPT-5.2 (medium)",
-    "description": "Allowed by id. Default effort."
+    "value": "gpt-5.2",
+    "name": "GPT-5.2",
+    "description": "Allowed by id."
   },
   {
-    "modelId": "gpt-5.2[low]",
-    "name": "GPT-5.2 (low)",
-    "description": "Allowed by id. Fast effort."
+    "value": "other-id",
+    "name": "gpt-5.2",
+    "description": "Allowed"
   },
   {
-    "modelId": "other-id[medium]",
-    "name": "GPT-5.2 (medium)",
-    "description": "Allowed Default effort."
+    "value": "gpt-5.1-codex-mini",
+    "name": "Other",
+    "description": "Allowed by id."
   },
   {
-    "modelId": "gpt-5.1-codex-mini[medium]",
-    "name": "Other (medium)",
-    "description": "Allowed by id. Default effort."
+    "value": "gpt-4o",
+    "name": "gpt-4o",
+    "description": "Allowed."
   },
   {
-    "modelId": "gpt-4o[medium]",
-    "name": "GPT-4o (medium)",
-    "description": "Allowed. Default effort."
+    "value": "gpt-5.3-codex",
+    "name": "gpt-5.3-codex",
+    "description": "Codex suffix lowercased."
   },
   {
-    "modelId": "gpt-5.3-codex[medium]",
-    "name": "GPT-5.3-Codex (medium)",
-    "description": "Codex suffix lowercased. Default effort."
-  },
-  {
-    "modelId": "gpt-5.4-mini[medium]",
-    "name": "GPT-5.4-Mini (medium)",
-    "description": "Mini suffix lowercased. Default effort."
+    "value": "gpt-5.4-mini",
+    "name": "gpt-5.4-mini",
+    "description": "Mini suffix lowercased."
   }
 ]

--- a/src/__tests__/CodexACPAgent/data/session-config-response-keys.json
+++ b/src/__tests__/CodexACPAgent/data/session-config-response-keys.json
@@ -1,0 +1,5 @@
+[
+  "configOptions",
+  "modes",
+  "sessionId"
+]

--- a/src/__tests__/CodexACPAgent/e2e/acp-e2e-models-availability.test.ts
+++ b/src/__tests__/CodexACPAgent/e2e/acp-e2e-models-availability.test.ts
@@ -1,6 +1,7 @@
 import {afterEach, beforeEach, expect, it} from "vitest";
 import {createAuthenticatedFixture, describeE2E, type SpawnedAgentFixture,} from "./acp-e2e-test-utils";
 import {ModelId} from "../../../ModelId";
+import {MODEL_CONFIG_ID} from "../../../ModelConfigOption";
 
 const DEFAULT_MODEL_ID = ModelId.create("gpt-5.4-mini", "medium")
 
@@ -17,7 +18,10 @@ describeE2E("Models availability", () => {
 
     it(`default model is available`, async () => {
         const session = await fixture.createSession();
-        const models = session.models?.availableModels?.map(m => m.modelId);
-        expect(models).toContain(DEFAULT_MODEL_ID.toString())
+        const modelConfig = session.configOptions?.find(option => option.id === MODEL_CONFIG_ID);
+        const models = modelConfig?.type === "select"
+            ? modelConfig.options.map(option => "value" in option ? option.value : null)
+            : [];
+        expect(models).toContain(DEFAULT_MODEL_ID.model)
     });
 });

--- a/src/__tests__/CodexACPAgent/e2e/acp-e2e-session-persistence.test.ts
+++ b/src/__tests__/CodexACPAgent/e2e/acp-e2e-session-persistence.test.ts
@@ -1,5 +1,5 @@
 import {afterEach, expect, it} from "vitest";
-import {legacySetSessionModel, type LegacyLoadSessionResponse} from "../../../AcpExtensions";
+import {MODEL_CONFIG_ID, REASONING_EFFORT_CONFIG_ID} from "../../../ModelConfigOption";
 import {
     createAuthenticatedFixture,
     describeE2E,
@@ -23,7 +23,16 @@ describeE2E("E2E session persistence tests", () => {
         beforeRestartFixture = await createAuthenticatedFixture();
         const sessionId = (await beforeRestartFixture.createSession()).sessionId;
 
-        await legacySetSessionModel(beforeRestartFixture.connection, {sessionId, modelId: OTHER_TEST_MODEL_ID.toString()});
+        await beforeRestartFixture.connection.setSessionConfigOption({
+            sessionId,
+            configId: MODEL_CONFIG_ID,
+            value: OTHER_TEST_MODEL_ID.model,
+        });
+        await beforeRestartFixture.connection.setSessionConfigOption({
+            sessionId,
+            configId: REASONING_EFFORT_CONFIG_ID,
+            value: OTHER_TEST_MODEL_ID.effort,
+        });
         const memorizedToken = "token-for-tests-123";
         await beforeRestartFixture.expectPromptText(
             sessionId,
@@ -37,8 +46,11 @@ describeE2E("E2E session persistence tests", () => {
             sessionId,
             cwd: afterRestartFixture.workspaceDir,
             mcpServers: [],
-        }) as LegacyLoadSessionResponse;
-        expect(loadSessionResponse.models?.currentModelId).toBe(OTHER_TEST_MODEL_ID.toString());
+        });
+        expect(loadSessionResponse.configOptions?.find(option => option.id === MODEL_CONFIG_ID))
+            .toMatchObject({currentValue: OTHER_TEST_MODEL_ID.model});
+        expect(loadSessionResponse.configOptions?.find(option => option.id === REASONING_EFFORT_CONFIG_ID))
+            .toMatchObject({currentValue: OTHER_TEST_MODEL_ID.effort});
 
         await afterRestartFixture.expectPromptText(
             sessionId,

--- a/src/__tests__/CodexACPAgent/e2e/acp-e2e.test.ts
+++ b/src/__tests__/CodexACPAgent/e2e/acp-e2e.test.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import {afterEach, expect, it} from "vitest";
 import {AgentMode} from "../../../AgentMode";
-import {legacySetSessionModel} from "../../../AcpExtensions";
+import {MODEL_CONFIG_ID, REASONING_EFFORT_CONFIG_ID} from "../../../ModelConfigOption";
 import {
     createAuthenticatedFixture,
     createGatewayFixture,
@@ -43,16 +43,22 @@ describeE2E("E2E tests", () => {
         fixture = await createAuthenticatedFixture();
         const session = await fixture.createSession();
 
-        const models = session.models;
-        if (!models) {
-            throw new Error("Agent did not return initial model state.");
+        const modelConfig = session.configOptions?.find(option => option.id === MODEL_CONFIG_ID);
+        if (modelConfig?.type !== "select") {
+            throw new Error("Agent did not return initial model configuration.");
         }
-        expect(models.availableModels.length).toBeGreaterThan(0);
-        expect(models.currentModelId).toBe(DEFAULT_TEST_MODEL_ID.toString());
+        expect(modelConfig.options.length).toBeGreaterThan(0);
+        expect(modelConfig.currentValue).toBe(DEFAULT_TEST_MODEL_ID.model);
 
-        await legacySetSessionModel(fixture.connection, {
+        await fixture.connection.setSessionConfigOption({
             sessionId: session.sessionId,
-            modelId: OTHER_TEST_MODEL_ID.toString(),
+            configId: MODEL_CONFIG_ID,
+            value: OTHER_TEST_MODEL_ID.model,
+        });
+        await fixture.connection.setSessionConfigOption({
+            sessionId: session.sessionId,
+            configId: REASONING_EFFORT_CONFIG_ID,
+            value: OTHER_TEST_MODEL_ID.effort,
         });
         await fixture.expectStatus(session.sessionId, {Model: OTHER_TEST_MODEL_ID});
     });

--- a/src/__tests__/CodexACPAgent/e2e/spawned-agent-fixture.ts
+++ b/src/__tests__/CodexACPAgent/e2e/spawned-agent-fixture.ts
@@ -7,7 +7,6 @@ import {expect, vi} from "vitest";
 import {ModelId} from "../../../ModelId";
 import {removeDirectoryWithRetry, writeCodexHomeConfig} from "../../acp-test-utils";
 import type {PermissionResponder} from "./permission-responders";
-import type {LegacyNewSessionResponse} from "../../../AcpExtensions";
 
 export const DEFAULT_TEST_MODEL_ID = ModelId.create("gpt-5.2", "none");
 export const OTHER_TEST_MODEL_ID = ModelId.create("gpt-5.4-mini", "low");
@@ -21,7 +20,7 @@ export interface TestSkill {
 export interface SpawnedAgentFixture {
     readonly connection: acp.ClientSideConnection;
     readonly workspaceDir: string;
-    createSession(mcpServers?: acp.McpServer[]): Promise<LegacyNewSessionResponse>;
+    createSession(mcpServers?: acp.McpServer[]): Promise<acp.NewSessionResponse>;
     restart(): Promise<SpawnedAgentFixture>;
     writeSkill(skill: TestSkill, rootDir?: string): void;
     setPermissionResponder(responder: PermissionResponder): void;
@@ -178,11 +177,11 @@ class SpawnedAgentFixtureImpl implements SpawnedAgentFixture {
         return this.paths.workspaceDir;
     }
 
-    async createSession(mcpServers: acp.McpServer[] = []): Promise<LegacyNewSessionResponse> {
+    async createSession(mcpServers: acp.McpServer[] = []): Promise<acp.NewSessionResponse> {
         return await this.connection.newSession({
             cwd: this.workspaceDir,
             mcpServers,
-        }) as LegacyNewSessionResponse;
+        });
     }
 
     async restart(): Promise<SpawnedAgentFixture> {

--- a/src/__tests__/CodexACPAgent/fast-mode-config.test.ts
+++ b/src/__tests__/CodexACPAgent/fast-mode-config.test.ts
@@ -105,6 +105,7 @@ describe("Fast mode session config", () => {
         expect(codexAcpAgent.getSessionState("session-id").fastModeEnabled).toBe(true);
     });
 
+    // Disabled config options do not fall back to nonstandard fields.
     it("omits Fast mode config options for JetBrains 2026.1 IntelliJ clients", async () => {
         const {response} = await createSession(null, {
             name: "JetBrains.WebStorm",
@@ -116,6 +117,7 @@ describe("Fast mode session config", () => {
         });
 
         expect(response.configOptions).toBeUndefined();
+        expect(response).not.toHaveProperty("models");
     });
 
     it("omits Fast mode config options for JetBrains 2026.1 clients by name", async () => {

--- a/src/__tests__/CodexACPAgent/model-filtering.test.ts
+++ b/src/__tests__/CodexACPAgent/model-filtering.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Model, ReasoningEffortOption } from "../../app-server/v2";
 import { createCodexMockTestFixture } from "../acp-test-utils";
+import {MODEL_CONFIG_ID} from "../../ModelConfigOption";
 
 describe("Model filtering", () => {
     it("filters available models by id allowlist", async () => {
@@ -133,10 +134,10 @@ describe("Model filtering", () => {
         vi.spyOn(codexAcpClient, "getAccount").mockResolvedValue({account: null, requiresOpenaiAuth: false});
 
         const newSessionResponse = await codexAcpAgent.newSession({ cwd: "", mcpServers: [] });
-        const sessionModels = newSessionResponse.models;
-        const availableModels = sessionModels?.availableModels;
+        const modelConfig = newSessionResponse.configOptions?.find(option => option.id === MODEL_CONFIG_ID);
+        const availableModels = modelConfig?.type === "select" ? modelConfig.options : undefined;
 
-        await expect(JSON.stringify(availableModels, null, 2)).toMatchFileSnapshot(
+        await expect(`${JSON.stringify(availableModels, null, 2)}\n`).toMatchFileSnapshot(
             "data/model-filtering.json"
         );
     });

--- a/src/__tests__/CodexACPAgent/session-close.test.ts
+++ b/src/__tests__/CodexACPAgent/session-close.test.ts
@@ -10,6 +10,7 @@ import type {CodexAcpClient, SessionMetadata} from "../../CodexAcpClient";
 import type {McpStartupResult} from "../../CodexAppServerClient";
 import type {TurnStartResponse} from "../../app-server/v2";
 import type {McpServer} from "@agentclientprotocol/sdk";
+import {MODEL_CONFIG_ID, REASONING_EFFORT_CONFIG_ID} from "../../ModelConfigOption";
 
 const sessionId = "session-id";
 
@@ -284,9 +285,16 @@ describe("ACP session close", () => {
             cwd: "/test/cwd",
             mcpServers: [],
         })).resolves.toEqual(expect.objectContaining({
-            models: expect.objectContaining({
-                currentModelId: "model-id[medium]",
-            }),
+            configOptions: expect.arrayContaining([
+                expect.objectContaining({
+                    id: MODEL_CONFIG_ID,
+                    currentValue: "model-id",
+                }),
+                expect.objectContaining({
+                    id: REASONING_EFFORT_CONFIG_ID,
+                    currentValue: "medium",
+                }),
+            ]),
         }));
     });
 

--- a/src/__tests__/CodexACPAgent/session-config-options.test.ts
+++ b/src/__tests__/CodexACPAgent/session-config-options.test.ts
@@ -120,18 +120,15 @@ describe("Session config options", () => {
         expect(codexAcpAgent.getSessionState("session-id").currentModelId).toBe("custom-model[high]");
     });
 
-    it("keeps the legacy models list as combined model/effort entries", async () => {
+    // Guards the response against legacy configuration fields.
+    it("returns only ACP-standard session configuration fields", async () => {
         const {fast, slow} = buildModels();
         const {response} = await createSession("fast-model[medium]", [fast, slow]);
 
-        expect(response.models?.availableModels.map(m => m.modelId)).toEqual([
-            "fast-model[low]",
-            "fast-model[medium]",
-            "fast-model[high]",
-            "slow-model[low]",
-            "slow-model[medium]",
-        ]);
-        expect(response.models?.currentModelId).toBe("fast-model[medium]");
+        expect(response).not.toHaveProperty("models");
+        await expect(`${JSON.stringify(Object.keys(response).sort(), null, 2)}\n`).toMatchFileSnapshot(
+            "data/session-config-response-keys.json"
+        );
     });
 
     it("changes the agent mode via setSessionConfigOption", async () => {


### PR DESCRIPTION
Session lifecycle responses exposed model and reasoning options twice: through the legacy models field and standard ACP configOptions. That ACP non-compliance lead to ACP Client render weird duplicate model and effort options.
<img width="432" height="281" alt="image" src="https://github.com/user-attachments/assets/408c75c4-2f7e-461d-bd01-97e7862555a7" />

This fixes removes the legacy field from new, load, and resume responses, making configOptions the single standards-compliant configuration surface. Tests and E2E fixtures were updated accordingly.