### PR TITLE
feat: name Codex threads from session/new _meta.sessionTitle

### DIFF
--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -389,6 +389,8 @@ export class CodexAcpClient {
             cwd: request.cwd,
         });
 
+        const sessionTitle = await this.applySessionTitle(response.thread.id, request._meta);
+
         const codexModels = await this.fetchAvailableModels();
         if (codexModels.length === 0) {
             throw new Error("Codex did not return any models");
@@ -402,7 +404,31 @@ export class CodexAcpClient {
             modelProvider: response.modelProvider,
             currentServiceTier: response.serviceTier as ServiceTier ?? null,
             additionalDirectories,
+            sessionTitle,
         };
+    }
+
+    /**
+     * Name the thread from `_meta.sessionTitle`, supplied out of band by the
+     * client so the title never enters the prompt.
+     *
+     * Returns the applied title, or `null` when none was requested or the
+     * naming request failed. Naming is cosmetic: a failure must not fail
+     * session creation, so errors are logged and swallowed.
+     */
+    private async applySessionTitle(
+        threadId: string,
+        meta?: Record<string, unknown> | null,
+    ): Promise<string | null> {
+        const title = readMetaSessionTitle(meta);
+        if (!title) return null;
+        try {
+            await this.codexClient.threadSetName({threadId, name: title});
+            return title;
+        } catch (err) {
+            logger.error(`Failed to set thread name for ${threadId}`, err);
+            return null;
+        }
     }
 
     async closeSession(sessionId: string): Promise<void> {
@@ -901,6 +927,12 @@ export type SessionMetadata = {
     modelProvider?: string | null,
     currentServiceTier?: ServiceTier | null,
     additionalDirectories: string[],
+    /**
+     * Title applied to the thread from `_meta.sessionTitle`, or `null` when
+     * none was requested. Reported back so the caller can seed its title state
+     * synchronously and not let a fallback title overwrite an explicit one.
+     */
+    sessionTitle?: string | null,
 }
 
 export type SessionMetadataWithThread = SessionMetadata & {
@@ -998,6 +1030,15 @@ function readMetaAdditionalRoots(meta?: Record<string, unknown> | null): string[
         .filter((value): value is string => typeof value === "string")
         .map(value => value.trim())
         .filter(value => value.length > 0));
+}
+
+function readMetaSessionTitle(meta?: Record<string, unknown> | null): string | null {
+    const rawTitle = meta?.["sessionTitle"];
+    if (typeof rawTitle !== "string") {
+        return null;
+    }
+    const title = rawTitle.replace(/\s+/g, " ").trim();
+    return title.length > 0 ? title : null;
 }
 
 function readAdditionalDirectories(cwd: string, additionalDirectories?: string[],  meta?: Record<string, unknown> | null): string[] {

--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -1032,12 +1032,38 @@ function readMetaAdditionalRoots(meta?: Record<string, unknown> | null): string[
         .filter(value => value.length > 0));
 }
 
+/** Upper bound on the length of a title requested through `_meta`. */
+const SESSION_TITLE_MAX_CHARS = 80;
+
+/**
+ * Read and sanitize the title requested in `_meta.sessionTitle`.
+ *
+ * Whitespace collapses to single spaces, control and format characters are
+ * dropped, and the result is capped at [`SESSION_TITLE_MAX_CHARS`] code points.
+ * Returns `null` when the value is absent, not a string, or has nothing
+ * printable left.
+ *
+ * This is the ACP boundary for arbitrary clients, and Codex's own thread-name
+ * normalization only trims: without a cap and a control-character filter an
+ * unbounded or invisible-character title would be persisted verbatim into the
+ * Codex thread store.
+ */
 function readMetaSessionTitle(meta?: Record<string, unknown> | null): string | null {
     const rawTitle = meta?.["sessionTitle"];
     if (typeof rawTitle !== "string") {
         return null;
     }
-    const title = rawTitle.replace(/\s+/g, " ").trim();
+    const collapsed = rawTitle
+        // Whitespace controls become spaces before the control filter runs, so
+        // a newline separates words instead of joining them.
+        .replace(/\s/gu, " ")
+        // Cc/Cf/Cs carry no printable meaning; Cf covers zero-width spaces and
+        // bidi overrides, Cs covers lone surrogates.
+        .replace(/[\p{Cc}\p{Cf}\p{Cs}]/gu, "")
+        .replace(/ +/g, " ")
+        .trim();
+    // Slice by code point, not by UTF-16 unit, so the cap can't split a pair.
+    const title = Array.from(collapsed).slice(0, SESSION_TITLE_MAX_CHARS).join("").trimEnd();
     return title.length > 0 ? title : null;
 }
 

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -465,8 +465,12 @@ export class CodexAcpServer {
             sessionMcpServers: sessionMcpServers,
             terminalOutputMode: this.terminalOutputMode,
             goalRevision: 0,
-            sessionTitle: null,
-            sessionTitleSource: "sessionId" in request ? "unknown" : "unset",
+            sessionTitle: sessionMetadata.sessionTitle ?? null,
+            // Seed from the title the client already applied, so a later
+            // fallback title cannot overwrite an explicit one.
+            sessionTitleSource: "sessionId" in request
+                ? "unknown"
+                : (sessionMetadata.sessionTitle ? "explicit" : "unset"),
         };
         this.sessions.set(sessionId, sessionState);
         resumeSubscribed = false;

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -475,6 +475,10 @@ export class CodexAcpServer {
         this.sessions.set(sessionId, sessionState);
         resumeSubscribed = false;
 
+        if (sessionState.sessionTitleSource === "explicit" && sessionState.sessionTitle) {
+            this.publishExplicitSessionTitleAsync(sessionId, sessionGeneration, sessionState.sessionTitle);
+        }
+
         if (requestedMcpServers.length > 0 && mcpServerStartupVersion !== null) {
             this.pendingMcpStartupSessions.set(sessionId, {
                 requestedServers: new Set(getRequestedMcpServerNames(requestedMcpServers)),
@@ -1592,6 +1596,48 @@ export class CodexAcpServer {
 
     private publishMcpStartupStatusAsync(sessionId: string): void {
         void this.doPublishMcpStartupStatus(sessionId);
+    }
+
+    /**
+     * Publish the title the client requested in `_meta`, once, after the
+     * `session/new` response has been written.
+     *
+     * The SDK's client installs its per-session update queue only when
+     * `session/new` resolves, and drops updates for sessions that have no queue
+     * attached, so an update emitted from inside the create path would be lost
+     * for a legitimate client. `setImmediate` puts the publish behind a
+     * macrotask boundary, which drains the microtasks that hand the response to
+     * the connection, and the connection serializes its writes — so the
+     * notification can only leave after the response.
+     */
+    private publishExplicitSessionTitleAsync(sessionId: string, generation: number, title: string): void {
+        setImmediate(() => {
+            void this.doPublishExplicitSessionTitle(sessionId, generation, title);
+        });
+    }
+
+    private async doPublishExplicitSessionTitle(
+        sessionId: string,
+        generation: number,
+        title: string,
+    ): Promise<void> {
+        const sessionState = this.sessions.get(sessionId);
+        // A session closed, reopened, or renamed during the gap must not be
+        // told about a title that is no longer its own.
+        if (!sessionState
+            || !this.sessionOpenCanInstall(sessionId, generation)
+            || sessionState.sessionTitleSource !== "explicit"
+            || sessionState.sessionTitle !== title) {
+            return;
+        }
+        try {
+            await new ACPSessionConnection(this.connection, sessionId).update({
+                sessionUpdate: "session_info_update",
+                title,
+            });
+        } catch (err) {
+            logger.error(`Failed to publish session title for session ${sessionId}`, err);
+        }
     }
 
     private async doPublishMcpStartupStatus(sessionId: string): Promise<void> {

--- a/src/CodexAppServerClient.ts
+++ b/src/CodexAppServerClient.ts
@@ -49,6 +49,8 @@ import type {
     ThreadReadResponse,
     ThreadResumeParams,
     ThreadResumeResponse,
+    ThreadSetNameParams,
+    ThreadSetNameResponse,
     ThreadSettings,
     ThreadStartParams,
     ThreadStartResponse,
@@ -526,6 +528,10 @@ export class CodexAppServerClient {
 
     async threadResume(params: ThreadResumeParams): Promise<ThreadResumeResponse> {
         return await this.sendRequest({ method: "thread/resume", params: params });
+    }
+
+    async threadSetName(params: ThreadSetNameParams): Promise<ThreadSetNameResponse> {
+        return await this.sendRequest({ method: "thread/name/set", params: params });
     }
 
     getThreadSettings(threadId: string): ThreadSettings | undefined {

--- a/src/__tests__/CodexACPAgent/data/session-new-sets-thread-name.json
+++ b/src/__tests__/CodexACPAgent/data/session-new-sets-thread-name.json
@@ -3,7 +3,7 @@
   "method": "thread/name/set",
   "params": {
     "threadId": "thread-id",
-    "name": "Fizz · #buzz-dev"
+    "name": "Nightly · #release-prep"
   }
 }
 {

--- a/src/__tests__/CodexACPAgent/data/session-new-sets-thread-name.json
+++ b/src/__tests__/CodexACPAgent/data/session-new-sets-thread-name.json
@@ -1,0 +1,23 @@
+{
+  "eventType": "request",
+  "method": "thread/name/set",
+  "params": {
+    "threadId": "thread-id",
+    "name": "Fizz · #buzz-dev"
+  }
+}
+{
+  "eventType": "response"
+}
+{
+  "eventType": "request",
+  "method": "skills/list",
+  "params": {
+    "cwds": [
+      ""
+    ]
+  }
+}
+{
+  "eventType": "response"
+}

--- a/src/__tests__/CodexACPAgent/data/session-new-without-thread-name.json
+++ b/src/__tests__/CodexACPAgent/data/session-new-without-thread-name.json
@@ -1,0 +1,12 @@
+{
+  "eventType": "request",
+  "method": "skills/list",
+  "params": {
+    "cwds": [
+      ""
+    ]
+  }
+}
+{
+  "eventType": "response"
+}

--- a/src/__tests__/CodexACPAgent/session-title-from-meta.test.ts
+++ b/src/__tests__/CodexACPAgent/session-title-from-meta.test.ts
@@ -3,7 +3,7 @@ import {createCodexMockTestFixture, createTestModel, type CodexMockTestFixture} 
 import type * as acp from "@agentclientprotocol/sdk";
 
 const threadId = "thread-id";
-const sessionTitle = "Fizz · #buzz-dev";
+const sessionTitle = "Nightly · #release-prep";
 
 describe("session title from _meta", () => {
     it("names the thread with the title supplied in _meta", async () => {
@@ -29,15 +29,52 @@ describe("session title from _meta", () => {
     it("collapses whitespace in the requested title before naming the thread", async () => {
         const fixture = createFixture();
 
-        await fixture.getCodexAcpAgent().newSession(newSessionRequest({sessionTitle: "  Fizz  ·\n\t#buzz-dev  "}));
+        await fixture.getCodexAcpAgent().newSession(
+            newSessionRequest({sessionTitle: "  Nightly  ·\n\t#release-prep  "}),
+        );
 
         expect(threadNamesSet(fixture)).toEqual([sessionTitle]);
+    });
+
+    it("strips control characters from the requested title", async () => {
+        const fixture = createFixture();
+
+        await fixture.getCodexAcpAgent().newSession(
+            newSessionRequest({sessionTitle: "Nightly\u0007 \u200b·\u202e #release-prep"}),
+        );
+
+        expect(threadNamesSet(fixture)).toEqual([sessionTitle]);
+    });
+
+    it("caps an over-long requested title", async () => {
+        const fixture = createFixture();
+        const requested = "a".repeat(500);
+
+        await fixture.getCodexAcpAgent().newSession(newSessionRequest({sessionTitle: requested}));
+
+        expect(threadNamesSet(fixture)).toEqual(["a".repeat(80)]);
+    });
+
+    it("caps an over-long requested title without splitting a surrogate pair", async () => {
+        const fixture = createFixture();
+
+        await fixture.getCodexAcpAgent().newSession(newSessionRequest({sessionTitle: "😀".repeat(200)}));
+
+        expect(threadNamesSet(fixture)).toEqual(["😀".repeat(80)]);
     });
 
     it("does not name the thread when the requested title is blank", async () => {
         const fixture = createFixture();
 
         await fixture.getCodexAcpAgent().newSession(newSessionRequest({sessionTitle: " \n\t "}));
+
+        expect(threadNamesSet(fixture)).toEqual([]);
+    });
+
+    it("does not name the thread when the requested title is only control characters", async () => {
+        const fixture = createFixture();
+
+        await fixture.getCodexAcpAgent().newSession(newSessionRequest({sessionTitle: "\u0007\u200b\u202e"}));
 
         expect(threadNamesSet(fixture)).toEqual([]);
     });
@@ -50,7 +87,7 @@ describe("session title from _meta", () => {
         expect(threadNamesSet(fixture)).toEqual([]);
     });
 
-    it("seeds the session title state so a prompt fallback cannot overwrite it", async () => {
+    it("records the applied title as the explicit title in the session state", async () => {
         const fixture = createFixture();
 
         const response = await fixture.getCodexAcpAgent().newSession(newSessionRequest({sessionTitle}));

--- a/src/__tests__/CodexACPAgent/session-title-from-meta.test.ts
+++ b/src/__tests__/CodexACPAgent/session-title-from-meta.test.ts
@@ -1,0 +1,126 @@
+import {describe, expect, it, vi} from "vitest";
+import {createCodexMockTestFixture, createTestModel, type CodexMockTestFixture} from "../acp-test-utils";
+import type * as acp from "@agentclientprotocol/sdk";
+
+const threadId = "thread-id";
+const sessionTitle = "Fizz · #buzz-dev";
+
+describe("session title from _meta", () => {
+    it("names the thread with the title supplied in _meta", async () => {
+        const fixture = createFixture();
+
+        await fixture.getCodexAcpAgent().newSession(newSessionRequest({sessionTitle}));
+
+        await expect(fixture.getCodexConnectionDump([])).toMatchFileSnapshot(
+            "data/session-new-sets-thread-name.json"
+        );
+    });
+
+    it("does not name the thread when _meta carries no title", async () => {
+        const fixture = createFixture();
+
+        await fixture.getCodexAcpAgent().newSession(newSessionRequest());
+
+        await expect(fixture.getCodexConnectionDump([])).toMatchFileSnapshot(
+            "data/session-new-without-thread-name.json"
+        );
+    });
+
+    it("collapses whitespace in the requested title before naming the thread", async () => {
+        const fixture = createFixture();
+
+        await fixture.getCodexAcpAgent().newSession(newSessionRequest({sessionTitle: "  Fizz  ·\n\t#buzz-dev  "}));
+
+        expect(threadNamesSet(fixture)).toEqual([sessionTitle]);
+    });
+
+    it("does not name the thread when the requested title is blank", async () => {
+        const fixture = createFixture();
+
+        await fixture.getCodexAcpAgent().newSession(newSessionRequest({sessionTitle: " \n\t "}));
+
+        expect(threadNamesSet(fixture)).toEqual([]);
+    });
+
+    it("does not name the thread when the requested title is not a string", async () => {
+        const fixture = createFixture();
+
+        await fixture.getCodexAcpAgent().newSession(newSessionRequest({sessionTitle: 42}));
+
+        expect(threadNamesSet(fixture)).toEqual([]);
+    });
+
+    it("seeds the session title state so a prompt fallback cannot overwrite it", async () => {
+        const fixture = createFixture();
+
+        const response = await fixture.getCodexAcpAgent().newSession(newSessionRequest({sessionTitle}));
+
+        expect(fixture.getCodexAcpAgent().getSessionState(response.sessionId)).toMatchObject({
+            sessionTitle,
+            sessionTitleSource: "explicit",
+        });
+    });
+
+    it("leaves the title unset when none was requested", async () => {
+        const fixture = createFixture();
+
+        const response = await fixture.getCodexAcpAgent().newSession(newSessionRequest());
+
+        expect(fixture.getCodexAcpAgent().getSessionState(response.sessionId)).toMatchObject({
+            sessionTitle: null,
+            sessionTitleSource: "unset",
+        });
+    });
+
+    it("creates the session successfully when naming the thread fails", async () => {
+        const fixture = createFixture();
+        vi.spyOn(fixture.getCodexAppServerClient(), "threadSetName")
+            .mockRejectedValue(new Error("thread/name/set is not supported"));
+
+        const response = await fixture.getCodexAcpAgent().newSession(newSessionRequest({sessionTitle}));
+
+        expect(response.sessionId).toBe(threadId);
+        // A rejected naming request must not be recorded as an applied title,
+        // so a later fallback title is still free to fill the gap.
+        expect(fixture.getCodexAcpAgent().getSessionState(threadId)).toMatchObject({
+            sessionTitle: null,
+            sessionTitleSource: "unset",
+        });
+    });
+});
+
+function newSessionRequest(meta?: Record<string, unknown>): acp.NewSessionRequest {
+    // cwd is empty so skill discovery is skipped and the recorded frames hold
+    // only what these tests are about.
+    return {cwd: "", mcpServers: [], ...(meta ? {_meta: meta} : {})};
+}
+
+/** Names carried by the `thread/name/set` frames sent to Codex, in order. */
+function threadNamesSet(fixture: CodexMockTestFixture): unknown[] {
+    return fixture.getCodexConnectionEvents([])
+        .filter(event => event.eventType === "request" && event.method === "thread/name/set")
+        .map(event => (event as {params: {name: unknown}}).params.name);
+}
+
+/**
+ * Fixture whose `thread/start` and `model/list` calls are stubbed at the
+ * wrapper level, so they leave no transport frames and the connection dump
+ * shows only whether `thread/name/set` was sent.
+ */
+function createFixture(): CodexMockTestFixture {
+    const fixture = createCodexMockTestFixture();
+    const codexAcpClient = fixture.getCodexAcpClient();
+    const codexAppServerClient = fixture.getCodexAppServerClient();
+
+    vi.spyOn(codexAcpClient, "authRequired").mockResolvedValue(false);
+    vi.spyOn(codexAcpClient, "getAccount").mockResolvedValue({account: null, requiresOpenaiAuth: false});
+    vi.spyOn(codexAppServerClient, "threadStart").mockResolvedValue({
+        thread: {id: threadId} as any,
+        model: "model-id",
+        reasoningEffort: "medium",
+        modelProvider: "openai",
+    } as any);
+    vi.spyOn(codexAcpClient, "fetchAvailableModels").mockResolvedValue([createTestModel()]);
+
+    return fixture;
+}

--- a/src/__tests__/CodexACPAgent/session-title-ordering.test.ts
+++ b/src/__tests__/CodexACPAgent/session-title-ordering.test.ts
@@ -1,0 +1,130 @@
+import {describe, expect, it, vi} from "vitest";
+import * as acp from "@agentclientprotocol/sdk";
+import {CodexAcpClient} from "../../CodexAcpClient";
+import {CodexAcpServer} from "../../CodexAcpServer";
+import {CodexAppServerClient} from "../../CodexAppServerClient";
+import {createMockCodexConnection, createTestModel} from "../acp-test-utils";
+
+const threadId = "thread-id";
+const sessionTitle = "Nightly · #release-prep";
+const promptText = "Fix the flaky test";
+
+/**
+ * These tests drive a real in-process SDK client/agent pair rather than the
+ * smart mock, because what is under test is ordering: the SDK client installs
+ * its per-session update queue only once `session/new` resolves, and silently
+ * drops updates for sessions with no queue attached. An update published from
+ * inside the create path is therefore unobservable, and a mock that records
+ * every notification it is handed cannot tell the two cases apart.
+ */
+describe("explicit session title over a real ACP connection", () => {
+    it("delivers the requested title to the client after session/new returns", async () => {
+        await withConnectedClient(async (ctx) => {
+            const session = await startSession(ctx, {sessionTitle});
+
+            await expect(nextSessionTitle(session)).resolves.toBe(sessionTitle);
+        });
+    });
+
+    it("leaves the first title to the prompt fallback when none was requested", async () => {
+        await withConnectedClient(async (ctx) => {
+            const session = await startSession(ctx);
+            void session.prompt(promptText);
+
+            await expect(nextSessionTitle(session)).resolves.toBe(promptText);
+        });
+    });
+
+    it("does not follow the requested title with a prompt-derived one", async () => {
+        await withConnectedClient(async (ctx) => {
+            const session = await startSession(ctx, {sessionTitle});
+            await expect(nextSessionTitle(session)).resolves.toBe(sessionTitle);
+
+            expect(await sessionTitlesDuringPrompt(session)).toEqual([]);
+        });
+    });
+});
+
+/** Starts a session, optionally requesting a title through `_meta`. */
+async function startSession(ctx: acp.ClientContext, meta?: Record<string, unknown>): Promise<acp.ActiveSession> {
+    // cwd is empty so skill discovery is skipped.
+    return await ctx.buildSession({cwd: "", mcpServers: [], ...(meta ? {_meta: meta} : {})}).start();
+}
+
+/** Title carried by the next `session_info_update` the client observes. */
+async function nextSessionTitle(session: acp.ActiveSession): Promise<unknown> {
+    while (true) {
+        const message = await session.nextUpdate();
+        if (message.kind === "stop") {
+            throw new Error("prompt turn stopped before a session title arrived");
+        }
+        if (message.update.sessionUpdate === "session_info_update") {
+            return message.update.title;
+        }
+    }
+}
+
+/** Titles carried by `session_info_update`s seen during one prompt turn. */
+async function sessionTitlesDuringPrompt(session: acp.ActiveSession): Promise<unknown[]> {
+    void session.prompt(promptText);
+    const titles: unknown[] = [];
+    while (true) {
+        const message = await session.nextUpdate();
+        if (message.kind === "stop") return titles;
+        if (message.update.sessionUpdate === "session_info_update") {
+            titles.push(message.update.title);
+        }
+    }
+}
+
+/**
+ * Runs `op` against a real ACP connection to a `CodexAcpServer` whose Codex
+ * side is stubbed at the wrapper level.
+ */
+async function withConnectedClient(op: (ctx: acp.ClientContext) => Promise<void>): Promise<void> {
+    const codexConnection = createMockCodexConnection();
+    const appServerClient = new CodexAppServerClient(codexConnection.connection);
+    const codexAcpClient = new CodexAcpClient(appServerClient);
+
+    vi.spyOn(codexAcpClient, "authRequired").mockResolvedValue(false);
+    vi.spyOn(codexAcpClient, "getAccount").mockResolvedValue({account: null, requiresOpenaiAuth: false});
+    vi.spyOn(codexAcpClient, "fetchAvailableModels").mockResolvedValue([createTestModel()]);
+    vi.spyOn(appServerClient, "threadStart").mockResolvedValue({
+        thread: {id: threadId} as any,
+        model: "model-id",
+        reasoningEffort: "medium",
+        modelProvider: "openai",
+    } as any);
+    vi.spyOn(appServerClient, "threadSetName").mockResolvedValue({} as any);
+    vi.spyOn(codexAcpClient, "sendPrompt").mockResolvedValue({
+        threadId,
+        turn: {
+            id: "turn-id",
+            items: [],
+            itemsView: "notLoaded",
+            status: "completed",
+            error: null,
+            startedAt: null,
+            completedAt: null,
+            durationMs: null,
+        },
+    } as any);
+
+    let server: CodexAcpServer | null = null;
+    const getServer = (): CodexAcpServer => {
+        if (!server) throw new Error("agent is not connected");
+        return server;
+    };
+    const agentApp = acp.agent({name: "codex-acp-ordering-test"})
+        .onConnect((connection) => {
+            server = new CodexAcpServer(connection.client, codexAcpClient, undefined, () => null);
+        })
+        .onRequest(acp.methods.agent.initialize, (c) => getServer().initialize(c.params))
+        .onRequest(acp.methods.agent.session.new, (c) => getServer().newSession(c.params))
+        .onRequest(acp.methods.agent.session.prompt, (c) => getServer().prompt(c.params, c.signal));
+
+    await acp.client({name: "ordering-test-client"}).connectWith(agentApp, async (ctx) => {
+        await ctx.request(acp.methods.agent.initialize, {protocolVersion: acp.PROTOCOL_VERSION});
+        await op(ctx);
+    });
+}

--- a/src/__tests__/acp-test-utils.ts
+++ b/src/__tests__/acp-test-utils.ts
@@ -248,26 +248,22 @@ export interface CodexMockTestFixture extends TestFixture {
     setElicitationResponse(response: CreateElicitationResponse | Promise<CreateElicitationResponse>): void,
 }
 
+export interface MockCodexConnection {
+    connection: MessageConnection,
+    sendServerNotification(notification: ServerNotification | Record<string, unknown>): void,
+    sendServerRequest<T>(method: string, params: unknown): Promise<T>,
+}
+
 /**
- * Creates a test fixture with a mock Codex connection.
- * Use for unit tests that don't need a real Codex binary.
- * Provides `sendServerNotification()` to simulate server notifications.
- * Provides `sendServerRequest()` to simulate server-initiated requests (e.g., approval requests).
- * Provides `setPermissionResponse()` to control ACP permission dialog responses.
+ * Creates a mock Codex `MessageConnection` that records nothing and answers
+ * every request with `undefined`, so callers spy on the wrapper methods they
+ * care about.
  */
-export function createCodexMockTestFixture(): CodexMockTestFixture {
+export function createMockCodexConnection(): MockCodexConnection {
     let unhandledNotificationHandler: ((notification: any) => void) | null = null;
     const requestHandlers = new Map<string, (params: unknown) => Promise<unknown>>();
 
-    // State for controlling permission responses
-    const permissionState: { response: RequestPermissionResponse } = {
-        response: { outcome: { outcome: 'cancelled' } }
-    };
-    const elicitationState: { response: CreateElicitationResponse | Promise<CreateElicitationResponse> } = {
-        response: { action: 'cancel' }
-    };
-
-    const mockCodexConnection = {
+    const connection = {
         sendRequest: () => Promise.resolve(undefined),
         onUnhandledNotification: (handler: (notification: any) => void) => {
             unhandledNotificationHandler = handler;
@@ -278,6 +274,39 @@ export function createCodexMockTestFixture(): CodexMockTestFixture {
         },
         end: () => {},
     } as unknown as MessageConnection;
+
+    return {
+        connection,
+        sendServerNotification(notification: ServerNotification | Record<string, unknown>): void {
+            unhandledNotificationHandler?.(notification);
+        },
+        async sendServerRequest<T>(method: string, params: unknown): Promise<T> {
+            const handler = requestHandlers.get(method);
+            if (!handler) {
+                throw new Error(`No handler registered for ${method}`);
+            }
+            return await handler(params) as T;
+        },
+    };
+}
+
+/**
+ * Creates a test fixture with a mock Codex connection.
+ * Use for unit tests that don't need a real Codex binary.
+ * Provides `sendServerNotification()` to simulate server notifications.
+ * Provides `sendServerRequest()` to simulate server-initiated requests (e.g., approval requests).
+ * Provides `setPermissionResponse()` to control ACP permission dialog responses.
+ */
+export function createCodexMockTestFixture(): CodexMockTestFixture {
+    const mockCodexConnection = createMockCodexConnection();
+
+    // State for controlling permission responses
+    const permissionState: { response: RequestPermissionResponse } = {
+        response: { outcome: { outcome: 'cancelled' } }
+    };
+    const elicitationState: { response: CreateElicitationResponse | Promise<CreateElicitationResponse> } = {
+        response: { action: 'cancel' }
+    };
 
     // Create ACP connection with configurable permission response
     const acpConnectionEvents: MethodCallEvent[] = [];
@@ -301,7 +330,7 @@ export function createCodexMockTestFixture(): CodexMockTestFixture {
     }, { returnValues });
 
     const baseFixture = createBaseTestFixture({
-        connection: mockCodexConnection,
+        connection: mockCodexConnection.connection,
         getExitCode: () => null,
         acpConnection: {
             connection: acpConnection,
@@ -312,18 +341,8 @@ export function createCodexMockTestFixture(): CodexMockTestFixture {
 
     return {
         ...baseFixture,
-        sendServerNotification(notification: ServerNotification | Record<string, unknown>): void {
-            if (unhandledNotificationHandler) {
-                unhandledNotificationHandler(notification);
-            }
-        },
-        async sendServerRequest<T>(method: string, params: unknown): Promise<T> {
-            const handler = requestHandlers.get(method);
-            if (!handler) {
-                throw new Error(`No handler registered for ${method}`);
-            }
-            return await handler(params) as T;
-        },
+        sendServerNotification: mockCodexConnection.sendServerNotification,
+        sendServerRequest: mockCodexConnection.sendServerRequest,
         setPermissionResponse(response: RequestPermissionResponse): void {
             permissionState.response = response;
         },


### PR DESCRIPTION
## Summary

- name a Codex thread from `_meta.sessionTitle` on `session/new`, so a session is titled atomically at creation
- sanitize the requested title at the ACP boundary — whitespace collapsed, `Cc`/`Cf`/`Cs` stripped, capped at `SESSION_TITLE_MAX_CHARS` (80) code points
- record the applied title as the `"explicit"` title source, so a later prompt- or history-derived fallback cannot overwrite a title the client asked for
- publish one `session_info_update` carrying the title after the `session/new` response, so the client's own title state reflects it
- treat naming as cosmetic: a rejected `thread/name/set` is logged and swallowed, leaving the session created and the fallback title still eligible

## Why

A client running several sessions against one agent had no way to label them at creation. Every thread showed the same derived title, and the only title the client could influence arrived later, from the first prompt. Carrying the title in `_meta` keeps it out of the prompt entirely — it costs no tokens and cannot perturb the prompt contract — and `_meta` is already reserved for exactly this kind of client/agent metadata, so no protocol change is involved. Clients that send nothing are unaffected: `_meta` absence leaves the existing fallback path untouched.

**Sanitization is the adapter's job, not the caller's.** `CodexAcpClient` is the ACP boundary for arbitrary clients, and Codex's `normalize_thread_name` only trims — so without a bound here, a client could persist a megabyte-long title, or one carrying a BEL, a zero-width space, or a bidi override, verbatim into the Codex thread store. The cap counts code points via `Array.from()` rather than UTF-16 units, so truncation cannot split a surrogate pair. Counting code points also bounds storage to at most 320 UTF-8 bytes, which is why there is no separate byte cap competing with it as a second truncation rule.

**The `session_info_update` has to follow the `session/new` response, not precede it.** `thread/name/set` resolves before any thread notification handler exists, so Codex's own `thread/name/updated` is dropped, and `NewSessionResponse` has no title field — a client that supplied the title through opaque `_meta` otherwise had no way to see it reflected in its title state, and would have to mirror `_meta` by hand. Publishing from inside the create path does not work either: the SDK client installs its per-session update queue only when `session/new` resolves, and drops updates for sessions with no attached queue. `setImmediate` puts the publish behind a macrotask boundary, after the continuation that hands the response to the connection, and the connection's write queue serializes from there. The deferred publish re-checks session presence, the open generation, the title source, and title identity, so a session closed, reopened, or renamed in that gap is never told about a title that is no longer its own.

## Overlap with #252

#252 adds a byte-identical `threadSetName` wrapper to `CodexAppServerClient`, so whichever of the two lands second should drop its copy. The features themselves compose rather than collide: #252 is a **rename** affordance — a capability handshake, a `session/setTitle` extension request, and a `/rename` command, all a second round trip after the thread already exists. This is a **creation** affordance — the thread is named as part of `session/new`, so a client that never sends a second request still ends up with a correct title.

Related: [buzz#3028](https://github.com/block/buzz/pull/3028)
