### PR TITLE
fix: preserve UTF-8 across stdout chunks

### DIFF
--- a/src/StdUtils.ts
+++ b/src/StdUtils.ts
@@ -1,4 +1,5 @@
 import {Readable, Writable} from "node:stream";
+import {StringDecoder} from "node:string_decoder";
 import {Emitter} from "vscode-jsonrpc/node";
 import type {DataCallback, Disposable, Message, MessageReader, MessageWriter, PartialMessageInfo} from "vscode-jsonrpc/node";
 import * as acp from "@agentclientprotocol/sdk";
@@ -32,9 +33,10 @@ export function createJSONRPCWriter(writable: Writable): MessageWriter {
 export function createJSONRPCReader(readable: Readable): MessageReader {
     return {
         listen(callback: DataCallback): Disposable {
+            const decoder = new StringDecoder('utf8');
             let buf = '';
-            const onData = (chunk: Buffer) => {
-                buf += chunk.toString();
+            const onData = (chunk: Buffer | string) => {
+                buf += typeof chunk === 'string' ? chunk : decoder.write(chunk);
                 for (;;) {
                     const i = buf.indexOf('\n');
                     if (i < 0) break;

--- a/src/__tests__/StdUtils.test.ts
+++ b/src/__tests__/StdUtils.test.ts
@@ -1,0 +1,27 @@
+import {PassThrough} from "node:stream";
+import {describe, expect, it} from "vitest";
+import {createJSONRPCReader} from "../StdUtils";
+
+describe("createJSONRPCReader", () => {
+    it("preserves UTF-8 characters split across chunks", () => {
+        const readable = new PassThrough();
+        const messages: unknown[] = [];
+        const listener = createJSONRPCReader(readable).listen((message) => messages.push(message));
+        const payload = Buffer.from(JSON.stringify({id: 1, result: {text: "服务治理需求"}}) + "\n");
+        const character = Buffer.from("需");
+        const characterOffset = payload.indexOf(character);
+
+        readable.write(payload.subarray(0, characterOffset + 1));
+        readable.write(payload.subarray(characterOffset + 1, characterOffset + 2));
+        readable.write(payload.subarray(characterOffset + 2));
+
+        expect(messages).toEqual([{
+            jsonrpc: "2.0",
+            id: 1,
+            result: {text: "服务治理需求"},
+        }]);
+
+        listener.dispose();
+        readable.destroy();
+    });
+});


### PR DESCRIPTION
## Summary

- decode Codex app-server stdout with `StringDecoder` so UTF-8 characters survive arbitrary Node stream chunk boundaries
- add a regression test that splits a three-byte Chinese character across three chunks

## Problem

`createJSONRPCReader` called `Buffer#toString()` independently for each stdout chunk. If a multibyte UTF-8 character crossed a chunk boundary, Node emitted replacement characters. The resulting JSON remained parseable but its text was corrupted, which could also defeat downstream content-based history deduplication and surface duplicate messages.

## Testing

- `npx vitest run src/__tests__/StdUtils.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run build`