### PR TITLE
Support Codex request_user_input elicitation

### DIFF
--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -616,6 +616,10 @@ export class CodexAcpClient {
                 await this.waitForSessionNotifications(sessionId);
                 return await elicitationHandler.handleElicitation(params);
             },
+            handleUserInput: async (params) => {
+                await this.waitForSessionNotifications(sessionId);
+                return await elicitationHandler.handleUserInput(params);
+            },
         });
     }
 

--- a/src/CodexAppServerClient.ts
+++ b/src/CodexAppServerClient.ts
@@ -51,6 +51,8 @@ import type {
     ThreadStartResponse,
     ThreadUnsubscribeParams,
     ThreadUnsubscribeResponse,
+    ToolRequestUserInputParams,
+    ToolRequestUserInputResponse,
     TurnCompletedNotification,
     TurnInterruptParams,
     TurnInterruptResponse,
@@ -73,6 +75,7 @@ export interface ApprovalHandler {
 
 export interface ElicitationHandler {
     handleElicitation(params: McpServerElicitationRequestParams): Promise<McpServerElicitationRequestResponse>;
+    handleUserInput(params: ToolRequestUserInputParams): Promise<ToolRequestUserInputResponse>;
 }
 
 export type McpStartupFailure = {
@@ -109,6 +112,12 @@ const McpServerElicitationRequest = new RequestType<
     McpServerElicitationRequestResponse,
     void
 >('mcpServer/elicitation/request');
+
+const ToolRequestUserInputRequest = new RequestType<
+    ToolRequestUserInputParams,
+    ToolRequestUserInputResponse,
+    void
+>('item/tool/requestUserInput');
 
 const GOAL_RUNTIME_EFFECTS_GRACE_MS = 1_000;
 
@@ -216,6 +225,17 @@ export class CodexAppServerClient {
                 return { action: "cancel", content: null, _meta: null };
             }
             return await handler.handleElicitation(params);
+        });
+
+        this.connection.onRequest(ToolRequestUserInputRequest, async (params) => {
+            if (this.isStaleTurn(params.threadId, params.turnId)) {
+                return { answers: {} };
+            }
+            const handler = this.elicitationHandlers.get(params.threadId);
+            if (!handler) {
+                return { answers: {} };
+            }
+            return await handler.handleUserInput(params);
         });
     }
 

--- a/src/CodexElicitationHandler.ts
+++ b/src/CodexElicitationHandler.ts
@@ -8,6 +8,8 @@ import type {
     ItemStartedNotification,
     McpServerElicitationRequestParams,
     McpServerElicitationRequestResponse,
+    ToolRequestUserInputParams,
+    ToolRequestUserInputResponse,
 } from "./app-server/v2";
 import { logger } from "./Logger";
 import { McpApprovalOptionId } from "./McpApprovalOptionId";
@@ -35,6 +37,8 @@ type AcpBackedMcpElicitationParams = Extract<
     McpServerElicitationRequestParams,
     { mode: "form" } | { mode: "url" }
 >;
+
+const USER_INPUT_OTHER_FIELD_SUFFIX = "__other";
 
 /**
  * Parses the `persist` field from the elicitation request `_meta`.
@@ -219,6 +223,33 @@ function elicitationResponseMeta(
     return Object.keys(meta).length === 0 ? null : meta;
 }
 
+function userInputOtherFieldId(questionId: string, questionIds: Set<string>): string {
+    const base = `${questionId}${USER_INPUT_OTHER_FIELD_SUFFIX}`;
+    if (!questionIds.has(base)) {
+        return base;
+    }
+
+    let index = 1;
+    while (questionIds.has(`${base}${index}`)) {
+        index += 1;
+    }
+    return `${base}${index}`;
+}
+
+function userInputResponseValue(
+    content: Record<string, acp.ElicitationContentValue>,
+    fieldId: string
+): acp.ElicitationContentValue | undefined {
+    const value = content[fieldId];
+    if (typeof value === "string" && value.trim() === "") {
+        return undefined;
+    }
+    if (Array.isArray(value) && value.length === 0) {
+        return undefined;
+    }
+    return value;
+}
+
 /**
  * Builds the ACP permission options for an MCP tool call approval elicitation.
  * Always includes "Allow Once"; adds session/always persist options when advertised.
@@ -332,8 +363,76 @@ export class CodexElicitationHandler implements ElicitationHandler {
         }
     }
 
-    private requestOptions(): acp.SendRequestOptions | undefined {
-        return this.cancellationSignal ? {cancellationSignal: this.cancellationSignal} : undefined;
+    async handleUserInput(params: ToolRequestUserInputParams): Promise<ToolRequestUserInputResponse> {
+        if (!clientSupportsFormElicitation(this.clientCapabilities)) {
+            return { answers: {} };
+        }
+
+        try {
+            const response = await this.requestUserInputElicitation(params);
+            if (response === null) {
+                return { answers: {} };
+            }
+            return this.convertUserInputResponse(response, params);
+        } catch (error) {
+            logger.error("Error handling Codex user input request", error);
+            return { answers: {} };
+        }
+    }
+
+    private requestOptions(
+        cancellationSignal: AbortSignal | undefined = this.cancellationSignal
+    ): acp.SendRequestOptions | undefined {
+        return cancellationSignal ? {cancellationSignal} : undefined;
+    }
+
+    private async requestUserInputElicitation(
+        params: ToolRequestUserInputParams
+    ): Promise<acp.CreateElicitationResponse | null> {
+        const request = this.buildUserInputRequest(params);
+        if (params.autoResolutionMs === null) {
+            return await this.connection.request(
+                acp.methods.client.elicitation.create,
+                request,
+                this.requestOptions(),
+            );
+        }
+
+        const abortController = new AbortController();
+        let timeout: ReturnType<typeof setTimeout> | undefined;
+        let removeAbortListener: (() => void) | undefined;
+        const timeoutPromise = new Promise<null>((resolve) => {
+            const resolveWithoutInput = () => {
+                abortController.abort();
+                resolve(null);
+            };
+            timeout = setTimeout(resolveWithoutInput, Math.max(0, params.autoResolutionMs ?? 0));
+            if (this.cancellationSignal?.aborted) {
+                resolveWithoutInput();
+                return;
+            }
+            if (this.cancellationSignal) {
+                this.cancellationSignal.addEventListener("abort", resolveWithoutInput, { once: true });
+                removeAbortListener = () => {
+                    this.cancellationSignal?.removeEventListener("abort", resolveWithoutInput);
+                };
+            }
+        });
+        const requestPromise = Promise.resolve(this.connection.request(
+            acp.methods.client.elicitation.create,
+            request,
+            this.requestOptions(abortController.signal),
+        ));
+        void requestPromise.catch(() => {});
+
+        try {
+            return await Promise.race([requestPromise, timeoutPromise]);
+        } finally {
+            if (timeout) {
+                clearTimeout(timeout);
+            }
+            removeAbortListener?.();
+        }
     }
 
     private createMcpElicitationContext(params: McpServerElicitationRequestParams): McpElicitationContext {
@@ -391,6 +490,79 @@ export class CodexElicitationHandler implements ElicitationHandler {
                     elicitationId: params.elicitationId,
                 };
         }
+    }
+
+    private buildUserInputRequest(params: ToolRequestUserInputParams): acp.CreateElicitationRequest {
+        const properties: Record<string, acp.ElicitationPropertySchema> = {};
+        const required: string[] = [];
+        const questionIds = new Set(params.questions.map(question => question.id));
+
+        for (const question of params.questions) {
+            const options = question.options ?? [];
+            const hasOptions = options.length > 0;
+            const hasOtherAnswer = question.isOther && hasOptions;
+            const base = {
+                title: question.header || question.id,
+                description: question.question,
+                _meta: {
+                    codex: {
+                        isOther: question.isOther,
+                        isSecret: question.isSecret,
+                    },
+                },
+            };
+            if (!hasOtherAnswer) {
+                required.push(question.id);
+            }
+            properties[question.id] = hasOptions
+                ? {
+                    ...base,
+                    type: "string",
+                    oneOf: options.map(option => ({
+                        const: option.label,
+                        title: option.label,
+                        description: option.description,
+                    })),
+                }
+                : {
+                    ...base,
+                    type: "string",
+                };
+            if (hasOtherAnswer) {
+                properties[userInputOtherFieldId(question.id, questionIds)] = {
+                    type: "string",
+                    title: "Other",
+                    description: "Type your own answer instead of choosing an option above.",
+                    _meta: {
+                        codex: {
+                            questionId: question.id,
+                            isOtherAnswer: true,
+                            isSecret: question.isSecret,
+                        },
+                    },
+                };
+            }
+        }
+
+        const firstQuestion = params.questions[0];
+        return {
+            sessionId: this.sessionState.sessionId,
+            toolCallId: params.itemId,
+            mode: "form",
+            message: params.questions.length === 1 && firstQuestion
+                ? firstQuestion.question
+                : "Input requested",
+            requestedSchema: {
+                type: "object",
+                properties,
+                required,
+            },
+            _meta: {
+                codex: {
+                    autoResolutionMs: params.autoResolutionMs,
+                },
+            },
+        };
     }
 
     private buildPermissionRequest(
@@ -512,6 +684,34 @@ export class CodexElicitationHandler implements ElicitationHandler {
 
         // Malformed known variants match none of the SDK guards.
         return { action: "cancel", content: null, _meta: null };
+    }
+
+    private convertUserInputResponse(
+        response: acp.CreateElicitationResponse,
+        params: ToolRequestUserInputParams
+    ): ToolRequestUserInputResponse {
+        if (!acp.CreateElicitationResponse.isAccept(response)) {
+            return { answers: {} };
+        }
+
+        const answers: ToolRequestUserInputResponse["answers"] = {};
+        const content = contentRecord(response.content);
+        const questionIds = new Set(params.questions.map(question => question.id));
+        for (const question of params.questions) {
+            const value = question.isOther && question.options != null && question.options.length > 0
+                ? userInputResponseValue(content, userInputOtherFieldId(question.id, questionIds))
+                    ?? userInputResponseValue(content, question.id)
+                : userInputResponseValue(content, question.id);
+            if (value === undefined) {
+                continue;
+            }
+            answers[question.id] = {
+                answers: Array.isArray(value)
+                    ? value.map(String)
+                    : [String(value)],
+            };
+        }
+        return { answers };
     }
 
     private async publishAcceptedMcpToolApproval(

--- a/src/ElicitationCapabilities.ts
+++ b/src/ElicitationCapabilities.ts
@@ -1,4 +1,5 @@
 import type * as acp from "@agentclientprotocol/sdk";
+import type {InitializeCapabilities} from "./app-server";
 
 export function clientSupportsFormElicitation(
     clientCapabilities?: acp.ClientCapabilities | null

--- a/src/__tests__/CodexACPAgent/elicitation-events.test.ts
+++ b/src/__tests__/CodexACPAgent/elicitation-events.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as acp from "@agentclientprotocol/sdk";
-import type { McpServerElicitationRequestParams } from '../../app-server/v2';
+import type { McpServerElicitationRequestParams, ToolRequestUserInputParams } from '../../app-server/v2';
 import { createCodexMockTestFixture, createTestSessionState, type CodexMockTestFixture } from '../acp-test-utils';
 import type { SessionState } from '../../CodexAcpServer';
 import { AgentMode } from "../../AgentMode";
@@ -672,6 +672,193 @@ describe('Elicitation Events', () => {
 
             await fixture.sendServerRequest('mcpServer/elicitation/request', params);
             await expect(fixture.getAcpConnectionDump(['_meta'])).toMatchFileSnapshot('data/elicitation-url-accept.json');
+
+            completeTurn();
+            await promptPromise;
+        });
+    });
+
+    describe('Codex request_user_input', () => {
+        it('should use ACP form elicitation for request_user_input when supported', async () => {
+            const { promptPromise, completeTurn } = await setupSessionWithPendingPromptAndCapabilities({
+                elicitation: { form: {} },
+            });
+            fixture.setElicitationResponse({
+                action: 'accept',
+                content: {
+                    next_step: 'Run tests',
+                    notes: 'Focus auth',
+                },
+            });
+
+            const params: ToolRequestUserInputParams = {
+                threadId: sessionId,
+                turnId: 'turn-1',
+                itemId: 'request-user-input-1',
+                autoResolutionMs: 60000,
+                questions: [
+                    {
+                        id: 'next_step',
+                        header: 'Next step',
+                        question: 'What should I do next?',
+                        isOther: true,
+                        isSecret: false,
+                        options: [
+                            { label: 'Run tests', description: 'Run the focused test suite.' },
+                            { label: 'Stop', description: 'Stop and report current status.' },
+                        ],
+                    },
+                    {
+                        id: 'notes',
+                        header: 'Notes',
+                        question: 'Any extra instructions?',
+                        isOther: false,
+                        isSecret: false,
+                        options: null,
+                    },
+                ],
+            };
+
+            const response = await fixture.sendServerRequest('item/tool/requestUserInput', params);
+            expect(response).toEqual({
+                answers: {
+                    next_step: { answers: ['Run tests'] },
+                    notes: { answers: ['Focus auth'] },
+                },
+            });
+
+            const [elicitationEvent] = fixture.getAcpConnectionEvents(['_meta']);
+            expect(elicitationEvent).toMatchObject({
+                method: 'createElicitation',
+                args: [{
+                    sessionId,
+                    toolCallId: 'request-user-input-1',
+                    mode: 'form',
+                    message: 'Input requested',
+                    requestedSchema: {
+                        type: 'object',
+                        required: ['notes'],
+                    },
+                }],
+            });
+            expect(elicitationEvent!.args[0].requestedSchema.properties.next_step.oneOf).toEqual([
+                { const: 'Run tests', title: 'Run tests', description: 'Run the focused test suite.' },
+                { const: 'Stop', title: 'Stop', description: 'Stop and report current status.' },
+            ]);
+            expect(elicitationEvent!.args[0].requestedSchema.properties.next_step__other).toMatchObject({
+                type: 'string',
+                title: 'Other',
+            });
+            expect(elicitationEvent!.args[0].requestedSchema.properties.notes).toMatchObject({
+                type: 'string',
+                title: 'Notes',
+                description: 'Any extra instructions?',
+            });
+
+            completeTurn();
+            await promptPromise;
+        });
+
+        it('should prefer free-form Other answers over fixed choices', async () => {
+            const { promptPromise, completeTurn } = await setupSessionWithPendingPromptAndCapabilities({
+                elicitation: { form: {} },
+            });
+            fixture.setElicitationResponse({
+                action: 'accept',
+                content: {
+                    next_step: 'Run tests',
+                    next_step__other: 'Inspect flaky logs',
+                },
+            });
+
+            const params: ToolRequestUserInputParams = {
+                threadId: sessionId,
+                turnId: 'turn-1',
+                itemId: 'request-user-input-1',
+                autoResolutionMs: null,
+                questions: [{
+                    id: 'next_step',
+                    header: 'Next step',
+                    question: 'What should I do next?',
+                    isOther: true,
+                    isSecret: false,
+                    options: [
+                        { label: 'Run tests', description: 'Run the focused test suite.' },
+                        { label: 'Stop', description: 'Stop and report current status.' },
+                    ],
+                }],
+            };
+
+            const response = await fixture.sendServerRequest('item/tool/requestUserInput', params);
+            expect(response).toEqual({
+                answers: {
+                    next_step: { answers: ['Inspect flaky logs'] },
+                },
+            });
+
+            completeTurn();
+            await promptPromise;
+        });
+
+        it('should auto-resolve request_user_input when the client does not answer in time', async () => {
+            const { promptPromise, completeTurn } = await setupSessionWithPendingPromptAndCapabilities({
+                elicitation: { form: {} },
+            });
+            fixture.setElicitationResponse(new Promise(() => {}));
+
+            const params: ToolRequestUserInputParams = {
+                threadId: sessionId,
+                turnId: 'turn-1',
+                itemId: 'request-user-input-1',
+                autoResolutionMs: 1,
+                questions: [{
+                    id: 'next_step',
+                    header: 'Next step',
+                    question: 'What should I do next?',
+                    isOther: false,
+                    isSecret: false,
+                    options: null,
+                }],
+            };
+
+            const response = await fixture.sendServerRequest('item/tool/requestUserInput', params);
+            expect(response).toEqual({ answers: {} });
+
+            const [elicitationEvent] = fixture.getAcpConnectionEvents(['_meta']);
+            expect(elicitationEvent).toMatchObject({
+                method: 'createElicitation',
+                args: [{
+                    sessionId,
+                    toolCallId: 'request-user-input-1',
+                    mode: 'form',
+                }],
+            });
+
+            completeTurn();
+            await promptPromise;
+        });
+
+        it('should not call ACP elicitation for request_user_input without form support', async () => {
+            const { promptPromise, completeTurn } = setupSessionWithPendingPrompt();
+
+            const params: ToolRequestUserInputParams = {
+                threadId: sessionId,
+                turnId: 'turn-1',
+                itemId: 'request-user-input-1',
+                autoResolutionMs: null,
+                questions: [{
+                    id: 'next_step',
+                    header: 'Next step',
+                    question: 'What should I do next?',
+                    isOther: false,
+                    isSecret: false,
+                    options: null,
+                }],
+            };
+
+            const response = await fixture.sendServerRequest('item/tool/requestUserInput', params);
+            expect(response).toEqual({ answers: {} });
+            expect(fixture.getAcpConnectionEvents(['_meta'])).toEqual([]);
 
             completeTurn();
             await promptPromise;

--- a/src/__tests__/CodexACPAgent/initialize.test.ts
+++ b/src/__tests__/CodexACPAgent/initialize.test.ts
@@ -85,11 +85,26 @@ describe('CodexACPAgent - initialize', () => {
         ]));
     });
 
-    it('should not opt into experimental app-server capabilities for ACP elicitation support', async () => {
+    it('should opt into request_user_input only when the client supports ACP form elicitation', async () => {
         await agent.initialize({
             protocolVersion: acp.PROTOCOL_VERSION,
             clientCapabilities: {
-                elicitation: { form: {}, url: {} },
+                elicitation: { form: {} },
+            },
+        });
+
+        expect(mockCodexConnection.sendRequest).toHaveBeenCalledWith("initialize", expect.objectContaining({
+            capabilities: {
+                experimentalApi: true,
+                requestAttestation: false,
+            },
+        }));
+
+        vi.clearAllMocks();
+        await agent.initialize({
+            protocolVersion: acp.PROTOCOL_VERSION,
+            clientCapabilities: {
+                elicitation: { url: {} },
             },
         });
 

--- a/src/__tests__/CodexACPAgent/initialize.test.ts
+++ b/src/__tests__/CodexACPAgent/initialize.test.ts
@@ -85,34 +85,6 @@ describe('CodexACPAgent - initialize', () => {
         ]));
     });
 
-    it('should opt into request_user_input only when the client supports ACP form elicitation', async () => {
-        await agent.initialize({
-            protocolVersion: acp.PROTOCOL_VERSION,
-            clientCapabilities: {
-                elicitation: { form: {} },
-            },
-        });
-
-        expect(mockCodexConnection.sendRequest).toHaveBeenCalledWith("initialize", expect.objectContaining({
-            capabilities: {
-                experimentalApi: true,
-                requestAttestation: false,
-            },
-        }));
-
-        vi.clearAllMocks();
-        await agent.initialize({
-            protocolVersion: acp.PROTOCOL_VERSION,
-            clientCapabilities: {
-                elicitation: { url: {} },
-            },
-        });
-
-        expect(mockCodexConnection.sendRequest).toHaveBeenCalledWith("initialize", expect.objectContaining({
-            capabilities: null,
-        }));
-    });
-
     it('should advertise API key auth with the legacy metadata method', () => {
         expect(getCodexAuthMethods()).toEqual(expect.arrayContaining([
             expect.objectContaining({


### PR DESCRIPTION
We dont' enable experimental flags, but if we get the events, we process
them.
