### PR TITLE
fix: explicitly enable MCP servers supplied through ACP

### DIFF
--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -578,12 +578,14 @@ export class CodexAcpClient {
                     throw RequestError.invalidRequest("Codex doesn't support MCP SSE transport protocol")
                 case "http":
                     return {
+                        "enabled": true,
                         "url": mcpServer.url,
                         "http_headers": Object.fromEntries(mcpServer.headers.map(h => [h.name, h.value])),
                     }
             }
         }
         return {
+            "enabled": true,
             "command": mcpServer.command,
             "args": mcpServer.args,
             "env": Object.fromEntries(mcpServer.env.map(env => [env.name, env.value])),

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -677,11 +677,13 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         const threadStartRequest = threadStartSpy.mock.calls[0]![0];
         expect(threadStartRequest.config?.["mcp_servers"]).toEqual({
             stdio_server_one: {
+                enabled: true,
                 command: "npx",
                 args: ["stdio"],
                 env: {EXAMPLE: "1"},
             },
             http_server_two: {
+                enabled: true,
                 url: "https://example.com/http",
                 http_headers: {Authorization: "Bearer token"},
             },


### PR DESCRIPTION
## Summary

- explicitly set `enabled: true` for stdio and HTTP MCP servers supplied through ACP
- make the ACP-to-Codex mapping express that session-provided MCP servers are intended to be active
- add focused assertions for the generated Codex configuration

## Testing

- `npm run typecheck`
- `npm test` (329 passed, 28 skipped)

## Related issue

N/A — no related issue was identified.
