### PR TITLE
Emit completed Codex plan artifacts via negotiated plan_update

### DIFF
--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -83,6 +83,7 @@ import {
     createCodexMessagePhaseMeta,
     createAgentTextMessageChunk,
     createAgentTextThoughtChunk,
+    createPlanTextUpdate,
     createUserMessageChunk,
 } from "./ContentChunks";
 import {
@@ -1523,11 +1524,7 @@ export class CodexAcpServer {
     private createPlanMessageUpdate(
         item: ThreadItem & { type: "plan" }
     ): UpdateSessionEvent {
-        return createAgentTextMessageChunk(
-            item.text,
-            item.id,
-            createCodexMessagePhaseMeta("final_answer"),
-        );
+        return createPlanTextUpdate(item.text, item.id, this.clientCapabilities);
     }
 
     private userInputToContentBlocks(input: UserInput): acp.ContentBlock[] {
@@ -1876,7 +1873,11 @@ export class CodexAcpServer {
         const disposePromptRequestCancellation = this.observePromptRequestCancellation(signal, sessionState, activePrompt);
 
         try {
-            const eventHandler = new CodexEventHandler(this.connection, sessionState);
+            const eventHandler = new CodexEventHandler(
+                this.connection,
+                sessionState,
+                this.clientCapabilities,
+            );
             const approvalHandler = new CodexApprovalHandler(this.connection, sessionState, activePrompt.signal);
             const elicitationHandler = new CodexElicitationHandler(
                 this.connection,

--- a/src/CodexEventHandler.ts
+++ b/src/CodexEventHandler.ts
@@ -4,7 +4,7 @@ import type {
     ServerNotification
 } from "./app-server";
 import type {SessionState} from "./CodexAcpServer";
-import {type PlanEntry, RequestError} from "@agentclientprotocol/sdk";
+import {type ClientCapabilities, type PlanEntry, RequestError} from "@agentclientprotocol/sdk";
 import {ACPSessionConnection, type AcpClientConnection, type UpdateSessionEvent} from "./ACPSessionConnection";
 import type {
     AccountRateLimitsUpdatedNotification,
@@ -63,6 +63,7 @@ import {
     createCodexMessagePhaseMeta,
     createAgentTextMessageChunk,
     createAgentTextThoughtChunk,
+    createPlanTextUpdate,
 } from "./ContentChunks";
 import {sameThreadGoalSnapshot, toThreadGoalSnapshot} from "./ThreadGoalSnapshot";
 
@@ -72,6 +73,7 @@ export class CodexEventHandler {
 
     private readonly connection: AcpClientConnection;
     private readonly sessionState: SessionState;
+    private readonly clientCapabilities: ClientCapabilities | null;
     private failure: RequestError | null = null;
     private readonly activeFuzzyFileSearchSessions = new Set<string>();
     private readonly activeGuardianApprovalReviews = new Set<string>();
@@ -84,9 +86,14 @@ export class CodexEventHandler {
     private readonly agentMessagePhases = new Map<string, string | null>();
     private readonly activeSubAgentActivities = new Set<string>();
 
-    constructor(connection: AcpClientConnection, sessionState: SessionState) {
+    constructor(
+        connection: AcpClientConnection,
+        sessionState: SessionState,
+        clientCapabilities: ClientCapabilities | null,
+    ) {
         this.connection = connection;
         this.sessionState = sessionState;
+        this.clientCapabilities = clientCapabilities;
     }
 
     getFailure(): RequestError | null {
@@ -451,11 +458,7 @@ export class CodexEventHandler {
     }
 
     private createPlanTextEvent(text: string, messageId: string): UpdateSessionEvent {
-        return createAgentTextMessageChunk(
-            text,
-            messageId,
-            createCodexMessagePhaseMeta("final_answer"),
-        );
+        return createPlanTextUpdate(text, messageId, this.clientCapabilities);
     }
 
     private createExitedReviewModeEvent(item: ThreadItem & { type: "exitedReviewMode" }): UpdateSessionEvent | null {

--- a/src/ContentChunks.ts
+++ b/src/ContentChunks.ts
@@ -1,4 +1,4 @@
-import type {ContentBlock} from "@agentclientprotocol/sdk";
+import type {ClientCapabilities, ContentBlock} from "@agentclientprotocol/sdk";
 import type {UpdateSessionEvent} from "./ACPSessionConnection";
 
 type AcpMeta = Record<string, unknown>;
@@ -60,6 +60,28 @@ export function createAgentThoughtChunk(content: ContentBlock, messageId?: strin
 
 export function createAgentTextMessageChunk(text: string, messageId?: string, meta?: AcpMeta): UpdateSessionEvent {
     return createAgentMessageChunk({type: "text", text}, messageId, meta);
+}
+
+export function createPlanTextUpdate(
+    text: string,
+    planId: string,
+    clientCapabilities: ClientCapabilities | null,
+): UpdateSessionEvent {
+    if (clientCapabilities?.plan) {
+        return {
+            sessionUpdate: "plan_update",
+            plan: {
+                type: "markdown",
+                planId,
+                content: text,
+            },
+        };
+    }
+    return createAgentTextMessageChunk(
+        text,
+        planId,
+        createCodexMessagePhaseMeta("final_answer"),
+    );
 }
 
 export function createAgentTextThoughtChunk(text: string, messageId?: string, meta?: AcpMeta): UpdateSessionEvent {

--- a/src/__tests__/CodexACPAgent/data/load-session-history.json
+++ b/src/__tests__/CodexACPAgent/data/load-session-history.json
@@ -189,6 +189,27 @@
     {
       "sessionId": "session-1",
       "update": {
+        "sessionUpdate": "agent_message_chunk",
+        "messageId": "item-plan-1",
+        "content": {
+          "type": "text",
+          "text": "Inspect project files"
+        },
+        "_meta": {
+          "codex": {
+            "phase": "final_answer"
+          }
+        }
+      }
+    }
+  ]
+}
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "session-1",
+      "update": {
         "sessionUpdate": "tool_call",
         "toolCallId": "item-cmd-1",
         "kind": "execute",

--- a/src/__tests__/CodexACPAgent/data/load-session-response-item-history-fallback.json
+++ b/src/__tests__/CodexACPAgent/data/load-session-response-item-history-fallback.json
@@ -150,16 +150,11 @@
     {
       "sessionId": "session-legacy",
       "update": {
-        "sessionUpdate": "agent_message_chunk",
-        "messageId": "item-plan-1",
-        "content": {
-          "type": "text",
-          "text": "Inspect project files"
-        },
-        "_meta": {
-          "codex": {
-            "phase": "final_answer"
-          }
+        "sessionUpdate": "plan_update",
+        "plan": {
+          "type": "markdown",
+          "planId": "item-plan-1",
+          "content": "Inspect project files"
         }
       }
     }

--- a/src/__tests__/CodexACPAgent/data/plan-delta-fallback.json
+++ b/src/__tests__/CodexACPAgent/data/plan-delta-fallback.json
@@ -4,16 +4,11 @@
     {
       "sessionId": "test-session-id",
       "update": {
-        "sessionUpdate": "agent_message_chunk",
-        "messageId": "plan-2",
-        "content": {
-          "type": "text",
-          "text": "### Buffered plan\n\n1. Use the buffered fallback."
-        },
-        "_meta": {
-          "codex": {
-            "phase": "final_answer"
-          }
+        "sessionUpdate": "plan_update",
+        "plan": {
+          "type": "markdown",
+          "planId": "plan-2",
+          "content": "### Buffered plan\n\n1. Use the buffered fallback."
         }
       }
     }

--- a/src/__tests__/CodexACPAgent/data/plan-deltas.json
+++ b/src/__tests__/CodexACPAgent/data/plan-deltas.json
@@ -4,16 +4,11 @@
     {
       "sessionId": "test-session-id",
       "update": {
-        "sessionUpdate": "agent_message_chunk",
-        "messageId": "plan-1",
-        "content": {
-          "type": "text",
-          "text": "Completed text should not duplicate the streamed plan."
-        },
-        "_meta": {
-          "codex": {
-            "phase": "final_answer"
-          }
+        "sessionUpdate": "plan_update",
+        "plan": {
+          "type": "markdown",
+          "planId": "plan-1",
+          "content": "Completed text should not duplicate the streamed plan."
         }
       }
     }

--- a/src/__tests__/CodexACPAgent/load-session.test.ts
+++ b/src/__tests__/CodexACPAgent/load-session.test.ts
@@ -551,6 +551,7 @@ describe("CodexACPAgent - loadSession", () => {
             await codexAcpAgent.initialize({
                 protocolVersion: 1,
                 clientCapabilities: {
+                    plan: {},
                     _meta: {
                         terminal_output: true,
                     },

--- a/src/__tests__/CodexACPAgent/load-session.test.ts
+++ b/src/__tests__/CodexACPAgent/load-session.test.ts
@@ -100,6 +100,11 @@ describe("CodexACPAgent - loadSession", () => {
                             content: [],
                         },
                         {
+                            type: "plan",
+                            id: "item-plan-1",
+                            text: "Inspect project files",
+                        },
+                        {
                             type: "commandExecution",
                             id: "item-cmd-1",
                             command: "ls",

--- a/src/__tests__/CodexACPAgent/plan-events.test.ts
+++ b/src/__tests__/CodexACPAgent/plan-events.test.ts
@@ -25,6 +25,10 @@ describe("CodexEventHandler - plan events", () => {
     });
 
     it("emits the authoritative completed plan after buffering deltas", async () => {
+        await mockFixture.getCodexAcpAgent().initialize({
+            protocolVersion: 1,
+            clientCapabilities: {plan: {}},
+        });
         const notifications: ServerNotification[] = [
             {
                 method: "item/started",
@@ -80,6 +84,10 @@ describe("CodexEventHandler - plan events", () => {
     });
 
     it("falls back to buffered deltas when the completed plan is empty", async () => {
+        await mockFixture.getCodexAcpAgent().initialize({
+            protocolVersion: 1,
+            clientCapabilities: {plan: {}},
+        });
         const notifications: ServerNotification[] = [
             {
                 method: "item/plan/delta",
@@ -121,7 +129,7 @@ describe("CodexEventHandler - plan events", () => {
         );
     });
 
-    it("emits the completed plan when no deltas streamed", async () => {
+    it("retains the agent-message fallback when the client does not support plans", async () => {
         const notifications: ServerNotification[] = [
             {
                 method: "item/completed",

--- a/src/__tests__/CodexACPAgent/plan-events.test.ts
+++ b/src/__tests__/CodexACPAgent/plan-events.test.ts
@@ -153,7 +153,11 @@ describe("CodexEventHandler - plan events", () => {
         );
     });
 
-    it("keeps turn plan updates as ACP checklist updates", async () => {
+    it("keeps turn plan updates as standard ACP checklist updates when plan_update is supported", async () => {
+        await mockFixture.getCodexAcpAgent().initialize({
+            protocolVersion: 1,
+            clientCapabilities: {plan: {}},
+        });
         const notifications: ServerNotification[] = [
             {
                 method: "turn/plan/updated",


### PR DESCRIPTION
## Summary

- emit completed live Codex plan artifacts as ACP `plan_update` events when the client advertises the unstable `clientCapabilities.plan` capability
- replay saved plan artifacts through the same capability-dependent representation
- preserve the #326 `agent_message_chunk` fallback for clients without that capability
- leave standard ACP v1 `sessionUpdate: "plan"` execution-plan updates unchanged
- keep completed item text authoritative, with buffered deltas as a fallback

## Rationale

[#326](https://github.com/agentclientprotocol/codex-acp/pull/326) fixed plan visibility by emitting completed Codex plan items as ordinary final-answer messages. That preserves broad client compatibility, but loses the plan semantic: a client cannot reliably distinguish a proposed plan from an ordinary final answer.

ACP currently exposes two related representations:

- standard v1 `sessionUpdate: "plan"`, a complete execution-plan snapshot containing entries, priorities, and progress statuses
- unstable `plan_update`, a richer plan artifact that can preserve Markdown content and a stable `planId`

A completed Codex `ThreadItem` of type `plan` contains authoritative Markdown and a stable item ID. It therefore maps losslessly to a Markdown `plan_update`. Mapping it to the standard entry-based notification would require parsing the Markdown or inventing entry boundaries, priorities, and statuses, and would not preserve equivalent artifact identity.

This PR does not replace or change the standard execution-plan notifications Codex already emits. It only changes the representation of the completed plan artifact when the client explicitly advertises support for the unstable richer update.

## Compatibility

Clients without the unstable Plan capability retain the #326 representation:

- `agent_message_chunk`
- the Codex plan item ID as `messageId`
- `_meta.codex.phase: "final_answer"`

The same choice is applied to live events and replayed session history.

## Open design question

Should a completed Codex plan item be represented by the negotiated richer `plan_update`, as implemented here, or should it be mapped into the standard entry-based `plan` notification? The current implementation chooses the lossless richer representation when negotiated and preserves #326 as the fallback. Feedback on the intended protocol model is welcome.

## Testing

- `npm run typecheck`
- `npx vitest run src/__tests__/CodexACPAgent/load-session.test.ts` — includes legacy replay without Plan capability
- `npm test` — 329 passed, 28 skipped
- `npm run bundle:all` with Bun 1.3.11
- `git diff --check main...HEAD`

## Related work

- follow-up to #326
- [ACP v1 Agent Plan](https://agentclientprotocol.com/protocol/v1/agent-plan)

AI assisted with implementation, test verification, and PR text.
