### PR TITLE
Expose MIME type for viewed images

### DIFF
--- a/src/CodexToolCallMapper.ts
+++ b/src/CodexToolCallMapper.ts
@@ -2,6 +2,7 @@ import type { ContentBlock, ToolCallContent } from "@agentclientprotocol/sdk";
 import { applyPatch, parsePatch, reversePatch } from "diff";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import type { UpdateSessionEvent } from "./ACPSessionConnection";
 import { stripShellPrefix } from "./CommandUtils";
 import type {
@@ -158,6 +159,7 @@ export function createImageViewUpdate(
     item: ThreadItem & { type: "imageView" }
 ): UpdateSessionEvent {
     const displayPath = item.path;
+    const mimeType = imageMimeTypeFromPath(displayPath);
     return {
         sessionUpdate: "tool_call",
         toolCallId: item.id,
@@ -167,13 +169,45 @@ export function createImageViewUpdate(
         content: [createContent({
             type: "resource_link",
             name: displayPath,
-            uri: displayPath,
+            uri: pathToFileURL(displayPath).href,
+            ...(mimeType ? { mimeType } : {}),
         })],
         locations: [{ path: item.path }],
         rawInput: {
             path: item.path,
         },
     };
+}
+
+function imageMimeTypeFromPath(filePath: string): string | undefined {
+    switch (path.extname(filePath).toLowerCase()) {
+        case ".avif":
+            return "image/avif";
+        case ".bmp":
+            return "image/bmp";
+        case ".gif":
+            return "image/gif";
+        case ".heic":
+            return "image/heic";
+        case ".heif":
+            return "image/heif";
+        case ".ico":
+            return "image/vnd.microsoft.icon";
+        case ".jpeg":
+        case ".jpg":
+            return "image/jpeg";
+        case ".png":
+            return "image/png";
+        case ".svg":
+            return "image/svg+xml";
+        case ".tif":
+        case ".tiff":
+            return "image/tiff";
+        case ".webp":
+            return "image/webp";
+        default:
+            return undefined;
+    }
 }
 
 export function createImageGenerationStartUpdate(

--- a/src/__tests__/CodexACPAgent/data/load-session-history.json
+++ b/src/__tests__/CodexACPAgent/data/load-session-history.json
@@ -273,7 +273,8 @@
             "content": {
               "type": "resource_link",
               "name": "/test/project/input.png",
-              "uri": "/test/project/input.png"
+              "uri": "file:///test/project/input.png",
+              "mimeType": "image/png"
             }
           }
         ],

--- a/src/__tests__/CodexACPAgent/data/view-image-flow.json
+++ b/src/__tests__/CodexACPAgent/data/view-image-flow.json
@@ -7,25 +7,26 @@
         "sessionUpdate": "tool_call",
         "toolCallId": "view-image-1",
         "kind": "read",
-        "title": "View Image /tmp/codex/input.png",
+        "title": "View Image /tmp/codex/input image.PNG",
         "status": "completed",
         "content": [
           {
             "type": "content",
             "content": {
               "type": "resource_link",
-              "name": "/tmp/codex/input.png",
-              "uri": "/tmp/codex/input.png"
+              "name": "/tmp/codex/input image.PNG",
+              "uri": "file:///tmp/codex/input%20image.PNG",
+              "mimeType": "image/png"
             }
           }
         ],
         "locations": [
           {
-            "path": "/tmp/codex/input.png"
+            "path": "/tmp/codex/input image.PNG"
           }
         ],
         "rawInput": {
-          "path": "/tmp/codex/input.png"
+          "path": "/tmp/codex/input image.PNG"
         }
       }
     }

--- a/src/__tests__/CodexACPAgent/image-events.test.ts
+++ b/src/__tests__/CodexACPAgent/image-events.test.ts
@@ -89,7 +89,7 @@ describe("CodexEventHandler - image events", () => {
         const item = {
             type: "imageView" as const,
             id: "view-image-1",
-            path: "/tmp/codex/input.png",
+            path: "/tmp/codex/input image.PNG",
         };
         const notifications: ServerNotification[] = [
             {


### PR DESCRIPTION
## Summary
- add the image MIME type to imageView resource links so ACP clients can recognize and preview local images
- convert local paths to standards-compliant file URIs while retaining locations.path and rawInput.path
- keep image bytes local; no base64 payload is added
- cover URI escaping, case-insensitive extensions, live events, and history replay in snapshots

## Verification
- npm run typecheck
- npm test (297 passed, 28 skipped)
- npm run build