### PR TITLE
feat: bridge Codex dynamic tools through ACP

### DIFF
--- a/src/AcpExtensions.ts
+++ b/src/AcpExtensions.ts
@@ -5,8 +5,17 @@ import type {
     ResumeSessionResponse,
     SessionId,
 } from "@agentclientprotocol/sdk";
+import {RequestError} from "@agentclientprotocol/sdk";
+import type {
+    DynamicToolCallParams,
+    DynamicToolCallResponse,
+    DynamicToolFunctionSpec,
+    DynamicToolSpec,
+} from "./app-server/v2";
 
 export const LEGACY_SET_SESSION_MODEL_METHOD = "session/set_model";
+export const CODEX_DYNAMIC_TOOLS_META_KEY = "codex/dynamic_tools";
+export const CODEX_DYNAMIC_TOOL_CALL_METHOD = "_codex/dynamic_tool_call";
 
 export type LegacySessionModel = {
     modelId: string;
@@ -42,6 +51,75 @@ export type ExtMethodRequest =
     AuthenticationStatusRequest
     | AuthenticationLogoutRequest
     | LegacySetSessionModelExtRequest
+
+export type CodexDynamicToolsMeta = {
+    version: 1;
+    tools: Array<DynamicToolSpec>;
+}
+
+export type CodexDynamicToolCallRequest = {
+    method: typeof CODEX_DYNAMIC_TOOL_CALL_METHOD;
+    params: DynamicToolCallParams;
+}
+
+export type CodexDynamicToolCallResponse = DynamicToolCallResponse;
+
+export function readCodexDynamicToolsMeta(meta?: Record<string, unknown> | null): Array<DynamicToolSpec> | undefined {
+    const raw = meta?.[CODEX_DYNAMIC_TOOLS_META_KEY];
+    if (raw === undefined) {
+        return undefined;
+    }
+    if (
+        !isRecord(raw)
+        || raw["version"] !== 1
+        || !Array.isArray(raw["tools"])
+        || !raw["tools"].every(isDynamicToolSpec)
+    ) {
+        throw RequestError.invalidParams(undefined, `${CODEX_DYNAMIC_TOOLS_META_KEY} must be a version 1 dynamic tool registry`);
+    }
+    return raw["tools"];
+}
+
+export async function callCodexDynamicTool(
+    connection: Pick<ClientContext, "request">,
+    params: DynamicToolCallParams,
+): Promise<CodexDynamicToolCallResponse> {
+    return await connection.request<CodexDynamicToolCallResponse, DynamicToolCallParams>(
+        CODEX_DYNAMIC_TOOL_CALL_METHOD,
+        params,
+    );
+}
+
+function isDynamicToolSpec(value: unknown): value is DynamicToolSpec {
+    if (!isRecord(value)) {
+        return false;
+    }
+    if (value["type"] === "function") {
+        return isDynamicToolFunctionSpec(value);
+    }
+    return value["type"] === "namespace"
+        && isNonEmptyString(value["name"])
+        && typeof value["description"] === "string"
+        && Array.isArray(value["tools"])
+        && value["tools"].every((tool) =>
+            isRecord(tool) && tool["type"] === "function" && isDynamicToolFunctionSpec(tool)
+        );
+}
+
+function isDynamicToolFunctionSpec(value: Record<string, unknown>): value is DynamicToolFunctionSpec & Record<string, unknown> {
+    return isNonEmptyString(value["name"])
+        && typeof value["description"] === "string"
+        && value["inputSchema"] !== undefined
+        && (value["deferLoading"] === undefined || typeof value["deferLoading"] === "boolean");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+    return typeof value === "string" && value.trim().length > 0;
+}
 
 export function isExtMethodRequest(request: { method: string, params: Record<string, unknown> }): request is ExtMethodRequest {
     return request.method === "authentication/status"

--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -40,6 +40,7 @@ import type {
 } from "./app-server/v2";
 import packageJson from "../package.json";
 import type {AuthenticationStatusResponse} from "./AcpExtensions";
+import {readCodexDynamicToolsMeta} from "./AcpExtensions";
 
 /**
  * Well-known provider id for the client-configurable custom LLM gateway.
@@ -366,12 +367,14 @@ export class CodexAcpClient {
 
     async newSession(request: acp.NewSessionRequest): Promise<SessionMetadata> {
         const additionalDirectories = readAdditionalDirectories(request.cwd, request.additionalDirectories, request._meta);
+        const dynamicTools = readCodexDynamicToolsMeta(request._meta);
         await this.refreshSkills(request.cwd, additionalDirectories);
 
         const response = await this.codexClient.threadStart({
             config: await this.createSessionConfig(request.cwd, additionalDirectories, request.mcpServers),
             modelProvider: this.getModelProvider(),
             cwd: request.cwd,
+            ...(dynamicTools ? {dynamicTools} : {}),
         });
 
         const codexModels = await this.fetchAvailableModels();

--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -316,6 +316,7 @@ export class CodexAcpClient {
 
     async resumeSession(request: acp.ResumeSessionRequest, onSubscribed?: () => void): Promise<SessionMetadata> {
         const additionalDirectories = readAdditionalDirectories(request.cwd, request.additionalDirectories, request._meta);
+        const dynamicTools = readCodexDynamicToolsMeta(request._meta);
         await this.refreshSkills(request.cwd, additionalDirectories);
 
         const response = await this.codexClient.threadResume({
@@ -324,6 +325,10 @@ export class CodexAcpClient {
             modelProvider: await this.getResumeModelProvider(),
             threadId: request.sessionId,
         });
+        this.codexClient.bindThread(request.sessionId);
+        if (dynamicTools !== undefined) {
+            this.codexClient.bindDynamicToolHandler(request.sessionId);
+        }
         onSubscribed?.();
         const codexModels = await this.fetchAvailableModels();
         const currentModelId = this.createModelId(codexModels, response.model, response.reasoningEffort).toString();
@@ -339,6 +344,7 @@ export class CodexAcpClient {
 
     async loadSession(request: acp.LoadSessionRequest, onSubscribed?: () => void): Promise<SessionMetadataWithThread> {
         const additionalDirectories = readAdditionalDirectories(request.cwd, request.additionalDirectories, request._meta);
+        const dynamicTools = readCodexDynamicToolsMeta(request._meta);
         await this.refreshSkills(request.cwd, additionalDirectories);
 
         const response = await this.codexClient.threadResume({
@@ -347,6 +353,10 @@ export class CodexAcpClient {
             modelProvider: await this.getResumeModelProvider(),
             threadId: request.sessionId,
         });
+        this.codexClient.bindThread(request.sessionId);
+        if (dynamicTools !== undefined) {
+            this.codexClient.bindDynamicToolHandler(request.sessionId);
+        }
         onSubscribed?.();
         const historyResponse = await this.codexClient.threadRead({
             threadId: response.thread.id,
@@ -376,6 +386,10 @@ export class CodexAcpClient {
             cwd: request.cwd,
             ...(dynamicTools ? {dynamicTools} : {}),
         });
+        this.codexClient.bindThread(response.thread.id);
+        if (dynamicTools !== undefined) {
+            this.codexClient.bindDynamicToolHandler(response.thread.id);
+        }
 
         const codexModels = await this.fetchAvailableModels();
         if (codexModels.length === 0) {
@@ -398,6 +412,10 @@ export class CodexAcpClient {
         } finally {
             this.codexClient.clearThreadHandlers(sessionId);
         }
+    }
+
+    dispose(): void {
+        this.codexClient.dispose();
     }
 
     async deleteSession(sessionId: string): Promise<void> {

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -190,6 +190,10 @@ export class CodexAcpServer {
         );
     }
 
+    dispose(): void {
+        this.codexAcpClient.dispose();
+    }
+
     async initialize(
         _params: acp.InitializeRequest,
     ): Promise<acp.InitializeResponse> {

--- a/src/CodexAppServerClient.ts
+++ b/src/CodexAppServerClient.ts
@@ -136,12 +136,120 @@ const DynamicToolCallRequest = new RequestType<
 
 const GOAL_RUNTIME_EFFECTS_GRACE_MS = 1_000;
 
+type SharedConnectionClient = {
+    ownsThread(threadId: string): boolean;
+    onNotification(notification: ServerNotification): void;
+    ownsApproval(threadId: string): boolean;
+    handleCommandExecution(params: CommandExecutionRequestApprovalParams): Promise<CommandExecutionRequestApprovalResponse>;
+    handleFileChange(params: FileChangeRequestApprovalParams): Promise<FileChangeRequestApprovalResponse>;
+    handlePermissionsRequest(params: PermissionsRequestApprovalParams): Promise<PermissionsRequestApprovalResponse>;
+    ownsElicitation(threadId: string): boolean;
+    handleElicitation(params: McpServerElicitationRequestParams): Promise<McpServerElicitationRequestResponse>;
+    handleUserInput(params: ToolRequestUserInputParams): Promise<ToolRequestUserInputResponse>;
+    ownsDynamicToolThread(threadId: string): boolean;
+    handleDynamicToolCall(params: DynamicToolCallParams): Promise<DynamicToolCallResponse>;
+};
+
+const sharedConnectionRouters = new WeakMap<MessageConnection, SharedConnectionRouter>();
+
+class SharedConnectionRouter {
+    private readonly clients = new Set<SharedConnectionClient>();
+
+    constructor(connection: MessageConnection) {
+        connection.onUnhandledNotification((notification) => {
+            const serverNotification = notification as ServerNotification;
+            const threadId = extractThreadId(serverNotification);
+            if (threadId !== null) {
+                this.uniqueOwner((client) => client.ownsThread(threadId))?.onNotification(serverNotification);
+                return;
+            }
+            for (const client of [...this.clients]) {
+                client.onNotification(serverNotification);
+            }
+        });
+
+        connection.onRequest(CommandExecutionApprovalRequest, async (params) => {
+            const owner = this.uniqueOwner((client) => client.ownsApproval(params.threadId));
+            return owner ? await owner.handleCommandExecution(params) : {decision: 'cancel'};
+        });
+
+        connection.onRequest(FileChangeApprovalRequest, async (params) => {
+            const owner = this.uniqueOwner((client) => client.ownsApproval(params.threadId));
+            return owner ? await owner.handleFileChange(params) : {decision: 'cancel'};
+        });
+
+        connection.onRequest(PermissionsApprovalRequest, async (params) => {
+            const owner = this.uniqueOwner((client) => client.ownsApproval(params.threadId));
+            return owner
+                ? await owner.handlePermissionsRequest(params)
+                : {permissions: {}, scope: 'turn', strictAutoReview: true};
+        });
+
+        connection.onRequest(McpServerElicitationRequest, async (params) => {
+            const owner = this.uniqueOwner((client) => client.ownsElicitation(params.threadId));
+            return owner
+                ? await owner.handleElicitation(params)
+                : {action: 'cancel', content: null, _meta: null};
+        });
+
+        connection.onRequest(ToolRequestUserInputRequest, async (params) => {
+            const owner = this.uniqueOwner((client) => client.ownsElicitation(params.threadId));
+            return owner ? await owner.handleUserInput(params) : {answers: {}};
+        });
+
+        connection.onRequest(DynamicToolCallRequest, async (params) => {
+            const owner = this.uniqueOwner((client) => client.ownsDynamicToolThread(params.threadId));
+            return owner ? await owner.handleDynamicToolCall(params) : dynamicToolUnavailableResponse();
+        });
+    }
+
+    register(client: SharedConnectionClient): () => void {
+        this.clients.add(client);
+        let released = false;
+        return () => {
+            if (released) {
+                return;
+            }
+            released = true;
+            this.clients.delete(client);
+        };
+    }
+
+    private uniqueOwner(predicate: (client: SharedConnectionClient) => boolean): SharedConnectionClient | null {
+        let owner: SharedConnectionClient | null = null;
+        for (const client of this.clients) {
+            if (!predicate(client)) {
+                continue;
+            }
+            if (owner !== null) {
+                return null;
+            }
+            owner = client;
+        }
+        return owner;
+    }
+}
+
+function sharedConnectionRouter(connection: MessageConnection): SharedConnectionRouter {
+    const existing = sharedConnectionRouters.get(connection);
+    if (existing) {
+        return existing;
+    }
+    const created = new SharedConnectionRouter(connection);
+    sharedConnectionRouters.set(connection, created);
+    return created;
+}
+
 /**
  * A type-safe client over the Codex App Server's JSON-RPC API.
  * Maps each request to its expected response and exposes clear, typed methods for supported JSON-RPC operations.
  */
 export class CodexAppServerClient {
     readonly connection: MessageConnection;
+    private readonly dynamicToolCallHandler: DynamicToolCallHandler | undefined;
+    private readonly ownedThreads = new Set<string>();
+    private readonly dynamicToolThreads = new Set<string>();
+    private readonly releaseSharedConnectionRouter: () => void;
     private approvalHandlers = new Map<string, ApprovalHandler>();
     private elicitationHandlers = new Map<string, ElicitationHandler>();
     private mcpServerStartupVersion = 0;
@@ -158,106 +266,93 @@ export class CodexAppServerClient {
 
     constructor(connection: MessageConnection, dynamicToolCallHandler?: DynamicToolCallHandler) {
         this.connection = connection;
-        this.connection.onUnhandledNotification((data) => {
-            const serverNotification = data as ServerNotification;
-            if (isMcpServerStatusUpdatedNotification(serverNotification)) {
-                this.mcpServerStartupVersion += 1;
-                this.mcpServerStartupStates.set(serverNotification.params.name, {
-                    status: serverNotification.params.status,
-                    error: serverNotification.params.error,
-                    version: this.mcpServerStartupVersion,
-                });
-                this.resolveMcpServerStartupResolvers();
-            }
-            if (isTurnCompletedNotification(serverNotification)) {
-                this.recordTurnCompleted(serverNotification.params);
-            }
-            if (isCompactionCompletedNotification(serverNotification)) {
-                this.recordCompactionCompleted(serverNotification);
-            }
-            if (isThreadStatusChangedNotification(serverNotification)) {
-                this.recordThreadStatusChanged(serverNotification.params);
-            }
-            if (isThreadGoalUpdatedNotification(serverNotification)) {
-                this.recordThreadGoalUpdated(serverNotification.params);
-            }
-            if (isThreadGoalClearedNotification(serverNotification)) {
-                this.recordThreadGoalCleared(serverNotification.params);
-            }
-            const routing = extractTurnRouting(serverNotification);
-            if (this.handleStaleTurnNotification(serverNotification, routing)) {
-                return;
-            }
-            this.recordTurnRouting(routing);
-            if (this.handleStaleTurnNotification(serverNotification, routing)) {
-                return;
-            }
-            this.notify(serverNotification);
-            for (const callback of this.codexEventHandlers) {
-                callback({ eventType: "notification", ...serverNotification });
-            }
-        });
-
-        this.connection.onRequest(CommandExecutionApprovalRequest, async (params) => {
-            if (this.isStaleTurn(params.threadId, params.turnId)) {
-                return { decision: "cancel" };
-            }
-            const handler = this.approvalHandlers.get(params.threadId);
-            if (!handler) {
-                return { decision: "cancel" };
-            }
-            return await handler.handleCommandExecution(params);
-        });
-
-        this.connection.onRequest(FileChangeApprovalRequest, async (params) => {
-            if (this.isStaleTurn(params.threadId, params.turnId)) {
-                return { decision: "cancel" };
-            }
-            const handler = this.approvalHandlers.get(params.threadId);
-            if (!handler) {
-                return { decision: "cancel" };
-            }
-            return await handler.handleFileChange(params);
-        });
-
-        this.connection.onRequest(PermissionsApprovalRequest, async (params) => {
-            if (this.isStaleTurn(params.threadId, params.turnId)) {
-                return { permissions: {}, scope: "turn", strictAutoReview: true };
-            }
-            const handler = this.approvalHandlers.get(params.threadId);
-            if (!handler) {
-                return { permissions: {}, scope: "turn", strictAutoReview: true };
-            }
-            return await handler.handlePermissionsRequest(params);
-        });
-
-        this.connection.onRequest(McpServerElicitationRequest, async (params) => {
-            if (this.isStaleTurn(params.threadId, params.turnId)) {
-                return { action: "cancel", content: null, _meta: null };
-            }
-            const handler = this.elicitationHandlers.get(params.threadId);
-            if (!handler) {
-                return { action: "cancel", content: null, _meta: null };
-            }
-            return await handler.handleElicitation(params);
-        });
-
-        this.connection.onRequest(ToolRequestUserInputRequest, async (params) => {
-            if (this.isStaleTurn(params.threadId, params.turnId)) {
-                return { answers: {} };
-            }
-            const handler = this.elicitationHandlers.get(params.threadId);
-            if (!handler) {
-                return { answers: {} };
-            }
-            return await handler.handleUserInput(params);
-        });
-
-        this.connection.onRequest(DynamicToolCallRequest, async (params) => {
-            if (this.isStaleTurn(params.threadId, params.turnId) || !dynamicToolCallHandler) {
-                return dynamicToolUnavailableResponse();
-            }
-            return await dynamicToolCallHandler(params);
+        this.dynamicToolCallHandler = dynamicToolCallHandler;
+        this.releaseSharedConnectionRouter = sharedConnectionRouter(connection).register({
+            ownsThread: (threadId) => this.ownsThread(threadId),
+            onNotification: (serverNotification) => {
+                if (isMcpServerStatusUpdatedNotification(serverNotification)) {
+                    this.mcpServerStartupVersion += 1;
+                    this.mcpServerStartupStates.set(serverNotification.params.name, {
+                        status: serverNotification.params.status,
+                        error: serverNotification.params.error,
+                        version: this.mcpServerStartupVersion,
+                    });
+                    this.resolveMcpServerStartupResolvers();
+                }
+                if (isTurnCompletedNotification(serverNotification)) {
+                    this.recordTurnCompleted(serverNotification.params);
+                }
+                if (isCompactionCompletedNotification(serverNotification)) {
+                    this.recordCompactionCompleted(serverNotification);
+                }
+                if (isThreadStatusChangedNotification(serverNotification)) {
+                    this.recordThreadStatusChanged(serverNotification.params);
+                }
+                if (isThreadGoalUpdatedNotification(serverNotification)) {
+                    this.recordThreadGoalUpdated(serverNotification.params);
+                }
+                if (isThreadGoalClearedNotification(serverNotification)) {
+                    this.recordThreadGoalCleared(serverNotification.params);
+                }
+                const routing = extractTurnRouting(serverNotification);
+                if (this.handleStaleTurnNotification(serverNotification, routing)) {
+                    return;
+                }
+                this.recordTurnRouting(routing);
+                if (this.handleStaleTurnNotification(serverNotification, routing)) {
+                    return;
+                }
+                this.notify(serverNotification);
+                for (const callback of this.codexEventHandlers) {
+                    callback({ eventType: "notification", ...serverNotification });
+                }
+                if (serverNotification.method === 'thread/closed') {
+                    this.clearThreadHandlers(serverNotification.params.threadId);
+                }
+            },
+            ownsApproval: (threadId) => this.approvalHandlers.has(threadId),
+            handleCommandExecution: async (params) => {
+                if (this.isStaleTurn(params.threadId, params.turnId)) {
+                    return {decision: 'cancel'};
+                }
+                return await this.approvalHandlers.get(params.threadId)!.handleCommandExecution(params);
+            },
+            handleFileChange: async (params) => {
+                if (this.isStaleTurn(params.threadId, params.turnId)) {
+                    return {decision: 'cancel'};
+                }
+                return await this.approvalHandlers.get(params.threadId)!.handleFileChange(params);
+            },
+            handlePermissionsRequest: async (params) => {
+                if (this.isStaleTurn(params.threadId, params.turnId)) {
+                    return {permissions: {}, scope: 'turn', strictAutoReview: true};
+                }
+                return await this.approvalHandlers.get(params.threadId)!.handlePermissionsRequest(params);
+            },
+            ownsElicitation: (threadId) => this.elicitationHandlers.has(threadId),
+            handleElicitation: async (params) => {
+                if (this.isStaleTurn(params.threadId, params.turnId)) {
+                    return {action: 'cancel', content: null, _meta: null};
+                }
+                return await this.elicitationHandlers.get(params.threadId)!.handleElicitation(params);
+            },
+            handleUserInput: async (params) => {
+                if (this.isStaleTurn(params.threadId, params.turnId)) {
+                    return {answers: {}};
+                }
+                return await this.elicitationHandlers.get(params.threadId)!.handleUserInput(params);
+            },
+            ownsDynamicToolThread: (threadId) => this.dynamicToolThreads.has(threadId),
+            handleDynamicToolCall: async (params) => {
+                if (this.isStaleTurn(params.threadId, params.turnId) || !this.dynamicToolCallHandler) {
+                    return dynamicToolUnavailableResponse();
+                }
+                try {
+                    return await this.dynamicToolCallHandler(params);
+                } catch {
+                    return dynamicToolUnavailableResponse();
+                }
+            },
         });
     }
 
@@ -273,6 +368,45 @@ export class CodexAppServerClient {
         this.notificationHandlers.delete(threadId);
         this.approvalHandlers.delete(threadId);
         this.elicitationHandlers.delete(threadId);
+        this.ownedThreads.delete(threadId);
+        this.dynamicToolThreads.delete(threadId);
+        this.staleTurnIds.delete(threadId);
+    }
+
+    bindThread(threadId: string): void {
+        this.ownedThreads.add(threadId);
+    }
+
+    bindDynamicToolHandler(threadId: string): void {
+        if (this.dynamicToolCallHandler) {
+            this.ownedThreads.add(threadId);
+            this.dynamicToolThreads.add(threadId);
+        }
+    }
+
+    dispose(): void {
+        this.releaseSharedConnectionRouter();
+        this.notificationHandlers.clear();
+        this.approvalHandlers.clear();
+        this.elicitationHandlers.clear();
+        this.ownedThreads.clear();
+        this.dynamicToolThreads.clear();
+        this.staleTurnIds.clear();
+    }
+
+    private ownsThread(threadId: string): boolean {
+        return this.ownedThreads.has(threadId)
+            || this.notificationHandlers.has(threadId)
+            || this.approvalHandlers.has(threadId)
+            || this.elicitationHandlers.has(threadId)
+            || this.dynamicToolThreads.has(threadId)
+            || this.pendingTurnCompletionResolvers.has(threadId)
+            || this.pendingCompactionCompletionResolvers.has(threadId)
+            || this.turnCompletionCaptures.has(threadId)
+            || this.turnRoutingCaptures.has(threadId)
+            || this.threadStatusCaptures.has(threadId)
+            || this.threadGoalUpdateCaptures.has(threadId)
+            || this.threadGoalClearedCaptures.has(threadId);
     }
 
     async initialize(params: InitializeParams): Promise<InitializeResponse> {

--- a/src/CodexAppServerClient.ts
+++ b/src/CodexAppServerClient.ts
@@ -160,6 +160,14 @@ class SharedConnectionRouter {
             const serverNotification = notification as ServerNotification;
             const threadId = extractThreadId(serverNotification);
             if (threadId !== null) {
+                if (serverNotification.method === 'thread/closed') {
+                    for (const client of this.clients) {
+                        if (client.ownsThread(threadId)) {
+                            client.onNotification(serverNotification);
+                        }
+                    }
+                    return;
+                }
                 this.uniqueOwner((client) => client.ownsThread(threadId))?.onNotification(serverNotification);
                 return;
             }

--- a/src/CodexAppServerClient.ts
+++ b/src/CodexAppServerClient.ts
@@ -65,6 +65,9 @@ import type {
     PermissionsRequestApprovalParams,
     PermissionsRequestApprovalResponse,
     ItemCompletedNotification,
+    DynamicToolCallParams,
+    DynamicToolCallResponse,
+    DynamicToolSpec,
 } from "./app-server/v2";
 
 export interface ApprovalHandler {
@@ -77,6 +80,12 @@ export interface ElicitationHandler {
     handleElicitation(params: McpServerElicitationRequestParams): Promise<McpServerElicitationRequestResponse>;
     handleUserInput(params: ToolRequestUserInputParams): Promise<ToolRequestUserInputResponse>;
 }
+
+export type DynamicToolCallHandler = (params: DynamicToolCallParams) => Promise<DynamicToolCallResponse>;
+
+export type ExperimentalThreadStartParams = ThreadStartParams & {
+    dynamicTools?: Array<DynamicToolSpec> | null;
+};
 
 export type McpStartupFailure = {
     server: string;
@@ -119,6 +128,12 @@ const ToolRequestUserInputRequest = new RequestType<
     void
 >('item/tool/requestUserInput');
 
+const DynamicToolCallRequest = new RequestType<
+    DynamicToolCallParams,
+    DynamicToolCallResponse,
+    void
+>('item/tool/call');
+
 const GOAL_RUNTIME_EFFECTS_GRACE_MS = 1_000;
 
 /**
@@ -141,7 +156,7 @@ export class CodexAppServerClient {
     private readonly threadGoalClearedCaptures = new Map<string, Set<() => void>>();
     private readonly staleTurnIds = new Map<string, Set<string>>();
 
-    constructor(connection: MessageConnection) {
+    constructor(connection: MessageConnection, dynamicToolCallHandler?: DynamicToolCallHandler) {
         this.connection = connection;
         this.connection.onUnhandledNotification((data) => {
             const serverNotification = data as ServerNotification;
@@ -236,6 +251,13 @@ export class CodexAppServerClient {
                 return { answers: {} };
             }
             return await handler.handleUserInput(params);
+        });
+
+        this.connection.onRequest(DynamicToolCallRequest, async (params) => {
+            if (this.isStaleTurn(params.threadId, params.turnId) || !dynamicToolCallHandler) {
+                return dynamicToolUnavailableResponse();
+            }
+            return await dynamicToolCallHandler(params);
         });
     }
 
@@ -505,7 +527,7 @@ export class CodexAppServerClient {
         this.staleTurnIds.set(threadId, threadStaleTurns);
     }
 
-    async threadStart(params: ThreadStartParams): Promise<ThreadStartResponse> {
+    async threadStart(params: ExperimentalThreadStartParams): Promise<ThreadStartResponse> {
         return await this.sendRequest({ method: "thread/start", params: params });
     }
 
@@ -930,6 +952,13 @@ export class CodexAppServerClient {
         }
         return result;
     }
+}
+
+function dynamicToolUnavailableResponse(): DynamicToolCallResponse {
+    return {
+        success: false,
+        contentItems: [{type: "inputText", text: "Dynamic tool dispatcher unavailable"}],
+    };
 }
 
 export type CodexConnectionEvent =

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -415,6 +415,7 @@ describe('ACP server test', { timeout: 40_000 }, () => {
             contentItems: [{type: "inputText", text: "ready"}],
         };
         mockFixture.setDynamicToolResponse(response);
+        mockFixture.getCodexAppServerClient().bindDynamicToolHandler('thread-id');
 
         await expect(mockFixture.sendServerRequest<DynamicToolCallResponse>('item/tool/call', {
             threadId: 'thread-id',
@@ -717,6 +718,7 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         const mockFixture = createCodexMockTestFixture();
         const codexAcpClient = mockFixture.getCodexAcpClient();
         const codexAppServerClient = mockFixture.getCodexAppServerClient();
+        codexAppServerClient.bindThread('thread-id');
 
         const startupPromise = codexAcpClient.awaitMcpServerStartup(
             ["alpha", "beta"],

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -10,6 +10,8 @@ import {
     createTestSessionState,
     type TestFixture
 } from "../acp-test-utils";
+import {CODEX_DYNAMIC_TOOL_CALL_METHOD, CODEX_DYNAMIC_TOOLS_META_KEY} from "../../AcpExtensions";
+import type {DynamicToolCallResponse} from "../../app-server/v2";
 import type {ServerNotification} from "../../app-server";
 import type {SessionState} from "../../CodexAcpServer";
 import {AgentMode} from "../../AgentMode";
@@ -354,6 +356,85 @@ describe('ACP server test', { timeout: 40_000 }, () => {
             forceReload: true,
         });
         expect(listSkillsSpy.mock.invocationCallOrder[0]!).toBeLessThan(threadStartSpy.mock.invocationCallOrder[0]!);
+    });
+
+    it('injects versioned ACP dynamic tool registrations into thread/start', async () => {
+        const mockFixture = createCodexMockTestFixture();
+        const codexAcpClient = mockFixture.getCodexAcpClient();
+        const codexAppServerClient = mockFixture.getCodexAppServerClient();
+        const threadStartSpy = vi.spyOn(codexAppServerClient, "threadStart").mockResolvedValue({
+            thread: {id: "thread-id"} as any,
+            model: "gpt-5",
+            reasoningEffort: "medium",
+            serviceTier: null,
+        } as any);
+        vi.spyOn(codexAppServerClient, "listSkills").mockResolvedValue({data: []});
+        vi.spyOn(codexAppServerClient, "listModels").mockResolvedValue({
+            data: [createTestModel({id: "gpt-5"})],
+            nextCursor: null,
+        });
+
+        await codexAcpClient.newSession({
+            cwd: "/workspace",
+            mcpServers: [],
+            _meta: {
+                [CODEX_DYNAMIC_TOOLS_META_KEY]: {
+                    version: 1,
+                    tools: [{
+                        type: "function",
+                        name: "opl_runtime_read",
+                        description: "Read the active OPL runtime projection",
+                        inputSchema: {type: "object", properties: {}},
+                    }],
+                },
+            },
+        });
+
+        expect(threadStartSpy).toHaveBeenCalledWith(expect.objectContaining({
+            dynamicTools: [expect.objectContaining({name: "opl_runtime_read"})],
+        }));
+    });
+
+    it('rejects malformed dynamic tool registration metadata before thread/start', async () => {
+        const mockFixture = createCodexMockTestFixture();
+        const codexAcpClient = mockFixture.getCodexAcpClient();
+        const threadStartSpy = vi.spyOn(mockFixture.getCodexAppServerClient(), "threadStart");
+
+        await expect(codexAcpClient.newSession({
+            cwd: "/workspace",
+            mcpServers: [],
+            _meta: {[CODEX_DYNAMIC_TOOLS_META_KEY]: {version: 1, tools: [{type: "function"}]}},
+        })).rejects.toThrow();
+        expect(threadStartSpy).not.toHaveBeenCalled();
+    });
+
+    it('round-trips item/tool/call through the typed ACP extension callback', async () => {
+        const mockFixture = createCodexMockTestFixture();
+        const response: DynamicToolCallResponse = {
+            success: true,
+            contentItems: [{type: "inputText", text: "ready"}],
+        };
+        mockFixture.setDynamicToolResponse(response);
+
+        await expect(mockFixture.sendServerRequest<DynamicToolCallResponse>('item/tool/call', {
+            threadId: 'thread-id',
+            turnId: 'turn-id',
+            callId: 'call-id',
+            namespace: null,
+            tool: 'opl_runtime_read',
+            arguments: {detail: 'fast'},
+        })).resolves.toEqual(response);
+        expect(mockFixture.getAcpConnectionEvents([])).toContainEqual({
+            method: 'request',
+            args: [CODEX_DYNAMIC_TOOL_CALL_METHOD, {
+                threadId: 'thread-id',
+                turnId: 'turn-id',
+                callId: 'call-id',
+                namespace: null,
+                tool: 'opl_runtime_read',
+                arguments: {detail: 'fast'},
+            }],
+        });
     });
 
     it('prefers ACP additional directories over legacy meta roots for new session skill discovery', async () => {

--- a/src/__tests__/CodexAppServerClient.dynamic-tools.test.ts
+++ b/src/__tests__/CodexAppServerClient.dynamic-tools.test.ts
@@ -1,0 +1,191 @@
+import {describe, expect, it, vi} from 'vitest';
+import type {MessageConnection} from 'vscode-jsonrpc/node';
+import {CodexAppServerClient} from '../CodexAppServerClient';
+import type {DynamicToolCallParams, DynamicToolCallResponse} from '../app-server/v2';
+import type {ServerNotification} from '../app-server';
+
+const DYNAMIC_TOOL_METHOD = 'item/tool/call';
+
+type SharedConnectionFixture = {
+    connection: MessageConnection;
+    requestRegistrationCount(method: string): number;
+    sendRequest<T>(method: string, params: unknown): Promise<T>;
+    sendNotification(notification: ServerNotification): void;
+};
+
+function createSharedConnectionFixture(): SharedConnectionFixture {
+    const requestHandlers = new Map<string, (params: unknown) => Promise<unknown>>();
+    const requestRegistrationCounts = new Map<string, number>();
+    let notificationHandler: ((notification: unknown) => void) | null = null;
+
+    const connection = {
+        onUnhandledNotification(handler: (notification: unknown) => void) {
+            notificationHandler = handler;
+            return {dispose() { notificationHandler = null; }};
+        },
+        onRequest(type: {method: string}, handler: (params: unknown) => Promise<unknown>) {
+            requestHandlers.set(type.method, handler);
+            requestRegistrationCounts.set(type.method, (requestRegistrationCounts.get(type.method) ?? 0) + 1);
+            return {dispose() { requestHandlers.delete(type.method); }};
+        },
+        sendRequest: vi.fn(),
+    } as unknown as MessageConnection;
+
+    return {
+        connection,
+        requestRegistrationCount(method) {
+            return requestRegistrationCounts.get(method) ?? 0;
+        },
+        async sendRequest<T>(method: string, params: unknown): Promise<T> {
+            const handler = requestHandlers.get(method);
+            if (!handler) {
+                throw new Error(`No request handler registered for ${method}`);
+            }
+            return await handler(params) as T;
+        },
+        sendNotification(notification) {
+            if (!notificationHandler) {
+                throw new Error('No notification handler registered');
+            }
+            notificationHandler(notification);
+        },
+    };
+}
+
+function dynamicToolParams(threadId: string, turnId = 'turn-1'): DynamicToolCallParams {
+    return {
+        threadId,
+        turnId,
+        callId: `call-${threadId}`,
+        namespace: null,
+        tool: 'opl_runtime_read',
+        arguments: {detail: 'fast'},
+    };
+}
+
+function successfulResponse(text: string): DynamicToolCallResponse {
+    return {
+        success: true,
+        contentItems: [{type: 'inputText', text}],
+    };
+}
+
+describe('CodexAppServerClient shared dynamic tool routing', () => {
+    it('keeps earlier thread callbacks when a later client shares the MessageConnection', async () => {
+        const fixture = createSharedConnectionFixture();
+        const firstHandler = vi.fn(async () => successfulResponse('first'));
+        const first = new CodexAppServerClient(fixture.connection, firstHandler);
+        first.bindDynamicToolHandler('thread-first');
+        const firstUpdates = vi.fn();
+        first.onServerNotification('thread-first', firstUpdates);
+
+        const secondHandler = vi.fn(async () => successfulResponse('second'));
+        const second = new CodexAppServerClient(fixture.connection, secondHandler);
+        second.bindDynamicToolHandler('thread-second');
+        const secondUpdates = vi.fn();
+        second.onServerNotification('thread-second', secondUpdates);
+
+        expect(fixture.requestRegistrationCount(DYNAMIC_TOOL_METHOD)).toBe(1);
+        await expect(fixture.sendRequest(DYNAMIC_TOOL_METHOD, dynamicToolParams('thread-first')))
+            .resolves.toEqual(successfulResponse('first'));
+        await expect(fixture.sendRequest(DYNAMIC_TOOL_METHOD, dynamicToolParams('thread-second')))
+            .resolves.toEqual(successfulResponse('second'));
+
+        fixture.sendNotification({
+            method: 'thread/name/updated',
+            params: {threadId: 'thread-first', threadName: 'First'},
+        });
+        expect(firstUpdates).toHaveBeenCalledOnce();
+        expect(secondUpdates).not.toHaveBeenCalled();
+        expect(firstHandler).toHaveBeenCalledOnce();
+        expect(secondHandler).toHaveBeenCalledOnce();
+    });
+
+    it('fails closed for unknown and ambiguous thread owners', async () => {
+        const fixture = createSharedConnectionFixture();
+        const firstHandler = vi.fn(async () => successfulResponse('first'));
+        const secondHandler = vi.fn(async () => successfulResponse('second'));
+        const first = new CodexAppServerClient(fixture.connection, firstHandler);
+        const second = new CodexAppServerClient(fixture.connection, secondHandler);
+
+        await expect(fixture.sendRequest<DynamicToolCallResponse>(DYNAMIC_TOOL_METHOD, dynamicToolParams('unknown')))
+            .resolves.toMatchObject({success: false});
+
+        first.bindDynamicToolHandler('duplicate');
+        second.bindDynamicToolHandler('duplicate');
+        const firstUpdates = vi.fn();
+        const secondUpdates = vi.fn();
+        first.onServerNotification('duplicate', firstUpdates);
+        second.onServerNotification('duplicate', secondUpdates);
+        await expect(fixture.sendRequest<DynamicToolCallResponse>(DYNAMIC_TOOL_METHOD, dynamicToolParams('duplicate')))
+            .resolves.toMatchObject({success: false});
+        fixture.sendNotification({
+            method: 'thread/name/updated',
+            params: {threadId: 'duplicate', threadName: 'Ambiguous'},
+        });
+        expect(firstHandler).not.toHaveBeenCalled();
+        expect(secondHandler).not.toHaveBeenCalled();
+        expect(firstUpdates).not.toHaveBeenCalled();
+        expect(secondUpdates).not.toHaveBeenCalled();
+
+        second.clearThreadHandlers('duplicate');
+        await expect(fixture.sendRequest(DYNAMIC_TOOL_METHOD, dynamicToolParams('duplicate')))
+            .resolves.toEqual(successfulResponse('first'));
+        fixture.sendNotification({
+            method: 'thread/name/updated',
+            params: {threadId: 'duplicate', threadName: 'First'},
+        });
+        expect(firstUpdates).toHaveBeenCalledOnce();
+    });
+
+    it('rejects stale turns and unregisters a server-closed session deterministically', async () => {
+        const fixture = createSharedConnectionFixture();
+        const handler = vi.fn(async () => successfulResponse('ready'));
+        const client = new CodexAppServerClient(fixture.connection, handler);
+        client.bindDynamicToolHandler('thread-stale');
+        client.markTurnStale('thread-stale', 'turn-stale');
+
+        await expect(fixture.sendRequest<DynamicToolCallResponse>(
+            DYNAMIC_TOOL_METHOD,
+            dynamicToolParams('thread-stale', 'turn-stale'),
+        )).resolves.toMatchObject({success: false});
+        expect(handler).not.toHaveBeenCalled();
+
+        client.bindDynamicToolHandler('thread-closed');
+        fixture.sendNotification({method: 'thread/closed', params: {threadId: 'thread-closed'}});
+        await expect(fixture.sendRequest<DynamicToolCallResponse>(
+            DYNAMIC_TOOL_METHOD,
+            dynamicToolParams('thread-closed'),
+        )).resolves.toMatchObject({success: false});
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('removes all owned thread routes on client disposal', async () => {
+        const fixture = createSharedConnectionFixture();
+        const handler = vi.fn(async () => successfulResponse('ready'));
+        const client = new CodexAppServerClient(fixture.connection, handler);
+        client.bindDynamicToolHandler('thread-disposed');
+        client.dispose();
+
+        await expect(fixture.sendRequest<DynamicToolCallResponse>(
+            DYNAMIC_TOOL_METHOD,
+            dynamicToolParams('thread-disposed'),
+        )).resolves.toMatchObject({success: false});
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('converts dispatcher failures into a typed unavailable response', async () => {
+        const fixture = createSharedConnectionFixture();
+        const handler = vi.fn(async (): Promise<DynamicToolCallResponse> => {
+            throw new Error('ACP dispatcher disconnected');
+        });
+        const client = new CodexAppServerClient(fixture.connection, handler);
+        client.bindDynamicToolHandler('thread-failed');
+
+        await expect(fixture.sendRequest<DynamicToolCallResponse>(
+            DYNAMIC_TOOL_METHOD,
+            dynamicToolParams('thread-failed'),
+        )).resolves.toMatchObject({success: false});
+        expect(handler).toHaveBeenCalledOnce();
+    });
+});

--- a/src/__tests__/CodexAppServerClient.dynamic-tools.test.ts
+++ b/src/__tests__/CodexAppServerClient.dynamic-tools.test.ts
@@ -160,6 +160,29 @@ describe('CodexAppServerClient shared dynamic tool routing', () => {
         expect(handler).not.toHaveBeenCalled();
     });
 
+    it('revokes every ambiguous claimant when the server closes the thread', async () => {
+        const fixture = createSharedConnectionFixture();
+        const firstHandler = vi.fn(async () => successfulResponse('first'));
+        const secondHandler = vi.fn(async () => successfulResponse('second'));
+        const first = new CodexAppServerClient(fixture.connection, firstHandler);
+        const second = new CodexAppServerClient(fixture.connection, secondHandler);
+        first.bindDynamicToolHandler('thread-ambiguous-closed');
+        second.bindDynamicToolHandler('thread-ambiguous-closed');
+
+        fixture.sendNotification({
+            method: 'thread/closed',
+            params: {threadId: 'thread-ambiguous-closed'},
+        });
+        second.dispose();
+
+        await expect(fixture.sendRequest<DynamicToolCallResponse>(
+            DYNAMIC_TOOL_METHOD,
+            dynamicToolParams('thread-ambiguous-closed'),
+        )).resolves.toMatchObject({success: false});
+        expect(firstHandler).not.toHaveBeenCalled();
+        expect(secondHandler).not.toHaveBeenCalled();
+    });
+
     it('removes all owned thread routes on client disposal', async () => {
         const fixture = createSharedConnectionFixture();
         const handler = vi.fn(async () => successfulResponse('ready'));

--- a/src/__tests__/acp-test-utils.ts
+++ b/src/__tests__/acp-test-utils.ts
@@ -13,6 +13,8 @@ import os from "node:os";
 import {AgentMode} from "../AgentMode";
 import {expect, vi} from "vitest";
 import type {Model, ReasoningEffortOption} from "../app-server/v2";
+import type {DynamicToolCallResponse} from "../app-server/v2";
+import {callCodexDynamicTool, CODEX_DYNAMIC_TOOL_CALL_METHOD} from "../AcpExtensions";
 
 export type MethodCallEvent = { method: string; args: any[] };
 
@@ -95,7 +97,10 @@ export function createBaseTestFixture(config: ConnectionConfig): TestFixture {
         acpEventHandlers.forEach(handler => handler(normalizedEvent));
     });
 
-    const codexAppServerClient = new CodexAppServerClient(config.connection);
+    const codexAppServerClient = new CodexAppServerClient(
+        config.connection,
+        (params) => callCodexDynamicTool(acpConnection, params),
+    );
     const codexAcpClient = new CodexAcpClient(codexAppServerClient);
     const codexAcpAgent = new CodexAcpServer(acpConnection, codexAcpClient, undefined, config.getExitCode);
 
@@ -245,6 +250,7 @@ export interface CodexMockTestFixture extends TestFixture {
     sendServerRequest<T>(method: string, params: unknown): Promise<T>,
     setPermissionResponse(response: RequestPermissionResponse): void,
     setElicitationResponse(response: CreateElicitationResponse | Promise<CreateElicitationResponse>): void,
+    setDynamicToolResponse(response: DynamicToolCallResponse | Promise<DynamicToolCallResponse>): void,
 }
 
 /**
@@ -264,6 +270,9 @@ export function createCodexMockTestFixture(): CodexMockTestFixture {
     };
     const elicitationState: { response: CreateElicitationResponse | Promise<CreateElicitationResponse> } = {
         response: { action: 'cancel' }
+    };
+    const dynamicToolState: { response: DynamicToolCallResponse | Promise<DynamicToolCallResponse> } = {
+        response: {success: false, contentItems: [{type: 'inputText', text: 'not configured'}]},
     };
 
     const mockCodexConnection = {
@@ -288,6 +297,9 @@ export function createCodexMockTestFixture(): CodexMockTestFixture {
         }
         if (args[0] === acp.methods.client.elicitation.create) {
             return elicitationState.response;
+        }
+        if (args[0] === CODEX_DYNAMIC_TOOL_CALL_METHOD) {
+            return dynamicToolState.response;
         }
         return { mock: "Mocked return" };
     });
@@ -328,6 +340,9 @@ export function createCodexMockTestFixture(): CodexMockTestFixture {
         },
         setElicitationResponse(response: CreateElicitationResponse | Promise<CreateElicitationResponse>): void {
             elicitationState.response = response;
+        },
+        setDynamicToolResponse(response: DynamicToolCallResponse | Promise<DynamicToolCallResponse>): void {
+            dynamicToolState.response = response;
         },
     };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import packageJson from "../package.json";
 import {logger} from "./Logger";
 import {runLoginCommand} from "./login";
 import {runCodexCli} from "./CodexCli";
-import {LEGACY_SET_SESSION_MODEL_METHOD} from "./AcpExtensions";
+import {callCodexDynamicTool, LEGACY_SET_SESSION_MODEL_METHOD} from "./AcpExtensions";
 
 const emptyExtensionParamsParser = z.preprocess(
     (params) => params ?? {},
@@ -90,7 +90,10 @@ function startAcpServer() {
     const acpJsonStream = createJsonStream(process.stdin, process.stdout);
 
     function createAgent(connection: acp.AgentContext): CodexAcpServer {
-        const appServerClient = new CodexAppServerClient(codexConnection.connection);
+        const appServerClient = new CodexAppServerClient(
+            codexConnection.connection,
+            (params) => callCodexDynamicTool(connection, params),
+        );
         const codexClient = new CodexAcpClient(appServerClient, config, modelProvider);
         return new CodexAcpServer(connection, codexClient, defaultAuthRequest, () => codexConnection.process.exitCode, () => stderr);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,7 @@ function startAcpServer() {
             const agent = createAgent(connection.client);
             codexAcpServer = agent;
             connection.signal.addEventListener("abort", () => {
+                agent.dispose();
                 if (codexAcpServer === agent) {
                     codexAcpServer = null;
                 }


### PR DESCRIPTION
## Summary

- accept a versioned `codex/dynamic_tools` registry in ACP `session/new._meta`
- inject those specs into the experimental Codex `thread/start.dynamicTools` field without regenerating the full experimental schema
- forward Codex App Server `item/tool/call` requests through the typed ACP extension `_codex/dynamic_tool_call`
- multiplex callbacks once per shared `MessageConnection`, route by explicit session/thread ownership, and revoke all claimants on terminal `thread/closed`

## Failure semantics

Malformed registration metadata fails with ACP `invalid_params` before `thread/start`. Unknown or duplicate owners, stale turns, closed sessions, disposed clients, missing dispatchers, and dispatcher failures return typed `success: false`. Ordinary thread notifications remain unique-owner only. Terminal `thread/closed` clears every claimant, so disposing one ambiguous claimant cannot resurrect a closed route.

## Validation

Validated on `24589322f1f6a2e7a9fba6ebb42067e47e4dfffd`:

- focused dynamic/session tests: 95 passed
- full `npm test`: 312 passed, 28 skipped
- `npm run typecheck`
- `npm run build`
- `git diff --check HEAD^ HEAD`
- fork HTTPS/SSH:443 readback exact

## Cross-repo evidence

- AionCore host dispatcher: iOfficeAI/AionCore#619 at `e1e022c9e327870bebefa26e417dc5f482349e10`
- downstream Shell registration and live round-trip: `103b078af91454e9938f417fda0fde5ad52554b7`
- Shell repository-native gate: 1,613 tests passed plus lint, format, typecheck, and i18n

This PR is ready for upstream review. The fork branch remains a contribution head only. Product completion still requires both upstream canonical mains to merge and the Shell to consume released canonical refs; no product dependency points at the fork.