### PR TITLE
fix: persist ACP session config in Codex threads

### DIFF
--- a/src/AcpExtensions.ts
+++ b/src/AcpExtensions.ts
@@ -34,6 +34,7 @@ export type LegacyNewSessionResponse = NewSessionResponse & {
 }
 
 export type LegacyLoadSessionResponse = LoadSessionResponse & {
+    sessionId: SessionId;
     models?: LegacySessionModelState | null;
 }
 

--- a/src/AgentMode.ts
+++ b/src/AgentMode.ts
@@ -96,6 +96,18 @@ export class AgentMode {
         return match ?? null;
     }
 
+    static fromSettings(
+        approvalPolicy: AskForApproval | undefined,
+        sandboxPolicy: SandboxPolicy | undefined,
+    ): AgentMode | null {
+        if (!sandboxPolicy) return null;
+        const match = AgentMode.all().find(mode =>
+            mode.approvalPolicy === approvalPolicy
+            && mode.sandboxPolicy.type === sandboxPolicy.type
+        );
+        return match ?? null;
+    }
+
     static getInitialAgentMode(): AgentMode {
         const predefinedAgentMode = process.env["INITIAL_AGENT_MODE"];
         if (predefinedAgentMode) {

--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -691,7 +691,7 @@ export class CodexAcpClient {
 
     async sendPrompt(
         request: acp.PromptRequest,
-        agentMode: AgentMode,
+        getAgentMode: () => AgentMode,
         modelId: ModelId,
         serviceTier: ServiceTier | null,
         disableSummary: boolean,
@@ -706,6 +706,7 @@ export class CodexAcpClient {
         if (shouldCancel?.()) {
             return null;
         }
+        const agentMode = getAgentMode();
         return await this.codexClient.runTurn({
             threadId: request.sessionId,
             input: input,

--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -343,6 +343,8 @@ export class CodexAcpClient {
             sessionId: request.sessionId,
             currentModelId: currentModelId,
             models: codexModels,
+            agentMode: AgentMode.fromSettings(response.approvalPolicy, response.sandbox)
+                ?? AgentMode.getInitialAgentMode(),
             collaborationMode: this.getCollaborationMode(response.thread.id),
             modelProvider: response.modelProvider,
             currentServiceTier: response.serviceTier as ServiceTier ?? null,
@@ -371,6 +373,8 @@ export class CodexAcpClient {
             sessionId: request.sessionId,
             currentModelId: currentModelId,
             models: codexModels,
+            agentMode: AgentMode.fromSettings(response.approvalPolicy, response.sandbox)
+                ?? AgentMode.getInitialAgentMode(),
             collaborationMode: this.getCollaborationMode(response.thread.id),
             modelProvider: response.modelProvider,
             currentServiceTier: response.serviceTier as ServiceTier ?? null,
@@ -398,6 +402,8 @@ export class CodexAcpClient {
             sessionId: response.thread.id,
             currentModelId: currentModelId,
             models: codexModels,
+            agentMode: AgentMode.fromSettings(response.approvalPolicy, response.sandbox)
+                ?? AgentMode.getInitialAgentMode(),
             collaborationMode: this.getCollaborationMode(response.thread.id),
             modelProvider: response.modelProvider,
             currentServiceTier: response.serviceTier as ServiceTier ?? null,
@@ -719,6 +725,23 @@ export class CodexAcpClient {
         });
     }
 
+    async setAgentMode(sessionId: string, mode: AgentMode): Promise<void> {
+        await this.codexClient.threadSettingsUpdate({
+            threadId: sessionId,
+            approvalPolicy: mode.approvalPolicy,
+            sandboxPolicy: mode.sandboxPolicy,
+        });
+    }
+
+    async setModelAndEffort(sessionId: string, currentModelId: string): Promise<void> {
+        const modelId = ModelId.fromString(currentModelId);
+        await this.codexClient.threadSettingsUpdate({
+            threadId: sessionId,
+            model: modelId.model,
+            effort: modelId.effort as ReasoningEffort,
+        });
+    }
+
     private getCollaborationMode(sessionId: string): ModeKind {
         return this.codexClient.getThreadSettings(sessionId)?.collaborationMode.mode ?? "default";
     }
@@ -897,6 +920,7 @@ export type SessionMetadata = {
     sessionId: string,
     currentModelId: string,
     models: Model[],
+    agentMode?: AgentMode,
     collaborationMode: ModeKind,
     modelProvider?: string | null,
     currentServiceTier?: ServiceTier | null,

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -1993,7 +1993,6 @@ export class CodexAcpServer {
             if (!sessionState.supportedInputModalities.includes("image") && params.prompt.some(b => b.type === "image")) {
                 throw RequestError.invalidRequest("The current model does not support image input");
             }
-            const agentMode = sessionState.agentMode;
             const serviceTier = resolveFastServiceTier(
                 sessionState.fastModeEnabled,
                 sessionState.currentModelSupportsFast,
@@ -2002,7 +2001,7 @@ export class CodexAcpServer {
             const sendPromptPromise = this.runWithProcessCheck(
                 () => this.codexAcpClient.sendPrompt(
                     params,
-                    agentMode,
+                    () => sessionState.agentMode,
                     modelId,
                     serviceTier,
                     disableSummary,

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -448,7 +448,7 @@ export class CodexAcpServer {
             availableModels: models,
             supportedReasoningEfforts: currentModel?.supportedReasoningEfforts ?? [],
             supportedInputModalities: currentModel?.inputModalities ?? ["text", "image"],
-            agentMode: AgentMode.getInitialAgentMode(),
+            agentMode: sessionMetadata.agentMode ?? AgentMode.getInitialAgentMode(),
             collaborationMode: sessionMetadata.collaborationMode,
             currentTurnId: null,
             lastTokenUsage: null,
@@ -728,7 +728,7 @@ export class CodexAcpServer {
         const sessionState = this.sessions.get(_params.sessionId);
         if (!sessionState) throw new Error(`Session ${_params.sessionId} not found`);
 
-        this.applyModeChange(sessionState, _params.modeId);
+        await this.applyModeChange(sessionState, _params.modeId);
         return {};
     }
 
@@ -753,16 +753,16 @@ export class CodexAcpServer {
                 this.applyFastModeChange(sessionState, params);
                 break;
             case MODE_CONFIG_ID:
-                this.applyModeChange(sessionState, this.stringConfigValue(params));
+                await this.applyModeChange(sessionState, this.stringConfigValue(params));
                 break;
             case COLLABORATION_MODE_CONFIG_ID:
                 await this.applyCollaborationModeChange(sessionState, this.stringConfigValue(params));
                 break;
             case MODEL_CONFIG_ID:
-                this.applyModelChange(sessionState, this.stringConfigValue(params));
+                await this.applyModelChange(sessionState, this.stringConfigValue(params));
                 break;
             case REASONING_EFFORT_CONFIG_ID:
-                this.applyReasoningEffortChange(sessionState, this.stringConfigValue(params));
+                await this.applyReasoningEffortChange(sessionState, this.stringConfigValue(params));
                 break;
             default:
                 throw RequestError.invalidParams();
@@ -788,11 +788,12 @@ export class CodexAcpServer {
         return params.value;
     }
 
-    private applyModeChange(sessionState: SessionState, value: string): void {
+    private async applyModeChange(sessionState: SessionState, value: string): Promise<void> {
         const newMode = AgentMode.find(value);
         if (!newMode) {
             throw RequestError.invalidParams();
         }
+        await this.codexAcpClient.setAgentMode(sessionState.sessionId, newMode);
         sessionState.agentMode = newMode;
     }
 
@@ -805,7 +806,7 @@ export class CodexAcpServer {
         sessionState.collaborationMode = mode;
     }
 
-    private applyModelChange(sessionState: SessionState, value: string): void {
+    private async applyModelChange(sessionState: SessionState, value: string): Promise<void> {
         const model = sessionState.availableModels.find(m => m.id === value);
         if (!model) {
             const currentModel = ModelId.fromString(sessionState.currentModelId).model;
@@ -817,16 +818,22 @@ export class CodexAcpServer {
         const currentEffort = ModelId.fromString(sessionState.currentModelId).effort;
         const effort = findSupportedEffort(model.supportedReasoningEfforts, currentEffort)
             ?? model.defaultReasoningEffort;
+        await this.codexAcpClient.setModelAndEffort(
+            sessionState.sessionId,
+            ModelId.fromComponents(model, effort).toString(),
+        );
         this.applyModelAndEffort(sessionState, model, effort);
     }
 
-    private applyReasoningEffortChange(sessionState: SessionState, value: string): void {
+    private async applyReasoningEffortChange(sessionState: SessionState, value: string): Promise<void> {
         const effort = findSupportedEffort(sessionState.supportedReasoningEfforts, value);
         if (!effort) {
             throw RequestError.invalidParams();
         }
         const {model} = ModelId.fromString(sessionState.currentModelId);
-        sessionState.currentModelId = ModelId.create(model, effort).toString();
+        const currentModelId = ModelId.create(model, effort).toString();
+        await this.codexAcpClient.setModelAndEffort(sessionState.sessionId, currentModelId);
+        sessionState.currentModelId = currentModelId;
     }
 
     private applyModelAndEffort(sessionState: SessionState, model: Model, effort: ReasoningEffort): void {
@@ -862,6 +869,10 @@ export class CodexAcpServer {
         }
 
         sessionState.availableModels = models;
+        await this.codexAcpClient.setModelAndEffort(
+            sessionState.sessionId,
+            ModelId.fromComponents(model, reasoningEffort).toString(),
+        );
         this.applyModelAndEffort(sessionState, model, reasoningEffort);
 
         return {};
@@ -1290,7 +1301,7 @@ export class CodexAcpServer {
             availableModels: models,
             supportedReasoningEfforts: currentModel?.supportedReasoningEfforts ?? [],
             supportedInputModalities: currentModel?.inputModalities ?? ["text", "image"],
-            agentMode: AgentMode.getInitialAgentMode(),
+            agentMode: sessionMetadata.agentMode ?? AgentMode.getInitialAgentMode(),
             collaborationMode: sessionMetadata.collaborationMode,
             currentTurnId: null,
             lastTokenUsage: null,

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -538,6 +538,7 @@ export class CodexAcpServer {
             availableModelCount: modelState.availableModels.length
         });
         return {
+            sessionId,
             models: modelState,
             modes: modeState,
             ...this.createSessionConfigOptionsResponse(this.getSessionState(sessionId)),

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -793,8 +793,14 @@ export class CodexAcpServer {
         if (!newMode) {
             throw RequestError.invalidParams();
         }
-        await this.codexAcpClient.setAgentMode(sessionState.sessionId, newMode);
+        const previousMode = sessionState.agentMode;
         sessionState.agentMode = newMode;
+        try {
+            await this.codexAcpClient.setAgentMode(sessionState.sessionId, newMode);
+        } catch (error) {
+            sessionState.agentMode = previousMode;
+            throw error;
+        }
     }
 
     private async applyCollaborationModeChange(sessionState: SessionState, value: string): Promise<void> {

--- a/src/CodexAppServerClient.ts
+++ b/src/CodexAppServerClient.ts
@@ -3,9 +3,11 @@ import type {
     ClientRequest,
     InitializeParams,
     InitializeResponse,
+    ReasoningEffort,
     ServerNotification
 } from "./app-server";
 import type {
+    AskForApproval,
     ConfigReadParams,
     ConfigReadResponse,
     GetAccountParams,
@@ -63,6 +65,7 @@ import type {
     TurnStartResponse,
     TurnSteerParams,
     TurnSteerResponse,
+    SandboxPolicy,
     CommandExecutionRequestApprovalParams,
     CommandExecutionRequestApprovalResponse,
     FileChangeRequestApprovalParams,
@@ -532,7 +535,7 @@ export class CodexAppServerClient {
         return this.threadSettings.get(threadId);
     }
 
-    async threadSettingsUpdate(params: ExperimentalThreadSettingsUpdateParams): Promise<void> {
+    async threadSettingsUpdate(params: ThreadSettingsUpdateParams): Promise<void> {
         await this.connection.sendRequest("thread/settings/update", params);
     }
 
@@ -974,9 +977,13 @@ type DistributiveOmit<T, K extends keyof any> = T extends any
     ? Omit<T, K>
     : never;
 
-export interface ExperimentalThreadSettingsUpdateParams {
+export interface ThreadSettingsUpdateParams {
     threadId: string;
-    collaborationMode: {
+    approvalPolicy?: AskForApproval;
+    sandboxPolicy?: SandboxPolicy;
+    model?: string;
+    effort?: ReasoningEffort;
+    collaborationMode?: {
         mode: "default" | "plan";
         settings: {
             model: string;

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -454,7 +454,7 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         });
     });
 
-    it('restores collaboration mode for resumed and loaded sessions', async () => {
+    it('restores collaboration and agent modes for resumed and loaded sessions', async () => {
         const mockFixture = createCodexMockTestFixture();
         const codexAcpAgent = mockFixture.getCodexAcpAgent();
         const codexAcpClient = mockFixture.getCodexAcpClient();
@@ -483,6 +483,8 @@ describe('ACP server test', { timeout: 40_000 }, () => {
                 modelProvider: "openai",
                 reasoningEffort: "medium",
                 serviceTier: null,
+                approvalPolicy: "never",
+                sandbox: {type: "dangerFullAccess"},
             } as any;
         });
         vi.spyOn(codexAppServerClient, "threadRead").mockImplementation(async ({threadId}) => ({
@@ -505,8 +507,12 @@ describe('ACP server test', { timeout: 40_000 }, () => {
 
         expect(codexAcpAgent.getSessionState("resume-id").collaborationMode).toBe("plan");
         expect(codexAcpAgent.getSessionState("load-id").collaborationMode).toBe("plan");
+        expect(codexAcpAgent.getSessionState("resume-id").agentMode).toBe(AgentMode.AgentFullAccess);
+        expect(codexAcpAgent.getSessionState("load-id").agentMode).toBe(AgentMode.AgentFullAccess);
         expect(resumed.configOptions?.find(option => option.id === "collaboration_mode")).toMatchObject({currentValue: "plan"});
         expect(loaded.configOptions?.find(option => option.id === "collaboration_mode")).toMatchObject({currentValue: "plan"});
+        expect(resumed.configOptions?.find(option => option.id === "mode")).toMatchObject({currentValue: "agent-full-access"});
+        expect(loaded.configOptions?.find(option => option.id === "mode")).toMatchObject({currentValue: "agent-full-access"});
     });
 
     it('uses configured model provider when resuming sessions without an explicit provider', async () => {

--- a/src/__tests__/CodexACPAgent/fast-mode-config.test.ts
+++ b/src/__tests__/CodexACPAgent/fast-mode-config.test.ts
@@ -47,6 +47,7 @@ describe("Fast mode session config", () => {
             currentServiceTier,
             additionalDirectories: [],
         });
+        vi.spyOn((codexAcpClient as any).codexClient, "threadSettingsUpdate").mockResolvedValue(undefined);
 
         await codexAcpAgent.initialize({
             protocolVersion: acp.PROTOCOL_VERSION,

--- a/src/__tests__/CodexACPAgent/load-session.test.ts
+++ b/src/__tests__/CodexACPAgent/load-session.test.ts
@@ -216,8 +216,9 @@ describe("CodexACPAgent - loadSession", () => {
             cwd: "/test/project",
             mcpServers: [],
         };
-        await codexAcpAgent.loadSession(loadParams);
+        const response = await codexAcpAgent.loadSession(loadParams);
 
+        expect(response.sessionId).toBe(thread.id);
         expect(codexAppServerClient.threadRead).toHaveBeenCalledWith({
             threadId: thread.id,
             includeTurns: true,

--- a/src/__tests__/CodexACPAgent/session-config-options.test.ts
+++ b/src/__tests__/CodexACPAgent/session-config-options.test.ts
@@ -206,6 +206,35 @@ describe("Session config options", () => {
         await modeChange;
     });
 
+    it("uses a new agent mode when it changes during prompt preparation", async () => {
+        const {fast} = buildModels();
+        const {fixture, codexAcpAgent} = await createSession("fast-model[medium]", [fast]);
+        const sessionState = codexAcpAgent.getSessionState("session-id");
+        const turnStartSpy = mockPromptTurn(fixture, sessionState.sessionId);
+        const skillRefresh = deferred<{data: []}>();
+        const listSkillsSpy = vi.spyOn(fixture.getCodexAppServerClient(), "listSkills")
+            .mockReturnValue(skillRefresh.promise);
+
+        const prompt = codexAcpAgent.prompt({
+            sessionId: sessionState.sessionId,
+            prompt: [{type: "text", text: "test"}],
+        });
+        await vi.waitFor(() => expect(listSkillsSpy).toHaveBeenCalled());
+
+        await codexAcpAgent.setSessionConfigOption({
+            sessionId: sessionState.sessionId,
+            configId: MODE_CONFIG_ID,
+            value: AgentMode.AgentFullAccess.id,
+        });
+        skillRefresh.resolve({data: []});
+        await prompt;
+
+        expect(turnStartSpy).toHaveBeenCalledWith(expect.objectContaining({
+            approvalPolicy: AgentMode.AgentFullAccess.approvalPolicy,
+            sandboxPolicy: AgentMode.AgentFullAccess.sandboxPolicy,
+        }));
+    });
+
     it("rolls back the agent mode when thread persistence fails", async () => {
         const {fast} = buildModels();
         const {codexAcpAgent, update} = await createSession("fast-model[medium]", [fast]);

--- a/src/__tests__/CodexACPAgent/session-config-options.test.ts
+++ b/src/__tests__/CodexACPAgent/session-config-options.test.ts
@@ -49,9 +49,11 @@ async function createSession(currentModelId: string, availableModels: Array<Mode
         collaborationMode: "default",
         additionalDirectories: [],
     });
+    const update = vi.spyOn((codexAcpClient as any).codexClient, "threadSettingsUpdate")
+        .mockResolvedValue(undefined);
 
     const response = await codexAcpAgent.newSession({cwd: "/test/cwd", mcpServers: []});
-    return {fixture, codexAcpAgent, codexAcpClient, response};
+    return {fixture, codexAcpAgent, codexAcpClient, response, update};
 }
 
 describe("Session config options", () => {
@@ -141,7 +143,7 @@ describe("Session config options", () => {
 
     it("changes the agent mode via setSessionConfigOption", async () => {
         const {fast} = buildModels();
-        const {codexAcpAgent} = await createSession("fast-model[medium]", [fast]);
+        const {codexAcpAgent, update} = await createSession("fast-model[medium]", [fast]);
 
         const result = await codexAcpAgent.setSessionConfigOption({
             sessionId: "session-id",
@@ -150,14 +152,18 @@ describe("Session config options", () => {
         });
 
         expect(codexAcpAgent.getSessionState("session-id").agentMode).toBe(AgentMode.ReadOnly);
+        expect(update).toHaveBeenCalledWith({
+            threadId: "session-id",
+            approvalPolicy: AgentMode.ReadOnly.approvalPolicy,
+            sandboxPolicy: AgentMode.ReadOnly.sandboxPolicy,
+        });
         const modeOption = result.configOptions?.find(o => o.id === MODE_CONFIG_ID);
         expect((modeOption as any).currentValue).toBe(AgentMode.ReadOnly.id);
     });
 
     it("changes collaboration mode without starting a model turn", async () => {
         const {fast} = buildModels();
-        const {codexAcpAgent, codexAcpClient} = await createSession("fast-model[medium]", [fast]);
-        const update = vi.spyOn((codexAcpClient as any).codexClient, "threadSettingsUpdate").mockResolvedValue(undefined);
+        const {codexAcpAgent, update} = await createSession("fast-model[medium]", [fast]);
 
         const result = await codexAcpAgent.setSessionConfigOption({
             sessionId: "session-id",
@@ -175,8 +181,7 @@ describe("Session config options", () => {
 
     it("toggles collaboration mode with /plan without starting a model turn", async () => {
         const {fast} = buildModels();
-        const {fixture, codexAcpAgent, codexAcpClient} = await createSession("fast-model[medium]", [fast]);
-        const update = vi.spyOn((codexAcpClient as any).codexClient, "threadSettingsUpdate").mockResolvedValue(undefined);
+        const {fixture, codexAcpAgent, update} = await createSession("fast-model[medium]", [fast]);
         const turnStart = vi.spyOn(fixture.getCodexAppServerClient(), "turnStart");
 
         const enabledResponse = await codexAcpAgent.prompt({
@@ -230,7 +235,7 @@ describe("Session config options", () => {
 
     it("changes the model and keeps the current reasoning effort when supported", async () => {
         const {fast, slow} = buildModels();
-        const {codexAcpAgent} = await createSession("fast-model[medium]", [fast, slow]);
+        const {codexAcpAgent, update} = await createSession("fast-model[medium]", [fast, slow]);
 
         await codexAcpAgent.setSessionConfigOption({
             sessionId: "session-id",
@@ -239,6 +244,11 @@ describe("Session config options", () => {
         });
 
         expect(codexAcpAgent.getSessionState("session-id").currentModelId).toBe("slow-model[medium]");
+        expect(update).toHaveBeenCalledWith({
+            threadId: "session-id",
+            model: "slow-model",
+            effort: "medium",
+        });
     });
 
     it("falls back to the new model's default effort when the current effort is unsupported", async () => {
@@ -256,7 +266,7 @@ describe("Session config options", () => {
 
     it("changes only the reasoning effort", async () => {
         const {fast} = buildModels();
-        const {codexAcpAgent} = await createSession("fast-model[medium]", [fast]);
+        const {codexAcpAgent, update} = await createSession("fast-model[medium]", [fast]);
 
         await codexAcpAgent.setSessionConfigOption({
             sessionId: "session-id",
@@ -265,6 +275,11 @@ describe("Session config options", () => {
         });
 
         expect(codexAcpAgent.getSessionState("session-id").currentModelId).toBe("fast-model[high]");
+        expect(update).toHaveBeenCalledWith({
+            threadId: "session-id",
+            model: "fast-model",
+            effort: "high",
+        });
     });
 
     it("refreshes the cached model list when unstable_setSessionModel picks a freshly fetched model", async () => {
@@ -292,6 +307,7 @@ describe("Session config options", () => {
             defaultReasoningEffort: "medium",
         });
         vi.spyOn(codexAcpClient, "fetchAvailableModels").mockResolvedValue([fast, extraModel]);
+        vi.spyOn((codexAcpClient as any).codexClient, "threadSettingsUpdate").mockResolvedValue(undefined);
 
         await codexAcpAgent.unstable_setSessionModel({
             sessionId: "session-id",

--- a/src/__tests__/CodexACPAgent/session-config-options.test.ts
+++ b/src/__tests__/CodexACPAgent/session-config-options.test.ts
@@ -1,5 +1,9 @@
 import {describe, expect, it, vi} from "vitest";
-import {createCodexMockTestFixture, createTestModel} from "../acp-test-utils";
+import {
+    createCodexMockTestFixture,
+    createTestModel,
+    mockPromptTurn,
+} from "../acp-test-utils";
 import {AgentMode, MODE_CONFIG_ID} from "../../AgentMode";
 import {
     MODEL_CONFIG_ID,
@@ -15,6 +19,17 @@ import {
 const lowEffort: ReasoningEffortOption = {reasoningEffort: "low", description: "Fast"};
 const mediumEffort: ReasoningEffortOption = {reasoningEffort: "medium", description: "Balanced"};
 const highEffort: ReasoningEffortOption = {reasoningEffort: "high", description: "Thorough"};
+
+function deferred<T>(): {
+    promise: Promise<T>;
+    resolve: (value: T | PromiseLike<T>) => void;
+} {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    const promise = new Promise<T>((resolvePromise) => {
+        resolve = resolvePromise;
+    });
+    return {promise, resolve};
+}
 
 function buildModels(): {fast: Model; slow: Model} {
     const fast = createTestModel({
@@ -159,6 +174,51 @@ describe("Session config options", () => {
         });
         const modeOption = result.configOptions?.find(o => o.id === MODE_CONFIG_ID);
         expect((modeOption as any).currentValue).toBe(AgentMode.ReadOnly.id);
+    });
+
+    it("uses a new agent mode for prompts while thread persistence is pending", async () => {
+        const {fast} = buildModels();
+        const {fixture, codexAcpAgent, update} = await createSession("fast-model[medium]", [fast]);
+        const sessionState = codexAcpAgent.getSessionState("session-id");
+        const turnStartSpy = mockPromptTurn(fixture, sessionState.sessionId);
+        const persistence = deferred<void>();
+        update.mockReturnValue(persistence.promise);
+
+        const modeChange = codexAcpAgent.setSessionConfigOption({
+            sessionId: sessionState.sessionId,
+            configId: MODE_CONFIG_ID,
+            value: AgentMode.AgentFullAccess.id,
+        });
+
+        expect(sessionState.agentMode).toBe(AgentMode.AgentFullAccess);
+
+        await codexAcpAgent.prompt({
+            sessionId: sessionState.sessionId,
+            prompt: [{type: "text", text: "test"}],
+        });
+
+        expect(turnStartSpy).toHaveBeenCalledWith(expect.objectContaining({
+            approvalPolicy: AgentMode.AgentFullAccess.approvalPolicy,
+            sandboxPolicy: AgentMode.AgentFullAccess.sandboxPolicy,
+        }));
+
+        persistence.resolve();
+        await modeChange;
+    });
+
+    it("rolls back the agent mode when thread persistence fails", async () => {
+        const {fast} = buildModels();
+        const {codexAcpAgent, update} = await createSession("fast-model[medium]", [fast]);
+        const sessionState = codexAcpAgent.getSessionState("session-id");
+        update.mockRejectedValue(new Error("settings update failed"));
+
+        await expect(codexAcpAgent.setSessionConfigOption({
+            sessionId: sessionState.sessionId,
+            configId: MODE_CONFIG_ID,
+            value: AgentMode.AgentFullAccess.id,
+        })).rejects.toThrow("settings update failed");
+
+        expect(sessionState.agentMode).toBe(AgentMode.Agent);
     });
 
     it("changes collaboration mode without starting a model turn", async () => {


### PR DESCRIPTION
## Summary

- persist mode, model, and reasoning-effort changes immediately with thread/settings/update
- restore the ACP agent mode from Codex approval and sandbox settings on session resume/load
- apply mode changes to in-memory session state before persistence completes
- resolve the current mode after asynchronous prompt preparation so a resumed first turn cannot overwrite full access with a stale Agent snapshot
- return the legacy sessionId field from session/load so persistent ACP clients can retain the loaded Codex thread

## Why

Session config was split between adapter memory and Codex thread state. Reasoning effort could revert after one turn, and agent mode could revert when the ACP worker restarted. AoE also restores Agent (full access) asynchronously after session/load, which exposed a second race: a queued first prompt could capture Agent mode, pause during skill refresh, then start with on-request approval even though full access had already been restored.

Codex 0.145 supports model, effort, approval policy, and sandbox policy in thread/settings/update. Persisting those values makes the Codex thread authoritative. Reading them back on resume restores the ACP picker state, and resolving the mode immediately before turn/start prevents stale prompt-preparation snapshots.

The legacy sessionId response is required by persistent ACP clients that validate session/new and session/load uniformly and cache the returned thread identifier for the next worker restart.

Fixes #336.

## Test plan

- npm test: 332 passed, 28 skipped
- npm run typecheck
- npm run build
- focused regression: prompt starts and pauses in skill refresh, full access is applied, then turn/start uses approvalPolicy never and dangerFullAccess
- real AoE cold-resume E2E with a disposable Codex structured-view session: queue the first prompt during worker session/load, execute a write outside the workspace, observe zero ApprovalRequested events, and confirm the Codex turn_context records approval_policy never with danger-full-access
