### PR TITLE
Surface context compaction lifecycle

### DIFF
--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -46,6 +46,7 @@ import {
 } from "./AcpExtensions";
 import {
     createCollabAgentToolCallUpdate,
+    createCompletedContextCompactionUpdate,
     createCommandExecutionCompleteUpdate,
     createCommandExecutionUpdate,
     createDynamicToolCallUpdate,
@@ -1039,7 +1040,7 @@ export class CodexAcpServer {
             case "exitedReviewMode":
                 return [this.createReviewModeUpdate(item, false)];
             case "contextCompaction":
-                return [this.createContextCompactionUpdate()];
+                return [createCompletedContextCompactionUpdate(item)];
             case "plan":
                 return [this.createPlanUpdate(item)];
         }
@@ -1088,16 +1089,6 @@ export class CodexAcpServer {
             content: {
                 type: "text",
                 text: `${entered ? "Entered" : "Exited"} review mode: ${item.review}`,
-            },
-        };
-    }
-
-    private createContextCompactionUpdate(): UpdateSessionEvent {
-        return {
-            sessionUpdate: "agent_message_chunk",
-            content: {
-                type: "text",
-                text: "Context compacted.",
             },
         };
     }

--- a/src/CodexEventHandler.ts
+++ b/src/CodexEventHandler.ts
@@ -36,6 +36,8 @@ import {
     createCollabAgentToolCallCompleteUpdate,
     createCollabAgentToolCallUpdate,
     createCommandExecutionUpdate,
+    createContextCompactionCompleteUpdate,
+    createContextCompactionStartUpdate,
     createDynamicToolCallUpdate,
     createFileChangeUpdate,
     createGuardianApprovalReviewToolCall,
@@ -337,6 +339,8 @@ export class CodexEventHandler {
             case "agentMessage":
                 this.rememberAgentMessagePhase(event.item);
                 return null;
+            case "contextCompaction":
+                return createContextCompactionStartUpdate(event.item);
             case "subAgentActivity":
             case "sleep":
             case "userMessage":
@@ -344,7 +348,6 @@ export class CodexEventHandler {
             case "reasoning":
             case "enteredReviewMode":
             case "exitedReviewMode":
-            case "contextCompaction":
             case "plan":
                 return null;
         }
@@ -394,7 +397,7 @@ export class CodexEventHandler {
             case "exitedReviewMode":
                 return this.createExitedReviewModeEvent(event.item);
             case "contextCompaction":
-                return this.createContextCompactedEvent();
+                return createContextCompactionCompleteUpdate(event.item);
             //ignored types
             case "subAgentActivity":
             case "sleep":

--- a/src/CodexToolCallMapper.ts
+++ b/src/CodexToolCallMapper.ts
@@ -41,7 +41,10 @@ type GuardianApprovalReviewNotification =
 type WebSearchItem = ThreadItem & { type: "webSearch" };
 type CollabAgentToolCallItem = ThreadItem & { type: "collabAgentToolCall" };
 type CommandExecutionItem = ThreadItem & { type: "commandExecution" };
+type ContextCompactionItem = ThreadItem & { type: "contextCompaction" };
 type AcpToolCallEvent = Extract<UpdateSessionEvent, { sessionUpdate: "tool_call" }>;
+
+const CONTEXT_COMPACTION_META = { contextCompaction: true };
 
 function toAcpStatus(status: CodexItemStatus): AcpToolCallStatus {
     switch (status) {
@@ -217,6 +220,44 @@ export function createImageGenerationUpdate(
             : imageGenerationToolStatus(item.status),
         content: imageGenerationContent(item),
         rawOutput: imageGenerationRawOutput(item),
+    };
+}
+
+export function createContextCompactionStartUpdate(
+    item: ContextCompactionItem,
+): UpdateSessionEvent {
+    return {
+        sessionUpdate: "tool_call",
+        toolCallId: item.id,
+        kind: "other",
+        title: "Context compacting",
+        status: "in_progress",
+        _meta: CONTEXT_COMPACTION_META,
+    };
+}
+
+export function createContextCompactionCompleteUpdate(
+    item: ContextCompactionItem,
+): UpdateSessionEvent {
+    return {
+        sessionUpdate: "tool_call_update",
+        toolCallId: item.id,
+        title: "Context compacted",
+        status: "completed",
+        _meta: CONTEXT_COMPACTION_META,
+    };
+}
+
+export function createCompletedContextCompactionUpdate(
+    item: ContextCompactionItem,
+): UpdateSessionEvent {
+    return {
+        sessionUpdate: "tool_call",
+        toolCallId: item.id,
+        kind: "other",
+        title: "Context compacted",
+        status: "completed",
+        _meta: CONTEXT_COMPACTION_META,
     };
 }
 

--- a/src/ResponseItemHistoryFallback.ts
+++ b/src/ResponseItemHistoryFallback.ts
@@ -175,6 +175,7 @@ function toolCallIdFromThreadItem(item: ThreadItem): string | null {
         case "webSearch":
         case "imageView":
         case "imageGeneration":
+        case "contextCompaction":
             return item.id;
         case "userMessage":
         case "hookPrompt":
@@ -184,7 +185,6 @@ function toolCallIdFromThreadItem(item: ThreadItem): string | null {
         case "subAgentActivity":
         case "enteredReviewMode":
         case "exitedReviewMode":
-        case "contextCompaction":
         case "sleep":
             return null;
     }

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -3243,7 +3243,7 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         await expect(mockFixture.getAcpConnectionDump([])).toMatchFileSnapshot("data/thread-compacted.json");
     });
 
-    it ('should surface contextCompaction item as user-visible message', async () => {
+    it ('should surface contextCompaction item lifecycle as a tool call', async () => {
         const sessionId = "test-session-id";
         const { mockFixture } = setupPromptFixture({ sessionId });
 
@@ -3255,6 +3255,15 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         mockFixture.clearAcpConnectionDump();
 
         mockFixture.sendServerNotification({
+            method: "item/started",
+            params: {
+                threadId: sessionId,
+                turnId: "turn-id",
+                startedAtMs: 0,
+                item: { type: "contextCompaction", id: "context-compaction-id" },
+            },
+        });
+        mockFixture.sendServerNotification({
             method: "item/completed",
             params: {
                 threadId: sessionId,
@@ -3265,11 +3274,11 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         });
 
         await vi.waitFor(() => {
-            const dump = mockFixture.getAcpConnectionDump([]);
-            expect(dump.length).toBeGreaterThan(0);
+            const events = mockFixture.getAcpConnectionEvents([]);
+            expect(events).toHaveLength(2);
         });
 
-        await expect(mockFixture.getAcpConnectionDump([])).toMatchFileSnapshot("data/thread-compacted.json");
+        await expect(mockFixture.getAcpConnectionDump([])).toMatchFileSnapshot("data/context-compaction-lifecycle.json");
     });
 
     it ('should surface exitedReviewMode item as user-visible review output', async () => {

--- a/src/__tests__/CodexACPAgent/data/context-compaction-lifecycle.json
+++ b/src/__tests__/CodexACPAgent/data/context-compaction-lifecycle.json
@@ -1,0 +1,35 @@
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "context-compaction-id",
+        "kind": "other",
+        "title": "Context compacting",
+        "status": "in_progress",
+        "_meta": {
+          "contextCompaction": true
+        }
+      }
+    }
+  ]
+}
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": "context-compaction-id",
+        "title": "Context compacted",
+        "status": "completed",
+        "_meta": {
+          "contextCompaction": true
+        }
+      }
+    }
+  ]
+}

--- a/src/__tests__/CodexACPAgent/data/load-session-history.json
+++ b/src/__tests__/CodexACPAgent/data/load-session-history.json
@@ -328,3 +328,21 @@
     }
   ]
 }
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "session-1",
+      "update": {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "item-context-compaction-1",
+        "kind": "other",
+        "title": "Context compacted",
+        "status": "completed",
+        "_meta": {
+          "contextCompaction": true
+        }
+      }
+    }
+  ]
+}

--- a/src/__tests__/CodexACPAgent/load-session.test.ts
+++ b/src/__tests__/CodexACPAgent/load-session.test.ts
@@ -161,6 +161,10 @@ describe("CodexACPAgent - loadSession", () => {
                             result: "iVBORw0KGgo=",
                             savedPath: "/test/project/generated-blue-square.png",
                         },
+                        {
+                            type: "contextCompaction",
+                            id: "item-context-compaction-1",
+                        },
                     ],
                 },
             ],


### PR DESCRIPTION
## Summary
- map context compaction start and completion items to an ACP tool-call lifecycle
- attach generic `contextCompaction` metadata so clients can provide specialized UI while older clients retain a standard `other` tool-call fallback
- replay completed context compactions consistently when loading session history

## Verification
- `npm run typecheck`
- `npm test` (297 passed, 28 skipped)
- `npm run build`
- real Codex `/compact` run confirmed matching `item/started` and `item/completed` events with the same item ID