### PR TITLE
Forward unrecognized slash commands to Codex

### DIFF
--- a/src/CodexCommands.ts
+++ b/src/CodexCommands.ts
@@ -254,8 +254,8 @@ export class CodexCommands {
                 return { handled: true };
             }
             default:
-                await this.sendUnknownCommandMessage(commandName, sessionId);
-                return { handled: true };
+                // Let Codex resolve unrecognized commands as raw prompts.
+                return { handled: false };
         }
     }
 
@@ -355,19 +355,6 @@ export class CodexCommands {
     private async sendCommandUsageMessage(name: string, inputHint: string, sessionId: string): Promise<void> {
         const session = new ACPSessionConnection(this.connection, sessionId);
         await session.update(createAgentTextMessageChunk(`Command "/${name}" requires ${inputHint}.`));
-    }
-
-    private async sendUnknownCommandMessage(name: string, sessionId: string): Promise<void> {
-        const lines = this.getBuiltinCommands().map(command => `- /${command.name}: ${command.description}`);
-        const text = [
-            `Unknown command "/${name}".`,
-            "Available commands:"
-        ];
-        if (lines.length > 0) {
-            text.push(...lines);
-        }
-        const session = new ACPSessionConnection(this.connection, sessionId);
-        await session.update(createAgentTextMessageChunk(text.join("\n")));
     }
 
     private buildStatusMessage(sessionState: SessionState): string {


### PR DESCRIPTION
Pass slash commands not handled by the ACP adapter through as raw prompts, allowing Codex to resolve skills freely. Built-in commands continue to be handled locally.