### PR TITLE
Fix resuming paused goals

### DIFF
--- a/docs/goal-extension.md
+++ b/docs/goal-extension.md
@@ -12,7 +12,7 @@ An agent advertises support in its `initialize` response:
     "goal": {
       "version": 1,
       "controlMethod": "_session/goal",
-      "actions": ["pause", "clear"]
+      "actions": ["pause", "resume", "clear"]
     }
   }
 }

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -284,8 +284,9 @@ export class CodexAcpServer {
                     throw RequestError.invalidParams(undefined, `Unknown session: ${methodRequest.params.sessionId}`);
                 }
                 const sessionGeneration = this.getSessionGeneration(sessionState.sessionId);
-                if (methodRequest.params.action === "pause") {
-                    const goal = await this.runWithProcessCheck(() => this.codexAcpClient.setGoalStatus(sessionState.sessionId, "paused"));
+                if (methodRequest.params.action === "pause" || methodRequest.params.action === "resume") {
+                    const status = methodRequest.params.action === "pause" ? "paused" : "active";
+                    const goal = await this.runWithProcessCheck(() => this.codexAcpClient.setGoalStatus(sessionState.sessionId, status));
                     if (this.goalPublishIsCurrent(sessionState, sessionGeneration)) {
                         await this.publishGoalSnapshot(sessionState, toThreadGoalSnapshot(goal), false);
                     }

--- a/src/GoalExtension.ts
+++ b/src/GoalExtension.ts
@@ -4,7 +4,7 @@ export const GOAL_EXTENSION_VERSION = 1;
 export const GOAL_CONTROL_METHOD = "_session/goal";
 export const LEGACY_GOAL_CONTROL_METHOD = "_codex/session/goal_control";
 
-export const GOAL_CONTROL_ACTIONS = ["pause", "clear"] as const;
+export const GOAL_CONTROL_ACTIONS = ["pause", "resume", "clear"] as const;
 export type GoalControlAction = typeof GOAL_CONTROL_ACTIONS[number];
 
 export type GoalCapability = {

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -2534,7 +2534,10 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         // @ts-expect-error - registering local session state for the extension request path
         mockFixture.getCodexAcpAgent().sessions.set("session-id", sessionState);
         const pausedGoal = createThreadGoal({status: "paused", timeUsedSeconds: 12});
-        const setStatusSpy = vi.spyOn(mockFixture.getCodexAcpClient(), "setGoalStatus").mockResolvedValue(pausedGoal);
+        const activeGoal = createThreadGoal({status: "active", timeUsedSeconds: 12});
+        const setStatusSpy = vi.spyOn(mockFixture.getCodexAcpClient(), "setGoalStatus")
+            .mockResolvedValueOnce(pausedGoal)
+            .mockResolvedValueOnce(activeGoal);
         const clearGoalSpy = vi.spyOn(mockFixture.getCodexAcpClient(), "clearGoal").mockResolvedValue(undefined);
         const getGoalSpy = vi.spyOn(mockFixture.getCodexAcpClient(), "getGoal");
         mockFixture.clearAcpConnectionDump();
@@ -2545,10 +2548,15 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         })).resolves.toEqual({});
         await expect(mockFixture.getCodexAcpAgent().extMethod(GOAL_CONTROL_METHOD, {
             sessionId: "session-id",
+            action: "resume",
+        })).resolves.toEqual({});
+        await expect(mockFixture.getCodexAcpAgent().extMethod(GOAL_CONTROL_METHOD, {
+            sessionId: "session-id",
             action: "clear",
         })).resolves.toEqual({});
 
-        expect(setStatusSpy).toHaveBeenCalledWith("session-id", "paused");
+        expect(setStatusSpy).toHaveBeenNthCalledWith(1, "session-id", "paused");
+        expect(setStatusSpy).toHaveBeenNthCalledWith(2, "session-id", "active");
         expect(clearGoalSpy).toHaveBeenCalledWith("session-id");
         expect(getGoalSpy).not.toHaveBeenCalled();
         const goalUpdates = mockFixture.getAcpConnectionEvents([]).filter(event =>
@@ -2561,6 +2569,13 @@ describe('ACP server test', { timeout: 40_000 }, () => {
                 args: [expect.objectContaining({
                     update: expect.objectContaining({
                         _meta: {goal: expect.objectContaining({status: "paused"})},
+                    }),
+                })],
+            }),
+            expect.objectContaining({
+                args: [expect.objectContaining({
+                    update: expect.objectContaining({
+                        _meta: {goal: expect.objectContaining({status: "active"})},
                     }),
                 })],
             }),

--- a/src/__tests__/CodexACPAgent/initialize.test.ts
+++ b/src/__tests__/CodexACPAgent/initialize.test.ts
@@ -68,7 +68,7 @@ describe('CodexACPAgent - initialize', () => {
                 goal: {
                     version: 1,
                     controlMethod: "_session/goal",
-                    actions: ["pause", "clear"],
+                    actions: ["pause", "resume", "clear"],
                 },
             },
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ const sessionSteerParamsParser = z.object({
 
 const goalControlParamsParser = z.object({
     sessionId: z.string(),
-    action: z.enum(["pause", "clear"]),
+    action: z.enum(["pause", "resume", "clear"]),
 }).passthrough();
 
 if (process.argv.includes("--version")) {


### PR DESCRIPTION
## Summary
- advertise resume in the provider-neutral goal control capability
- handle resume by setting the Codex goal status back to active and publishing the updated snapshot
- add a regression covering pause, resume, and clear transitions

## Validation
- npm run typecheck
- npm test (344 passed, 28 skipped)
- npm run build
- regression failed before the fix because setGoalStatus was never called with active