### PR TITLE
Add ACP plan review confirmation flow

### DIFF
--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -1,6 +1,6 @@
 import * as acp from "@agentclientprotocol/sdk";
 import {RequestError, type SessionId, type SessionModeState} from "@agentclientprotocol/sdk";
-import {CodexEventHandler} from "./CodexEventHandler";
+import {CodexEventHandler, type CompletedPlan} from "./CodexEventHandler";
 import {CodexApprovalHandler} from "./CodexApprovalHandler";
 import {CodexElicitationHandler} from "./CodexElicitationHandler";
 import {type CodexAuthRequest, getCodexAuthMethods, isCodexAuthRequest} from "./CodexAuthMethod";
@@ -22,7 +22,9 @@ import {AgentMode, MODE_CONFIG_ID} from "./AgentMode";
 import {
     COLLABORATION_MODE_CONFIG_ID,
     createCollaborationModeConfigOption,
+    DEFAULT_COLLABORATION_MODE,
     parseCollaborationMode,
+    PLAN_COLLABORATION_MODE,
 } from "./CollaborationModeConfig";
 import type {ModeKind} from "./app-server/ModeKind";
 import {
@@ -79,6 +81,7 @@ import {
 import packageJson from "../package.json";
 import {isJetBrains2026_1Client} from "./JBUtils";
 import {resolveTerminalOutputMode, type TerminalOutputMode} from "./TerminalOutputMode";
+import {clientSupportsPlanUpdates} from "./PlanCapabilities";
 import {
     createCodexMessagePhaseMeta,
     createAgentTextMessageChunk,
@@ -90,6 +93,9 @@ import {
     type ThreadGoalSnapshot,
     toThreadGoalSnapshot,
 } from "./ThreadGoalSnapshot";
+
+const IMPLEMENT_PLAN_OPTION_ID = "implement_plan";
+const REVISE_PLAN_OPTION_ID = "revise_plan";
 
 export interface SessionState {
     sessionId: string,
@@ -1469,7 +1475,7 @@ export class CodexAcpServer {
             case "contextCompaction":
                 return [createCompletedContextCompactionUpdate(item)];
             case "plan":
-                return [this.createPlanMessageUpdate(item)];
+                return item.text.length > 0 ? [this.createPlanHistoryUpdate(item)] : [];
         }
     }
 
@@ -1520,9 +1526,19 @@ export class CodexAcpServer {
         };
     }
 
-    private createPlanMessageUpdate(
+    private createPlanHistoryUpdate(
         item: ThreadItem & { type: "plan" }
     ): UpdateSessionEvent {
+        if (clientSupportsPlanUpdates(this.clientCapabilities)) {
+            return {
+                sessionUpdate: "plan_update",
+                plan: {
+                    type: "markdown",
+                    planId: item.id,
+                    content: item.text,
+                },
+            };
+        }
         return createAgentTextMessageChunk(
             item.text,
             item.id,
@@ -1876,7 +1892,11 @@ export class CodexAcpServer {
         const disposePromptRequestCancellation = this.observePromptRequestCancellation(signal, sessionState, activePrompt);
 
         try {
-            const eventHandler = new CodexEventHandler(this.connection, sessionState);
+            const eventHandler = new CodexEventHandler(
+                this.connection,
+                sessionState,
+                clientSupportsPlanUpdates(this.clientCapabilities),
+            );
             const approvalHandler = new CodexApprovalHandler(this.connection, sessionState, activePrompt.signal);
             const elicitationHandler = new CodexElicitationHandler(
                 this.connection,
@@ -2008,7 +2028,7 @@ export class CodexAcpServer {
                     logger.error(`Prompt for cancelled session ${params.sessionId} failed after prompt returned`, err);
                 }
             });
-            const turnCompleted = await Promise.race([
+            let turnCompleted = await Promise.race([
                 sendPromptPromise,
                 activePrompt.closeSignal,
                 this.cancelBeforeTurnStarted(activePrompt),
@@ -2029,6 +2049,82 @@ export class CodexAcpServer {
             if (error) {
                 // noinspection ExceptionCaughtLocallyJS
                 throw error;
+            }
+
+            const completedPlan = eventHandler.takeCompletedPlan();
+            if (
+                completedPlan !== null
+                && sessionState.collaborationMode === PLAN_COLLABORATION_MODE
+                && !this.promptShouldStop(params.sessionId, activePrompt)
+            ) {
+                const approved = await this.requestPlanImplementationPermission(
+                    sessionState,
+                    completedPlan,
+                    activePrompt.signal,
+                );
+                if (this.promptShouldStop(params.sessionId, activePrompt)) {
+                    return this.cancelledPromptResponse(sessionState);
+                }
+                if (approved && !this.promptShouldStop(params.sessionId, activePrompt)) {
+                    await this.applyCollaborationModeChange(sessionState, DEFAULT_COLLABORATION_MODE);
+                    const session = new ACPSessionConnection(this.connection, sessionState.sessionId);
+                    await session.update({
+                        sessionUpdate: "config_option_update",
+                        configOptions: this.createSessionConfigOptions(sessionState),
+                    });
+
+                    const implementationRequest: acp.PromptRequest = {
+                        sessionId: params.sessionId,
+                        prompt: [{type: "text", text: "Implement the approved plan."}],
+                    };
+                    activePrompt.currentTurn = null;
+                    const implementationPromise = this.runWithProcessCheck(
+                        () => this.codexAcpClient.sendPrompt(
+                            implementationRequest,
+                            agentMode,
+                            modelId,
+                            serviceTier,
+                            disableSummary,
+                            sessionState.cwd,
+                            sessionState.additionalDirectories,
+                            (turnId) => {
+                                const turn = {threadId: params.sessionId, turnId};
+                                activePrompt.currentTurn = turn;
+                                if (this.promptShouldStop(params.sessionId, activePrompt)) {
+                                    this.interruptLateStartedTurn(turn);
+                                    return;
+                                }
+                                sessionState.currentTurnId = turnId;
+                            },
+                            () => this.promptShouldStop(params.sessionId, activePrompt),
+                        ),
+                    );
+                    void implementationPromise.catch((err) => {
+                        if (this.activePrompts.get(params.sessionId) !== activePrompt) {
+                            logger.error(`Implementation turn for cancelled prompt ${params.sessionId} failed after prompt returned`, err);
+                        }
+                    });
+                    turnCompleted = await Promise.race([
+                        implementationPromise,
+                        activePrompt.closeSignal,
+                        this.cancelBeforeTurnStarted(activePrompt),
+                    ]);
+
+                    if (turnCompleted === null) {
+                        return this.cancelledPromptResponse(sessionState);
+                    }
+
+                    await this.codexAcpClient.waitForSessionNotifications(params.sessionId);
+                    if (turnCompleted.turn.status === "interrupted") {
+                        await this.notifyConversationInterrupted(params.sessionId);
+                        return this.cancelledPromptResponse(sessionState);
+                    }
+
+                    const implementationError = eventHandler.getFailure();
+                    if (implementationError) {
+                        throw implementationError;
+                    }
+                }
             }
 
             await this.publishFallbackSessionTitle(
@@ -2054,6 +2150,65 @@ export class CodexAcpServer {
                 registeredPendingTurnStart.resolve(null);
             }
             activePrompt.complete();
+        }
+    }
+
+    private async requestPlanImplementationPermission(
+        sessionState: SessionState,
+        plan: CompletedPlan,
+        cancellationSignal: AbortSignal,
+    ): Promise<boolean> {
+        const toolCallId = `plan-review:${plan.itemId}`;
+        try {
+            const response = await this.connection.request(
+                acp.methods.client.session.requestPermission,
+                {
+                    sessionId: sessionState.sessionId,
+                    toolCall: {
+                        toolCallId,
+                        title: "Implement this plan?",
+                        kind: "switch_mode",
+                        status: "pending",
+                        rawInput: {plan: plan.text},
+                    },
+                    options: [
+                        {
+                            optionId: IMPLEMENT_PLAN_OPTION_ID,
+                            name: "Yes, implement this plan",
+                            kind: "allow_once",
+                        },
+                        {
+                            optionId: REVISE_PLAN_OPTION_ID,
+                            name: "No, and tell Codex what to do differently",
+                            kind: "reject_once",
+                        },
+                    ],
+                    _meta: {
+                        codex: {
+                            kind: "plan_review",
+                            planItemId: plan.itemId,
+                        },
+                    },
+                },
+                {cancellationSignal},
+            );
+            const approved = response.outcome.outcome === "selected"
+                && response.outcome.optionId === IMPLEMENT_PLAN_OPTION_ID;
+            await this.connection.notify(acp.methods.client.session.update, {
+                sessionId: sessionState.sessionId,
+                update: {
+                    sessionUpdate: "tool_call_update",
+                    toolCallId,
+                    status: "completed",
+                    rawOutput: approved
+                        ? "User approved the plan."
+                        : "User kept the session in plan mode.",
+                },
+            });
+            return approved;
+        } catch (error) {
+            logger.error("Error requesting plan implementation permission", error);
+            return false;
         }
     }
 

--- a/src/CodexEventHandler.ts
+++ b/src/CodexEventHandler.ts
@@ -68,11 +68,18 @@ import {sameThreadGoalSnapshot, toThreadGoalSnapshot} from "./ThreadGoalSnapshot
 
 export { stripShellPrefix };
 
+export type CompletedPlan = {
+    itemId: string;
+    text: string;
+};
+
 export class CodexEventHandler {
 
     private readonly connection: AcpClientConnection;
     private readonly sessionState: SessionState;
+    private readonly supportsPlanUpdates: boolean;
     private failure: RequestError | null = null;
+    private completedPlan: CompletedPlan | null = null;
     private readonly activeFuzzyFileSearchSessions = new Set<string>();
     private readonly activeGuardianApprovalReviews = new Set<string>();
     private readonly activeImageGenerationItems = new Set<string>();
@@ -84,13 +91,24 @@ export class CodexEventHandler {
     private readonly agentMessagePhases = new Map<string, string | null>();
     private readonly activeSubAgentActivities = new Set<string>();
 
-    constructor(connection: AcpClientConnection, sessionState: SessionState) {
+    constructor(
+        connection: AcpClientConnection,
+        sessionState: SessionState,
+        supportsPlanUpdates = false,
+    ) {
         this.connection = connection;
         this.sessionState = sessionState;
+        this.supportsPlanUpdates = supportsPlanUpdates;
     }
 
     getFailure(): RequestError | null {
         return this.failure;
+    }
+
+    takeCompletedPlan(): CompletedPlan | null {
+        const plan = this.completedPlan;
+        this.completedPlan = null;
+        return plan;
     }
 
     async handleNotification(notification: ServerNotification) {
@@ -301,8 +319,11 @@ export class CodexEventHandler {
             return null;
         }
         const text = this.planDeltaTextByItemId.get(event.itemId) ?? "";
-        this.planDeltaTextByItemId.set(event.itemId, text + event.delta);
-        return null;
+        const updatedText = text + event.delta;
+        this.planDeltaTextByItemId.set(event.itemId, updatedText);
+        return this.supportsPlanUpdates
+            ? this.createPlanUpdateEvent(updatedText, event.itemId)
+            : null;
     }
 
     private createReasoningSectionBreakEvent(event: ReasoningSummaryPartAddedNotification): UpdateSessionEvent {
@@ -447,7 +468,21 @@ export class CodexEventHandler {
         if (text.length === 0) {
             return null;
         }
-        return this.createPlanTextEvent(text, item.id);
+        this.completedPlan = {itemId: item.id, text};
+        return this.supportsPlanUpdates
+            ? this.createPlanUpdateEvent(text, item.id)
+            : this.createPlanTextEvent(text, item.id);
+    }
+
+    private createPlanUpdateEvent(text: string, planId: string): UpdateSessionEvent {
+        return {
+            sessionUpdate: "plan_update",
+            plan: {
+                type: "markdown",
+                planId,
+                content: text,
+            },
+        };
     }
 
     private createPlanTextEvent(text: string, messageId: string): UpdateSessionEvent {

--- a/src/PlanCapabilities.ts
+++ b/src/PlanCapabilities.ts
@@ -1,0 +1,7 @@
+import type * as acp from "@agentclientprotocol/sdk";
+
+export function clientSupportsPlanUpdates(
+    clientCapabilities?: acp.ClientCapabilities | null,
+): boolean {
+    return clientCapabilities?.plan != null;
+}

--- a/src/__tests__/CodexACPAgent/plan-review-events.test.ts
+++ b/src/__tests__/CodexACPAgent/plan-review-events.test.ts
@@ -1,0 +1,202 @@
+import * as acp from "@agentclientprotocol/sdk";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {PLAN_COLLABORATION_MODE} from "../../CollaborationModeConfig";
+import {
+    createCodexMockTestFixture,
+    createTestSessionState,
+    type CodexMockTestFixture,
+} from "../acp-test-utils";
+
+type TurnCompletion = {
+    threadId: string;
+    turn: {
+        id: string;
+        items: never[];
+        itemsView: "notLoaded";
+        status: "completed";
+        error: null;
+        startedAt: null;
+        completedAt: null;
+        durationMs: null;
+    };
+};
+
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((promiseResolve) => {
+        resolve = promiseResolve;
+    });
+    return {promise, resolve};
+}
+
+describe("CodexACPAgent - plan review", () => {
+    let fixture: CodexMockTestFixture;
+    const sessionId = "plan-review-session";
+
+    beforeEach(() => {
+        fixture = createCodexMockTestFixture();
+        vi.clearAllMocks();
+    });
+
+    async function startPlanPrompt(permissionOptionId: string | null) {
+        await fixture.getCodexAcpAgent().initialize({
+            protocolVersion: acp.PROTOCOL_VERSION,
+            clientCapabilities: {plan: {}},
+        });
+        fixture.setPermissionResponse(permissionOptionId === null
+            ? {outcome: {outcome: "cancelled"}}
+            : {outcome: {outcome: "selected", optionId: permissionOptionId}});
+
+        const sessionState = createTestSessionState({
+            sessionId,
+            collaborationMode: PLAN_COLLABORATION_MODE,
+        });
+        vi.spyOn(fixture.getCodexAcpAgent(), "getSessionState").mockReturnValue(sessionState);
+
+        const planTurn = deferred<TurnCompletion>();
+        const implementationTurn = deferred<TurnCompletion>();
+        const turnStart = vi.spyOn(fixture.getCodexAppServerClient(), "turnStart")
+            .mockResolvedValueOnce({
+                turn: {
+                    id: "plan-turn",
+                    items: [],
+                    itemsView: "notLoaded",
+                    status: "inProgress",
+                    error: null,
+                    startedAt: null,
+                    completedAt: null,
+                    durationMs: null,
+                },
+            })
+            .mockResolvedValueOnce({
+                turn: {
+                    id: "implementation-turn",
+                    items: [],
+                    itemsView: "notLoaded",
+                    status: "inProgress",
+                    error: null,
+                    startedAt: null,
+                    completedAt: null,
+                    durationMs: null,
+                },
+            });
+        vi.spyOn(fixture.getCodexAppServerClient(), "awaitTurnCompleted")
+            .mockImplementation((_threadId, turnId) => turnId === "plan-turn"
+                ? planTurn.promise
+                : implementationTurn.promise);
+
+        const promptPromise = fixture.getCodexAcpAgent().prompt({
+            sessionId,
+            prompt: [{type: "text", text: "Plan the change"}],
+        });
+        await vi.waitFor(() => expect(turnStart).toHaveBeenCalledTimes(1));
+
+        fixture.sendServerNotification({
+            method: "item/plan/delta",
+            params: {
+                threadId: sessionId,
+                turnId: "plan-turn",
+                itemId: "plan-item",
+                delta: "# Implementation plan\n\n1. Make the change.",
+            },
+        });
+        fixture.sendServerNotification({
+            method: "item/completed",
+            params: {
+                threadId: sessionId,
+                turnId: "plan-turn",
+                completedAtMs: 0,
+                item: {
+                    type: "plan",
+                    id: "plan-item",
+                    text: "# Implementation plan\n\n1. Make the change.",
+                },
+            },
+        });
+        planTurn.resolve({
+            threadId: sessionId,
+            turn: {
+                id: "plan-turn",
+                items: [],
+                itemsView: "notLoaded",
+                status: "completed",
+                error: null,
+                startedAt: null,
+                completedAt: null,
+                durationMs: null,
+            },
+        });
+
+        return {promptPromise, sessionState, turnStart, implementationTurn};
+    }
+
+    it("requests plan permission and starts one implementation turn when approved", async () => {
+        const {promptPromise, sessionState, turnStart, implementationTurn} = await startPlanPrompt("implement_plan");
+
+        await vi.waitFor(() => expect(turnStart).toHaveBeenCalledTimes(2));
+        expect(turnStart.mock.calls[1]![0]).toMatchObject({
+            threadId: sessionId,
+            input: [{type: "text", text: "Implement the approved plan."}],
+        });
+
+        const events = fixture.getAcpConnectionEvents([]);
+        expect(events).toContainEqual({
+            method: "requestPermission",
+            args: [expect.objectContaining({
+                sessionId,
+                toolCall: expect.objectContaining({
+                    toolCallId: "plan-review:plan-item",
+                    title: "Implement this plan?",
+                    kind: "switch_mode",
+                    rawInput: {plan: "# Implementation plan\n\n1. Make the change."},
+                }),
+                options: [
+                    {optionId: "implement_plan", name: "Yes, implement this plan", kind: "allow_once"},
+                    {optionId: "revise_plan", name: "No, and tell Codex what to do differently", kind: "reject_once"},
+                ],
+            })],
+        });
+        expect(events).toContainEqual({
+            method: "sessionUpdate",
+            args: [{
+                sessionId,
+                update: {
+                    sessionUpdate: "plan_update",
+                    plan: {
+                        type: "markdown",
+                        planId: "plan-item",
+                        content: "# Implementation plan\n\n1. Make the change.",
+                    },
+                },
+            }],
+        });
+        expect(sessionState.collaborationMode).toBe("default");
+
+        implementationTurn.resolve({
+            threadId: sessionId,
+            turn: {
+                id: "implementation-turn",
+                items: [],
+                itemsView: "notLoaded",
+                status: "completed",
+                error: null,
+                startedAt: null,
+                completedAt: null,
+                durationMs: null,
+            },
+        });
+        await expect(promptPromise).resolves.toMatchObject({stopReason: "end_turn"});
+        expect(turnStart).toHaveBeenCalledTimes(2);
+    });
+
+    it.each([
+        ["revise_plan", "rejected"],
+        [null, "cancelled"],
+    ])("keeps plan mode and does not implement when review is %s", async (optionId, _description) => {
+        const {promptPromise, sessionState, turnStart} = await startPlanPrompt(optionId);
+
+        await expect(promptPromise).resolves.toMatchObject({stopReason: "end_turn"});
+        expect(turnStart).toHaveBeenCalledTimes(1);
+        expect(sessionState.collaborationMode).toBe(PLAN_COLLABORATION_MODE);
+    });
+});


### PR DESCRIPTION
## Summary

- emit Codex final plans as ACP Markdown `plan_update` events when the client advertises plan support, with the existing text fallback otherwise
- request explicit implementation permission after a completed Plan Mode turn using a `switch_mode` tool call with the full plan in `rawInput.plan`
- switch back to default collaboration mode and run one implementation turn only when the user approves
- keep Plan Mode active on rejection or cancellation and restore structured plans when replaying history

## Testing

- `npm run typecheck`
- `npm test` (333 passed, 28 skipped)
- real Codex approve flow: permission shown, mode changed to default, exactly two turns
- real Codex reject flow: permission shown, exactly one turn, Plan Mode retained