### PR TITLE
feat: expose rate limits on usage updates

### DIFF
--- a/src/CodexEventHandler.ts
+++ b/src/CodexEventHandler.ts
@@ -26,6 +26,7 @@ import type {
     ThreadItem,
     ModelReroutedNotification,
     PlanDeltaNotification,
+    RateLimitSnapshot,
     ReasoningSummaryPartAddedNotification,
     ReasoningSummaryTextDeltaNotification,
     ReasoningTextDeltaNotification,
@@ -191,6 +192,23 @@ const STRUCTURED_CODEX_ERROR_CATEGORIES = {
     responseTooManyFailedAttempts: "transport_lost",
     activeTurnNotSteerable: "provider_error",
 } satisfies Record<StructuredCodexErrorKind, CodexFailureKind>;
+
+function mergeSparseRateLimitSnapshot(
+    previous: RateLimitSnapshot,
+    update: RateLimitSnapshot
+): RateLimitSnapshot {
+    return {
+        limitId: update.limitId ?? previous.limitId,
+        limitName: update.limitName ?? previous.limitName,
+        primary: update.primary ?? previous.primary,
+        secondary: update.secondary ?? previous.secondary,
+        credits: update.credits ?? previous.credits,
+        individualLimit: update.individualLimit ?? previous.individualLimit,
+        spendControlReached: update.spendControlReached ?? previous.spendControlReached,
+        planType: update.planType ?? previous.planType,
+        rateLimitReachedType: update.rateLimitReachedType ?? previous.rateLimitReachedType,
+    };
+}
 
 export class CodexEventHandler {
 
@@ -1260,11 +1278,33 @@ export class CodexEventHandler {
         if (!this.sessionState.rateLimits) {
             this.sessionState.rateLimits = new Map();
         }
-        const limitId = params.rateLimits.limitId ?? params.rateLimits.limitName ?? "unknown";
+
+        const update = params.rateLimits;
+        let previousKey = update.limitId !== null && this.sessionState.rateLimits.has(update.limitId)
+            ? update.limitId
+            : undefined;
+        if (previousKey === undefined && update.limitName !== null) {
+            previousKey = Array.from(this.sessionState.rateLimits.entries())
+                .find(([, entry]) => entry.limitName === update.limitName)?.[0];
+        }
+        if (previousKey === undefined && update.limitId === null && update.limitName === null) {
+            previousKey = this.sessionState.rateLimits.has("unknown") ? "unknown" : undefined;
+        }
+
+        const previous = previousKey === undefined
+            ? undefined
+            : this.sessionState.rateLimits.get(previousKey);
+        const snapshot = previous
+            ? mergeSparseRateLimitSnapshot(previous.snapshot, update)
+            : update;
+        const limitId = snapshot.limitId ?? previous?.limitId ?? snapshot.limitName ?? "unknown";
+        if (previousKey !== undefined && previousKey !== limitId) {
+            this.sessionState.rateLimits.delete(previousKey);
+        }
         this.sessionState.rateLimits.set(limitId, {
-            limitId: limitId,
-            limitName: params.rateLimits.limitName ?? limitId,
-            snapshot: params.rateLimits,
+            limitId,
+            limitName: snapshot.limitName ?? previous?.limitName ?? limitId,
+            snapshot,
         });
     }
 

--- a/src/CodexEventHandler.ts
+++ b/src/CodexEventHandler.ts
@@ -470,7 +470,7 @@ export class CodexEventHandler {
                 return this.createMcpToolProgressEvent(notification.params);
             case "account/rateLimits/updated":
                 this.handleRateLimitsUpdated(notification.params);
-                return null;
+                return this.createUsageUpdateFromState();
             case "configWarning":
                 return await this.createConfigWarningEvent(notification.params);
             case "warning":
@@ -1229,7 +1229,10 @@ export class CodexEventHandler {
 
     private createUsageUpdate(params: ThreadTokenUsageUpdatedNotification): UpdateSessionEvent | null {
         this.handleTokenUsageUpdated(params);
+        return this.createUsageUpdateFromState();
+    }
 
+    private createUsageUpdateFromState(): UpdateSessionEvent | null {
         const used = this.sessionState.lastTokenUsage?.totalTokens;
         const size = this.sessionState.modelContextWindow;
         if (used == null || size == null || size <= 0) {
@@ -1240,6 +1243,16 @@ export class CodexEventHandler {
             sessionUpdate: "usage_update",
             used,
             size,
+            ...(this.sessionState.rateLimits
+                ? {
+                      _meta: {
+                          "_codex/rateLimits": Array.from(this.sessionState.rateLimits.values(), (entry) => ({
+                              ...entry.snapshot,
+                              limitId: entry.limitId,
+                          })),
+                      },
+                  }
+                : {}),
         };
     }
 

--- a/src/__tests__/CodexACPAgent/data/rate-limits-usage-updates.json
+++ b/src/__tests__/CodexACPAgent/data/rate-limits-usage-updates.json
@@ -1,0 +1,81 @@
+[
+  {
+    "method": "sessionUpdate",
+    "args": [
+      {
+        "sessionId": "test-session-id",
+        "update": {
+          "sessionUpdate": "usage_update",
+          "used": 1000,
+          "size": 128000,
+          "_meta": {
+            "_codex/rateLimits": [
+              {
+                "limitId": "standard-limit",
+                "limitName": "Standard",
+                "primary": {
+                  "usedPercent": 30,
+                  "resetsAt": 1800000000,
+                  "windowDurationMins": 300
+                },
+                "secondary": null,
+                "credits": null,
+                "individualLimit": null,
+                "spendControlReached": null,
+                "planType": null,
+                "rateLimitReachedType": null
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "method": "sessionUpdate",
+    "args": [
+      {
+        "sessionId": "test-session-id",
+        "update": {
+          "sessionUpdate": "usage_update",
+          "used": 1000,
+          "size": 128000,
+          "_meta": {
+            "_codex/rateLimits": [
+              {
+                "limitId": "standard-limit",
+                "limitName": "Standard",
+                "primary": {
+                  "usedPercent": 30,
+                  "resetsAt": 1800000000,
+                  "windowDurationMins": 300
+                },
+                "secondary": null,
+                "credits": null,
+                "individualLimit": null,
+                "spendControlReached": null,
+                "planType": null,
+                "rateLimitReachedType": null
+              },
+              {
+                "limitId": "fast-limit",
+                "limitName": "Fast",
+                "primary": {
+                  "usedPercent": 50,
+                  "resetsAt": 1800500000,
+                  "windowDurationMins": 60
+                },
+                "secondary": null,
+                "credits": null,
+                "individualLimit": null,
+                "spendControlReached": null,
+                "planType": null,
+                "rateLimitReachedType": null
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/src/__tests__/CodexACPAgent/token-usage-events.test.ts
+++ b/src/__tests__/CodexACPAgent/token-usage-events.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ServerNotification } from '../../app-server';
 import { createCodexMockTestFixture, createTestSessionState, type CodexMockTestFixture } from '../acp-test-utils';
-import type { TokenUsageBreakdown } from '../../app-server/v2';
+import type { RateLimitSnapshot, TokenUsageBreakdown } from '../../app-server/v2';
 
 function createTokenUsageNotification(
     sessionId: string,
@@ -18,6 +18,13 @@ function createTokenUsageNotification(
             turnId: 'turn-id',
             tokenUsage,
         },
+    };
+}
+
+function createRateLimitsNotification(rateLimits: RateLimitSnapshot): ServerNotification {
+    return {
+        method: 'account/rateLimits/updated',
+        params: { rateLimits },
     };
 }
 
@@ -240,6 +247,40 @@ describe('Token Usage Events', () => {
             ])();
 
             await expect(`${JSON.stringify(events, null, 2)}\n`).toMatchFileSnapshot('data/token-usage-session-update-multiple.json');
+        });
+
+        it('should emit stored rate limits on usage updates', async () => {
+            const events = await setupPromptAndReturnEvents([
+                createRateLimitsNotification({
+                    limitId: 'standard-limit',
+                    limitName: 'Standard',
+                    primary: { usedPercent: 30, resetsAt: 1_800_000_000, windowDurationMins: 300 },
+                    secondary: null,
+                    credits: null,
+                    individualLimit: null,
+                    spendControlReached: null,
+                    planType: null,
+                    rateLimitReachedType: null,
+                }),
+                createTokenUsageNotification(sessionId, {
+                    total: { totalTokens: 1000, inputTokens: 800, cachedInputTokens: 0, cacheWriteInputTokens: 0, outputTokens: 200, reasoningOutputTokens: 0 },
+                    last: { totalTokens: 1000, inputTokens: 800, cachedInputTokens: 0, cacheWriteInputTokens: 0, outputTokens: 200, reasoningOutputTokens: 0 },
+                    modelContextWindow: 128000,
+                }),
+                createRateLimitsNotification({
+                    limitId: 'fast-limit',
+                    limitName: 'Fast',
+                    primary: { usedPercent: 50, resetsAt: 1_800_500_000, windowDurationMins: 60 },
+                    secondary: null,
+                    credits: null,
+                    individualLimit: null,
+                    spendControlReached: null,
+                    planType: null,
+                    rateLimitReachedType: null,
+                }),
+            ])();
+
+            await expect(`${JSON.stringify(events, null, 2)}\n`).toMatchFileSnapshot('data/rate-limits-usage-updates.json');
         });
 
         it('should skip usage_update when model context window is unavailable', async () => {

--- a/src/__tests__/CodexACPAgent/token-usage-events.test.ts
+++ b/src/__tests__/CodexACPAgent/token-usage-events.test.ts
@@ -283,6 +283,69 @@ describe('Token Usage Events', () => {
             await expect(`${JSON.stringify(events, null, 2)}\n`).toMatchFileSnapshot('data/rate-limits-usage-updates.json');
         });
 
+        it('should preserve known values across sparse rate-limit updates', async () => {
+            const events = await setupPromptAndReturnEvents([
+                createTokenUsageNotification(sessionId, {
+                    total: { totalTokens: 1000, inputTokens: 800, cachedInputTokens: 0, cacheWriteInputTokens: 0, outputTokens: 200, reasoningOutputTokens: 0 },
+                    last: { totalTokens: 1000, inputTokens: 800, cachedInputTokens: 0, cacheWriteInputTokens: 0, outputTokens: 200, reasoningOutputTokens: 0 },
+                    modelContextWindow: 128000,
+                }),
+                createRateLimitsNotification({
+                    limitId: 'standard-limit',
+                    limitName: 'Standard',
+                    primary: { usedPercent: 30, resetsAt: 1_800_000_000, windowDurationMins: 300 },
+                    secondary: { usedPercent: 60, resetsAt: 1_800_500_000, windowDurationMins: 1440 },
+                    credits: { hasCredits: true, unlimited: false, balance: '12.50' },
+                    individualLimit: { limit: '100.00', used: '25.00', remainingPercent: 75, resetsAt: 1_801_000_000 },
+                    spendControlReached: false,
+                    planType: 'plus',
+                    rateLimitReachedType: 'rate_limit_reached',
+                }),
+                createRateLimitsNotification({
+                    limitId: null,
+                    limitName: 'Standard',
+                    primary: { usedPercent: 35, resetsAt: 1_800_100_000, windowDurationMins: 300 },
+                    secondary: null,
+                    credits: null,
+                    individualLimit: null,
+                    spendControlReached: null,
+                    planType: null,
+                    rateLimitReachedType: null,
+                }),
+                createRateLimitsNotification({
+                    limitId: 'standard-limit',
+                    limitName: null,
+                    primary: null,
+                    secondary: { usedPercent: 65, resetsAt: 1_800_600_000, windowDurationMins: 1440 },
+                    credits: null,
+                    individualLimit: null,
+                    spendControlReached: null,
+                    planType: null,
+                    rateLimitReachedType: null,
+                }),
+            ])();
+
+            expect(events.at(-1)).toMatchObject({
+                args: [{
+                    update: {
+                        _meta: {
+                            '_codex/rateLimits': [{
+                                limitId: 'standard-limit',
+                                limitName: 'Standard',
+                                primary: { usedPercent: 35, resetsAt: 1_800_100_000, windowDurationMins: 300 },
+                                secondary: { usedPercent: 65, resetsAt: 1_800_600_000, windowDurationMins: 1440 },
+                                credits: { hasCredits: true, unlimited: false, balance: '12.50' },
+                                individualLimit: { limit: '100.00', used: '25.00', remainingPercent: 75, resetsAt: 1_801_000_000 },
+                                spendControlReached: false,
+                                planType: 'plus',
+                                rateLimitReachedType: 'rate_limit_reached',
+                            }],
+                        },
+                    },
+                }],
+            });
+        });
+
         it('should skip usage_update when model context window is unavailable', async () => {
             const events = await setupPromptAndReturnEvents([
                 createTokenUsageNotification(sessionId, {


### PR DESCRIPTION
## Problem

ACP clients receive context usage but cannot display current Codex account limits or refresh them when account/rateLimits/updated arrives independently of token usage.

## Change

Expose current rate-limit snapshots as _meta["_codex/rateLimits"] in usage_update and emit the same update after account limit changes. This revision is rebased onto current main and uses the implementation tested in our 1.12.0 backport.

Removed this PR's obsolete sparse rate-limit merging changes. Upstream's current mergeRateLimitSnapshot rules remain unchanged, including missing limitId handling and window updates.

## Validation

- npm run build and npm run typecheck pass.
- npm test: 666 passed, 26 skipped.
- Focused regression coverage verifies rate-limit-only notifications and retained upstream merging behavior.
- Release backport previously completed a live no-tools prompt with token usage. An isolated live Plan smoke also passed on this revision: rejection caused no file creation; a subsequent approval continued and created only the requested temporary file.

The release-based Anvil fork PR remains pinned to its existing source revision; updating this upstream PR does not change the generated downstream patch.

AI assisted implementation, tests and rebase.
