### PR TITLE
Preserve turn timestamps during session replay

### DIFF
--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -1351,9 +1351,24 @@ export class CodexAcpServer {
 
         const threadUpdates: UpdateSessionEvent[] = [];
         for (const turn of thread.turns) {
+            const turnTiming = turn.startedAt !== null || turn.completedAt !== null
+                ? {startedAt: turn.startedAt, completedAt: turn.completedAt}
+                : null;
             for (const item of turn.items) {
                 const updates = await this.createHistoryUpdates(item, sessionState);
-                threadUpdates.push(...updates);
+                threadUpdates.push(...updates.map(update => {
+                    if (!turnTiming) return update;
+                    return {
+                        ...update,
+                        _meta: {
+                            ...update._meta,
+                            codex: {
+                                ...(update._meta?.["codex"] as Record<string, unknown> | undefined),
+                                ...turnTiming,
+                            },
+                        },
+                    };
+                }));
             }
         }
 

--- a/src/__tests__/CodexACPAgent/data/load-session-history.json
+++ b/src/__tests__/CodexACPAgent/data/load-session-history.json
@@ -130,6 +130,12 @@
         "content": {
           "type": "text",
           "text": "Hi"
+        },
+        "_meta": {
+          "codex": {
+            "startedAt": 1710000000,
+            "completedAt": 1710000005
+          }
         }
       }
     }
@@ -146,6 +152,12 @@
         "content": {
           "type": "text",
           "text": "[@image](https://example.com/image.png)"
+        },
+        "_meta": {
+          "codex": {
+            "startedAt": 1710000000,
+            "completedAt": 1710000005
+          }
         }
       }
     }
@@ -162,6 +174,12 @@
         "content": {
           "type": "text",
           "text": "Hello!"
+        },
+        "_meta": {
+          "codex": {
+            "startedAt": 1710000000,
+            "completedAt": 1710000005
+          }
         }
       }
     }
@@ -178,6 +196,12 @@
         "content": {
           "type": "text",
           "text": "Thinking..."
+        },
+        "_meta": {
+          "codex": {
+            "startedAt": 1710000000,
+            "completedAt": 1710000005
+          }
         }
       }
     }
@@ -208,6 +232,10 @@
           "terminal_info": {
             "cwd": "/test/project",
             "terminal_id": "item-cmd-1"
+          },
+          "codex": {
+            "startedAt": 1710000000,
+            "completedAt": 1710000005
           }
         }
       }
@@ -236,6 +264,10 @@
             "exit_code": 0,
             "signal": null,
             "terminal_id": "item-cmd-1"
+          },
+          "codex": {
+            "startedAt": 1710000000,
+            "completedAt": 1710000005
           }
         }
       }
@@ -263,7 +295,13 @@
               "kind": "add"
             }
           }
-        ]
+        ],
+        "_meta": {
+          "codex": {
+            "startedAt": 1710000000,
+            "completedAt": 1710000005
+          }
+        }
       }
     }
   ]
@@ -285,7 +323,11 @@
           "arguments": {}
         },
         "_meta": {
-          "is_mcp_tool_call": true
+          "is_mcp_tool_call": true,
+          "codex": {
+            "startedAt": 1710000000,
+            "completedAt": 1710000005
+          }
         }
       }
     }
@@ -305,6 +347,12 @@
         "rawInput": {
           "arguments": {
             "includeDisabled": false
+          }
+        },
+        "_meta": {
+          "codex": {
+            "startedAt": 1710000000,
+            "completedAt": 1710000005
           }
         }
       }
@@ -339,6 +387,12 @@
         ],
         "rawInput": {
           "path": "/test/project/input.png"
+        },
+        "_meta": {
+          "codex": {
+            "startedAt": 1710000000,
+            "completedAt": 1710000005
+          }
         }
       }
     }
@@ -378,6 +432,12 @@
           "revisedPrompt": "A tiny blue square",
           "result": "iVBORw0KGgo=",
           "savedPath": "/test/project/generated-blue-square.png"
+        },
+        "_meta": {
+          "codex": {
+            "startedAt": 1710000000,
+            "completedAt": 1710000005
+          }
         }
       }
     }
@@ -395,7 +455,11 @@
         "title": "Context compacted",
         "status": "completed",
         "_meta": {
-          "contextCompaction": true
+          "contextCompaction": true,
+          "codex": {
+            "startedAt": 1710000000,
+            "completedAt": 1710000005
+          }
         }
       }
     }
@@ -423,7 +487,9 @@
               "threadId": "thread-child-1",
               "path": "/root/test_audit",
               "activity": "started"
-            }
+            },
+            "startedAt": 1710000000,
+            "completedAt": 1710000005
           }
         }
       }

--- a/src/__tests__/CodexACPAgent/load-session.test.ts
+++ b/src/__tests__/CodexACPAgent/load-session.test.ts
@@ -74,8 +74,8 @@ describe("CodexACPAgent - loadSession", () => {
                     itemsView: "full",
                     status: "completed",
                     error: null,
-                    startedAt: null,
-                    completedAt: null,
+                    startedAt: 1710000000,
+                    completedAt: 1710000005,
                     durationMs: null,
                     items: [
                         {


### PR DESCRIPTION
[Matt's AI] Session replay currently drops the timing data returned with stored turns, so ACP clients cannot place historical transcript events on their original timeline. This carries each turn's timing window on its replayed updates.

- Adds started and completed epoch timestamps to the Codex metadata namespace
- Preserves existing per-update metadata
- Leaves turns without stored timing data unchanged