### PR TITLE
Expose structured permission changes in ACP metadata

### DIFF
--- a/src/CodexApprovalHandler.ts
+++ b/src/CodexApprovalHandler.ts
@@ -29,17 +29,28 @@ type FileChangeDecisionOption = {
     decision: FileChangeApprovalDecision;
 };
 
+type PermissionMetadata = {
+    version: 1;
+    changes: Array<Record<string, unknown>>;
+};
+
 function permissionOption(
     optionId: string,
     name: string,
     kind: acp.PermissionOptionKind,
     codexMeta?: Record<string, unknown>,
+    permission?: PermissionMetadata,
 ): acp.PermissionOption {
     return {
         optionId,
         name,
         kind,
-        ...(codexMeta ? { _meta: { codex: codexMeta } } : {}),
+        ...((codexMeta || permission) ? {
+            _meta: {
+                ...(permission ? {permission} : {}),
+                ...(codexMeta ? {codex: codexMeta} : {}),
+            },
+        } : {}),
     };
 }
 
@@ -175,12 +186,14 @@ export class CodexApprovalHandler implements ApprovalHandler {
                     "Allow for Session",
                     "allow_always",
                     { decision: "allowPermissionsForSession", permissions: params.permissions },
+                    this.permissionGrantMetadata(params.permissions, "session"),
                 ),
                 permissionOption(
                     ApprovalOptionId.AllowPermissionsForTurn,
                     "Allow Once",
                     "allow_once",
                     { decision: "allowPermissionsForTurn", permissions: params.permissions },
+                    this.permissionGrantMetadata(params.permissions, "turn"),
                 ),
                 permissionOption(
                     ApprovalOptionId.RejectPermissions,
@@ -265,6 +278,23 @@ export class CodexApprovalHandler implements ApprovalHandler {
                         : "Allow for Session",
                     "allow_always",
                     { decision: "acceptForSession" },
+                    params.networkApprovalContext ? {
+                        version: 1,
+                        changes: [{
+                            type: "grant",
+                            operation: "grant",
+                            description: `Allow access to ${params.networkApprovalContext.host} for this session`,
+                            lifetime: {scope: "session"},
+                            targets: [{
+                                type: "network",
+                                matcher: {
+                                    type: "host",
+                                    host: params.networkApprovalContext.host,
+                                    protocol: params.networkApprovalContext.protocol,
+                                },
+                            }],
+                        }],
+                    } : undefined,
                 ),
                 decision: "acceptForSession",
             },
@@ -279,6 +309,22 @@ export class CodexApprovalHandler implements ApprovalHandler {
                     {
                         decision: "acceptWithExecpolicyAmendment",
                         execpolicyAmendment: params.proposedExecpolicyAmendment,
+                    },
+                    {
+                        version: 1,
+                        changes: [{
+                            type: "policy_rule",
+                            operation: "add",
+                            ruleBehavior: "allow",
+                            description: `Allow commands starting with ${params.proposedExecpolicyAmendment.join(" ")}`,
+                            targets: [{
+                                type: "command",
+                                matcher: {
+                                    type: "argv_prefix",
+                                    argv: params.proposedExecpolicyAmendment,
+                                },
+                            }],
+                        }],
                     },
                 ),
                 decision: {
@@ -298,6 +344,24 @@ export class CodexApprovalHandler implements ApprovalHandler {
                     {
                         decision: "applyNetworkPolicyAmendment",
                         networkPolicyAmendment: amendment,
+                    },
+                    {
+                        version: 1,
+                        changes: [{
+                            type: "policy_rule",
+                            operation: "add",
+                            ruleBehavior: amendment.action,
+                            description: amendment.action === "allow"
+                                ? `Allow access to ${amendment.host}`
+                                : `Block access to ${amendment.host}`,
+                            targets: [{
+                                type: "network",
+                                matcher: {
+                                    type: "host",
+                                    host: amendment.host,
+                                },
+                            }],
+                        }],
                     },
                 ),
                 decision: {
@@ -328,6 +392,20 @@ export class CodexApprovalHandler implements ApprovalHandler {
                     params.grantRoot ? "Allow Root for Session" : "Allow for Session",
                     "allow_always",
                     { decision: "acceptForSession", grantRoot: params.grantRoot ?? null },
+                    params.grantRoot ? {
+                        version: 1,
+                        changes: [{
+                            type: "grant",
+                            operation: "grant",
+                            description: `Allow writes under ${params.grantRoot} for this session`,
+                            lifetime: {scope: "session"},
+                            targets: [{
+                                type: "filesystem",
+                                access: ["write"],
+                                matcher: {type: "directory", path: params.grantRoot},
+                            }],
+                        }],
+                    } : undefined,
                 ),
                 decision: "acceptForSession",
             },
@@ -350,6 +428,85 @@ export class CodexApprovalHandler implements ApprovalHandler {
         return {
             ...(permissions.network ? { network: permissions.network } : {}),
             ...(permissions.fileSystem ? { fileSystem: permissions.fileSystem } : {}),
+        };
+    }
+
+    private permissionGrantMetadata(
+        permissions: RequestPermissionProfile,
+        scope: "turn" | "session",
+    ): PermissionMetadata | undefined {
+        const changes: Array<Record<string, unknown>> = [];
+        const lifetime = {scope};
+        const suffix = scope === "session" ? " for this session" : " for this turn";
+
+        if (permissions.network?.enabled !== null && permissions.network?.enabled !== undefined) {
+            const allowed = permissions.network.enabled;
+            changes.push({
+                type: allowed ? "grant" : "policy_rule",
+                operation: allowed ? "grant" : "add",
+                ...(allowed ? {} : {ruleBehavior: "deny"}),
+                description: `${allowed ? "Allow" : "Deny"} network access${suffix}`,
+                lifetime,
+                targets: [{type: "network", matcher: {type: "any"}}],
+            });
+        }
+
+        const fileSystem = permissions.fileSystem;
+        for (const path of fileSystem?.read ?? []) {
+            changes.push(this.fileSystemGrantChange(path, "read", lifetime, suffix));
+        }
+        for (const path of fileSystem?.write ?? []) {
+            changes.push(this.fileSystemGrantChange(path, "write", lifetime, suffix));
+        }
+        for (const entry of fileSystem?.entries ?? []) {
+            const matcher = (() => {
+                switch (entry.path.type) {
+                    case "path":
+                        return {type: "exact_path", path: entry.path.path};
+                    case "glob_pattern":
+                        return {type: "glob", pattern: entry.path.pattern};
+                    case "special":
+                        return {type: "special", provider: "codex", value: entry.path.value};
+                }
+            })();
+            const pathDescription = entry.path.type === "path"
+                ? entry.path.path
+                : entry.path.type === "glob_pattern" ? entry.path.pattern : JSON.stringify(entry.path.value);
+            changes.push({
+                type: entry.access === "deny" ? "policy_rule" : "grant",
+                operation: entry.access === "deny" ? "add" : "grant",
+                ...(entry.access === "deny" ? {ruleBehavior: "deny"} : {}),
+                description: entry.access === "deny"
+                    ? `Deny filesystem access to ${pathDescription}${suffix}`
+                    : `Allow ${entry.access} access to ${pathDescription}${suffix}`,
+                lifetime,
+                targets: [{
+                    type: "filesystem",
+                    ...(entry.access === "deny" ? {} : {access: [entry.access]}),
+                    matcher,
+                }],
+            });
+        }
+
+        return changes.length > 0 ? {version: 1, changes} : undefined;
+    }
+
+    private fileSystemGrantChange(
+        path: string,
+        access: "read" | "write",
+        lifetime: {scope: "turn" | "session"},
+        suffix: string,
+    ): Record<string, unknown> {
+        return {
+            type: "grant",
+            operation: "grant",
+            description: `Allow ${access} access to ${path}${suffix}`,
+            lifetime,
+            targets: [{
+                type: "filesystem",
+                access: [access],
+                matcher: {type: "exact_path", path},
+            }],
         };
     }
 

--- a/src/__tests__/CodexACPAgent/approval-events.test.ts
+++ b/src/__tests__/CodexACPAgent/approval-events.test.ts
@@ -155,6 +155,27 @@ describe('Approval Events', () => {
                 expect.objectContaining({
                     optionId: ApprovalOptionId.AcceptWithExecpolicyAmendment,
                     kind: 'allow_always',
+                    _meta: {
+                        permission: {
+                            version: 1,
+                            changes: [{
+                                type: 'policy_rule',
+                                operation: 'add',
+                                ruleBehavior: 'allow',
+                                description: 'Allow commands starting with npm install',
+                                targets: [{
+                                    type: 'command',
+                                    matcher: {
+                                        type: 'argv_prefix',
+                                        argv: proposedExecpolicyAmendment,
+                                    },
+                                }],
+                            }],
+                        },
+                        codex: expect.objectContaining({
+                            execpolicyAmendment: proposedExecpolicyAmendment,
+                        }),
+                    },
                 })
             );
 
@@ -201,6 +222,27 @@ describe('Approval Events', () => {
                 expect.objectContaining({
                     optionId,
                     kind: 'allow_always',
+                    _meta: {
+                        permission: {
+                            version: 1,
+                            changes: [{
+                                type: 'policy_rule',
+                                operation: 'add',
+                                ruleBehavior: 'allow',
+                                description: 'Allow access to registry.npmjs.org',
+                                targets: [{
+                                    type: 'network',
+                                    matcher: {
+                                        type: 'host',
+                                        host: 'registry.npmjs.org',
+                                    },
+                                }],
+                            }],
+                        },
+                        codex: expect.objectContaining({
+                            networkPolicyAmendment,
+                        }),
+                    },
                 })
             );
 
@@ -384,6 +426,46 @@ describe('Approval Events', () => {
             );
 
             expect(response).toEqual({ decision: 'cancel' });
+
+            completeTurn();
+            await promptPromise;
+        });
+
+        it('should describe a session write-root grant with common permission metadata', async () => {
+            const { promptPromise, completeTurn } = setupSessionWithPendingPrompt();
+            fixture.setPermissionResponse({
+                outcome: { outcome: 'selected', optionId: ApprovalOptionId.AllowAlways }
+            });
+
+            const params: FileChangeRequestApprovalParams = {
+                threadId: sessionId,
+                turnId: 'turn-1',
+                startedAtMs: 0,
+                itemId: 'file-change-grant-root',
+                reason: 'Write generated files',
+                grantRoot: '/workspace/generated',
+            };
+
+            await fixture.sendServerRequest('item/fileChange/requestApproval', params);
+
+            const request = fixture.getAcpConnectionEvents([])[0]!.args[0];
+            expect(request.options.find((option: { optionId: string }) => option.optionId === ApprovalOptionId.AllowAlways)?._meta)
+                .toMatchObject({
+                    permission: {
+                        version: 1,
+                        changes: [{
+                            type: 'grant',
+                            operation: 'grant',
+                            description: 'Allow writes under /workspace/generated for this session',
+                            lifetime: {scope: 'session'},
+                            targets: [{
+                                type: 'filesystem',
+                                access: ['write'],
+                                matcher: {type: 'directory', path: '/workspace/generated'},
+                            }],
+                        }],
+                    },
+                });
 
             completeTurn();
             await promptPromise;

--- a/src/__tests__/CodexACPAgent/data/approval-permissions-request.json
+++ b/src/__tests__/CodexACPAgent/data/approval-permissions-request.json
@@ -47,6 +47,67 @@
           "name": "Allow for Session",
           "kind": "allow_always",
           "_meta": {
+            "permission": {
+              "version": 1,
+              "changes": [
+                {
+                  "type": "grant",
+                  "operation": "grant",
+                  "description": "Allow network access for this session",
+                  "lifetime": {
+                    "scope": "session"
+                  },
+                  "targets": [
+                    {
+                      "type": "network",
+                      "matcher": {
+                        "type": "any"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "grant",
+                  "operation": "grant",
+                  "description": "Allow read access to /home/user/project for this session",
+                  "lifetime": {
+                    "scope": "session"
+                  },
+                  "targets": [
+                    {
+                      "type": "filesystem",
+                      "access": [
+                        "read"
+                      ],
+                      "matcher": {
+                        "type": "exact_path",
+                        "path": "/home/user/project"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "grant",
+                  "operation": "grant",
+                  "description": "Allow write access to /home/user/project/tmp for this session",
+                  "lifetime": {
+                    "scope": "session"
+                  },
+                  "targets": [
+                    {
+                      "type": "filesystem",
+                      "access": [
+                        "write"
+                      ],
+                      "matcher": {
+                        "type": "exact_path",
+                        "path": "/home/user/project/tmp"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
             "codex": {
               "decision": "allowPermissionsForSession",
               "permissions": {
@@ -71,6 +132,67 @@
           "name": "Allow Once",
           "kind": "allow_once",
           "_meta": {
+            "permission": {
+              "version": 1,
+              "changes": [
+                {
+                  "type": "grant",
+                  "operation": "grant",
+                  "description": "Allow network access for this turn",
+                  "lifetime": {
+                    "scope": "turn"
+                  },
+                  "targets": [
+                    {
+                      "type": "network",
+                      "matcher": {
+                        "type": "any"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "grant",
+                  "operation": "grant",
+                  "description": "Allow read access to /home/user/project for this turn",
+                  "lifetime": {
+                    "scope": "turn"
+                  },
+                  "targets": [
+                    {
+                      "type": "filesystem",
+                      "access": [
+                        "read"
+                      ],
+                      "matcher": {
+                        "type": "exact_path",
+                        "path": "/home/user/project"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "grant",
+                  "operation": "grant",
+                  "description": "Allow write access to /home/user/project/tmp for this turn",
+                  "lifetime": {
+                    "scope": "turn"
+                  },
+                  "targets": [
+                    {
+                      "type": "filesystem",
+                      "access": [
+                        "write"
+                      ],
+                      "matcher": {
+                        "type": "exact_path",
+                        "path": "/home/user/project/tmp"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
             "codex": {
               "decision": "allowPermissionsForTurn",
               "permissions": {


### PR DESCRIPTION
## Summary

Expose the exact consequence of Codex permission options through a shared, versioned option-level metadata contract:

```json
{
  "_meta": {
    "permission": {
      "version": 1,
      "changes": []
    }
  }
}
```

Each change includes a producer-supplied human-readable `description` plus structured operation, target, matcher, lifetime, and access information where Codex provides it.

## Why

ACP already standardizes the option decision category through `kind` (`allow_once`, `allow_always`, `reject_once`, or `reject_always`), the button text through `name`, and selection through `optionId`. It does not currently describe the exact policy change behind an option.

Clients therefore cannot reliably explain whether an always option grants a command prefix, one network host, filesystem writes under a root, or a broader runtime permission. Parsing display labels is lossy and couples clients to one agent.

This metadata deliberately describes only the exact consequence of the option. It does not duplicate ACP button semantics and does not carry the request reason.

## Contract

The common `_meta.permission` object contains:

- `version: 1`
- ordered, atomic `changes`
- a non-empty human-readable `description` on every change
- `policy_rule` changes with `operation` and `ruleBehavior`
- runtime `grant` changes with explicit lifetime
- structured targets for commands, network, and filesystem resources

Example command policy amendment:

```json
{
  "type": "policy_rule",
  "operation": "add",
  "ruleBehavior": "allow",
  "description": "Allow commands starting with npm install",
  "targets": [
    {
      "type": "command",
      "matcher": {
        "type": "argv_prefix",
        "argv": ["npm", "install"]
      }
    }
  ]
}
```

## Codex coverage

- exec-policy argv-prefix amendments
- allow and deny network-host policy amendments
- session host grants from managed-network approvals
- session write-root grants for file changes
- turn/session permission-profile grants
- whole-network permission profiles
- legacy filesystem read/write paths
- typed filesystem path, glob, special-path, and deny entries

The original `_meta.codex` decision payload remains alongside the common metadata, so existing clients and response handling are unchanged.

## Compatibility

This uses the existing ACP `_meta` extension point and requires no protocol-version change. Clients that do not recognize the contract ignore it and continue using standard ACP fields. Missing common metadata means the exact structured consequence is unknown; it must not be interpreted as unrestricted access.

## Tests

- full suite: 330 passed, 28 skipped
- TypeScript typecheck passed
- production build passed
- approval snapshots cover turn/session network and filesystem grants
- focused assertions cover command, host, and write-root metadata