### PR TITLE
feat: persist ACP system prompts as developer instructions

### DIFF
--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -1075,7 +1075,7 @@ function readMetaAdditionalRoots(meta?: Record<string, unknown> | null): string[
         .filter(value => value.length > 0));
 }
 
-function readMetaSystemPrompt(meta?: Record<string, unknown> | null): string | undefined {
+export function readMetaSystemPrompt(meta?: Record<string, unknown> | null): string | undefined {
     const rawSystemPrompt = meta?.["systemPrompt"];
     if (rawSystemPrompt === undefined) {
         return undefined;
@@ -1083,13 +1083,13 @@ function readMetaSystemPrompt(meta?: Record<string, unknown> | null): string | u
     if (typeof rawSystemPrompt !== "string") {
         throw RequestError.invalidParams(undefined, "systemPrompt must be a string");
     }
+    if (new TextEncoder().encode(rawSystemPrompt).byteLength > 256 * 1024) {
+        throw RequestError.invalidParams(undefined, "systemPrompt must not exceed 262144 UTF-8 bytes");
+    }
 
     const systemPrompt = rawSystemPrompt.trim();
     if (systemPrompt.length === 0) {
         return undefined;
-    }
-    if (new TextEncoder().encode(systemPrompt).byteLength > 256 * 1024) {
-        throw RequestError.invalidParams(undefined, "systemPrompt must not exceed 262144 UTF-8 bytes");
     }
     return systemPrompt;
 }

--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -387,6 +387,7 @@ export class CodexAcpClient {
     }
 
     async resumeSession(request: acp.ResumeSessionRequest, onSubscribed?: () => void): Promise<SessionMetadata> {
+        const developerInstructions = readMetaSystemPrompt(request._meta);
         const additionalDirectories = readAdditionalDirectories(request.cwd, request.additionalDirectories, request._meta);
         await this.refreshSkills(request.cwd, additionalDirectories);
 
@@ -395,6 +396,7 @@ export class CodexAcpClient {
             cwd: request.cwd,
             modelProvider: await this.getResumeModelProvider(),
             threadId: request.sessionId,
+            ...(developerInstructions === undefined ? {} : {developerInstructions}),
         });
         onSubscribed?.();
         const codexModels = await this.fetchAvailableModels();
@@ -411,6 +413,7 @@ export class CodexAcpClient {
     }
 
     async loadSession(request: acp.LoadSessionRequest, onSubscribed?: () => void): Promise<SessionMetadataWithThread> {
+        const developerInstructions = readMetaSystemPrompt(request._meta);
         const additionalDirectories = readAdditionalDirectories(request.cwd, request.additionalDirectories, request._meta);
         await this.refreshSkills(request.cwd, additionalDirectories);
 
@@ -419,6 +422,7 @@ export class CodexAcpClient {
             cwd: request.cwd,
             modelProvider: await this.getResumeModelProvider(),
             threadId: request.sessionId,
+            ...(developerInstructions === undefined ? {} : {developerInstructions}),
         });
         onSubscribed?.();
         const historyResponse = await this.codexClient.threadRead({
@@ -440,6 +444,7 @@ export class CodexAcpClient {
     }
 
     async newSession(request: acp.NewSessionRequest): Promise<SessionMetadata> {
+        const developerInstructions = readMetaSystemPrompt(request._meta);
         const additionalDirectories = readAdditionalDirectories(request.cwd, request.additionalDirectories, request._meta);
         await this.refreshSkills(request.cwd, additionalDirectories);
 
@@ -447,6 +452,7 @@ export class CodexAcpClient {
             config: await this.createSessionConfig(request.cwd, additionalDirectories, request.mcpServers),
             modelProvider: this.getModelProvider(),
             cwd: request.cwd,
+            ...(developerInstructions === undefined ? {} : {developerInstructions}),
         });
 
         const codexModels = await this.fetchAvailableModels();
@@ -1067,6 +1073,25 @@ function readMetaAdditionalRoots(meta?: Record<string, unknown> | null): string[
         .filter((value): value is string => typeof value === "string")
         .map(value => value.trim())
         .filter(value => value.length > 0));
+}
+
+function readMetaSystemPrompt(meta?: Record<string, unknown> | null): string | undefined {
+    const rawSystemPrompt = meta?.["systemPrompt"];
+    if (rawSystemPrompt === undefined) {
+        return undefined;
+    }
+    if (typeof rawSystemPrompt !== "string") {
+        throw RequestError.invalidParams(undefined, "systemPrompt must be a string");
+    }
+
+    const systemPrompt = rawSystemPrompt.trim();
+    if (systemPrompt.length === 0) {
+        return undefined;
+    }
+    if (new TextEncoder().encode(systemPrompt).byteLength > 256 * 1024) {
+        throw RequestError.invalidParams(undefined, "systemPrompt must not exceed 262144 UTF-8 bytes");
+    }
+    return systemPrompt;
 }
 
 function readAdditionalDirectories(cwd: string, additionalDirectories?: string[],  meta?: Record<string, unknown> | null): string[] {

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -251,6 +251,9 @@ export class CodexAcpServer {
             },
             authMethods: getCodexAuthMethods(_params.clientCapabilities),
             _meta: {
+                capabilities: {
+                    persistentSystemPrompt: true,
+                },
                 steering: {
                     supported: true,
                 },

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -7,6 +7,7 @@ import {type CodexAuthRequest, getCodexAuthMethods, isCodexAuthRequest} from "./
 import {clientSupportsUrlElicitation} from "./ElicitationCapabilities";
 import {
     CodexAcpClient,
+    readMetaSystemPrompt,
     type SessionMetadata,
     type SessionMetadataWithThread,
     type UrlElicitationRequester
@@ -583,6 +584,7 @@ export class CodexAcpServer {
     }
 
     async loadSession(params: acp.LoadSessionRequest): Promise<LegacyLoadSessionResponse> {
+        readMetaSystemPrompt(params._meta);
         logger.log("Loading session...", {sessionId: params.sessionId});
         const {
             sessionId,
@@ -606,6 +608,7 @@ export class CodexAcpServer {
     }
 
     async resumeSession(params: acp.ResumeSessionRequest): Promise<LegacyResumeSessionResponse> {
+        readMetaSystemPrompt(params._meta);
         logger.log("Resuming session...", {sessionId: params.sessionId});
         const [sessionId, modelState, modeState] = await this.getOrCreateSession(params);
 
@@ -714,6 +717,7 @@ export class CodexAcpServer {
     async newSession(
         params: acp.NewSessionRequest,
     ): Promise<LegacyNewSessionResponse> {
+        readMetaSystemPrompt(params._meta);
         logger.log("Starting new session...");
         const [sessionId, modelState, modeState] = await this.getOrCreateSession(params);
 

--- a/src/__tests__/CodexACPAgent/initialize.test.ts
+++ b/src/__tests__/CodexACPAgent/initialize.test.ts
@@ -62,6 +62,9 @@ describe('CodexACPAgent - initialize', () => {
             },
             authMethods: getCodexAuthMethods(),
             _meta: {
+                capabilities: {
+                    persistentSystemPrompt: true,
+                },
                 steering: {
                     supported: true,
                 },

--- a/src/__tests__/CodexACPAgent/persistent-system-prompt.test.ts
+++ b/src/__tests__/CodexACPAgent/persistent-system-prompt.test.ts
@@ -1,0 +1,107 @@
+import {describe, expect, it, vi} from "vitest";
+import {createCodexMockTestFixture, createTestModel} from "../acp-test-utils";
+
+function setupSessionMocks() {
+    const fixture = createCodexMockTestFixture();
+    const client = fixture.getCodexAcpClient();
+    const appServer = fixture.getCodexAppServerClient();
+
+    vi.spyOn(appServer, "listSkills").mockResolvedValue({data: []});
+    vi.spyOn(appServer, "listModels").mockResolvedValue({
+        data: [createTestModel({id: "gpt-5"})],
+        nextCursor: null,
+    });
+    const threadStart = vi.spyOn(appServer, "threadStart").mockResolvedValue({
+        thread: {id: "new-thread"} as never,
+        model: "gpt-5",
+        reasoningEffort: "medium",
+        serviceTier: null,
+    } as never);
+    const threadResume = vi.spyOn(appServer, "threadResume").mockImplementation(async ({threadId}) => ({
+        thread: {id: threadId} as never,
+        model: "gpt-5",
+        reasoningEffort: "medium",
+        serviceTier: null,
+    }) as never);
+    vi.spyOn(appServer, "threadRead").mockImplementation(async ({threadId}) => ({
+        thread: {id: threadId} as never,
+    }) as never);
+
+    return {client, threadStart, threadResume};
+}
+
+describe("persistent system prompt metadata", () => {
+    it("installs systemPrompt as developer instructions when creating a session", async () => {
+        const {client, threadStart} = setupSessionMocks();
+
+        await client.newSession({
+            cwd: "/workspace",
+            mcpServers: [],
+            _meta: {
+                systemPrompt: "  [Base]\nOperate as the Buzz managed agent.  ",
+            },
+        });
+
+        expect(threadStart).toHaveBeenCalledWith(expect.objectContaining({
+            developerInstructions: "[Base]\nOperate as the Buzz managed agent.",
+        }));
+    });
+
+    it("reapplies systemPrompt as developer instructions when resuming or loading a session", async () => {
+        const {client, threadResume} = setupSessionMocks();
+        const meta = {systemPrompt: "Buzz persistent instructions"};
+
+        await client.resumeSession({
+            sessionId: "resume-thread",
+            cwd: "/workspace",
+            _meta: meta,
+        });
+        await client.loadSession({
+            sessionId: "load-thread",
+            cwd: "/workspace",
+            mcpServers: [],
+            _meta: meta,
+        });
+
+        expect(threadResume).toHaveBeenNthCalledWith(1, expect.objectContaining({
+            threadId: "resume-thread",
+            developerInstructions: "Buzz persistent instructions",
+        }));
+        expect(threadResume).toHaveBeenNthCalledWith(2, expect.objectContaining({
+            threadId: "load-thread",
+            developerInstructions: "Buzz persistent instructions",
+        }));
+    });
+
+    it("omits developer instructions when systemPrompt is absent or blank", async () => {
+        const {client, threadStart} = setupSessionMocks();
+
+        await client.newSession({cwd: "/workspace", mcpServers: []});
+        await client.newSession({
+            cwd: "/workspace",
+            mcpServers: [],
+            _meta: {systemPrompt: " \n\t "},
+        });
+
+        expect(threadStart.mock.calls[0]![0]).not.toHaveProperty("developerInstructions");
+        expect(threadStart.mock.calls[1]![0]).not.toHaveProperty("developerInstructions");
+    });
+
+    it("rejects malformed or oversized systemPrompt metadata before starting a thread", async () => {
+        const {client, threadStart} = setupSessionMocks();
+
+        await expect(client.newSession({
+            cwd: "/workspace",
+            mcpServers: [],
+            _meta: {systemPrompt: 42},
+        })).rejects.toThrow("systemPrompt must be a string");
+
+        await expect(client.newSession({
+            cwd: "/workspace",
+            mcpServers: [],
+            _meta: {systemPrompt: "a".repeat(256 * 1024 + 1)},
+        })).rejects.toThrow("systemPrompt must not exceed 262144 UTF-8 bytes");
+
+        expect(threadStart).not.toHaveBeenCalled();
+    });
+});

--- a/src/__tests__/CodexACPAgent/persistent-system-prompt.test.ts
+++ b/src/__tests__/CodexACPAgent/persistent-system-prompt.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, it, vi} from "vitest";
+import type {CodexAcpServer} from "../../CodexAcpServer";
 import {createCodexMockTestFixture, createTestModel} from "../acp-test-utils";
 
 function setupSessionMocks() {
@@ -28,6 +29,57 @@ function setupSessionMocks() {
     }) as never);
 
     return {client, threadStart, threadResume};
+}
+
+function setupServerValidationMocks() {
+    const fixture = createCodexMockTestFixture();
+    const agent = fixture.getCodexAcpAgent();
+    const client = fixture.getCodexAcpClient();
+    const appServer = fixture.getCodexAppServerClient();
+
+    const authRequired = vi.spyOn(client, "authRequired").mockResolvedValue(false);
+    const getAccount = vi.spyOn(client, "getAccount");
+    const clientNewSession = vi.spyOn(client, "newSession");
+    const clientResumeSession = vi.spyOn(client, "resumeSession");
+    const clientLoadSession = vi.spyOn(client, "loadSession");
+    const listSkills = vi.spyOn(appServer, "listSkills").mockResolvedValue({data: []});
+    const threadStart = vi.spyOn(appServer, "threadStart");
+    const threadResume = vi.spyOn(appServer, "threadResume");
+    const threadRead = vi.spyOn(appServer, "threadRead");
+
+    return {
+        agent,
+        authRequired,
+        getAccount,
+        clientNewSession,
+        clientResumeSession,
+        clientLoadSession,
+        listSkills,
+        threadStart,
+        threadResume,
+        threadRead,
+    };
+}
+
+function invokeSessionRoute(
+    agent: CodexAcpServer,
+    route: "new" | "resume" | "load",
+    systemPrompt: unknown,
+) {
+    const _meta = {systemPrompt};
+    switch (route) {
+        case "new":
+            return agent.newSession({cwd: "/workspace", mcpServers: [], _meta});
+        case "resume":
+            return agent.resumeSession({sessionId: "resume-thread", cwd: "/workspace", _meta});
+        case "load":
+            return agent.loadSession({sessionId: "load-thread", cwd: "/workspace", mcpServers: [], _meta});
+    }
+}
+
+function getPendingSessionOpenCount(agent: CodexAcpServer): number {
+    return (agent as unknown as {sessionOpenGenerations: Map<string, number>})
+        .sessionOpenGenerations.size;
 }
 
 describe("persistent system prompt metadata", () => {
@@ -104,4 +156,58 @@ describe("persistent system prompt metadata", () => {
 
         expect(threadStart).not.toHaveBeenCalled();
     });
+
+    it("applies the byte limit to raw UTF-8 metadata before trimming", async () => {
+        const {client, threadStart} = setupSessionMocks();
+        const exactlyAtLimit = "é".repeat(128 * 1024);
+
+        await client.newSession({
+            cwd: "/workspace",
+            mcpServers: [],
+            _meta: {systemPrompt: exactlyAtLimit},
+        });
+        await expect(client.newSession({
+            cwd: "/workspace",
+            mcpServers: [],
+            _meta: {systemPrompt: `${exactlyAtLimit}a`},
+        })).rejects.toThrow("systemPrompt must not exceed 262144 UTF-8 bytes");
+        await expect(client.newSession({
+            cwd: "/workspace",
+            mcpServers: [],
+            _meta: {systemPrompt: `${" ".repeat(256 * 1024)}x`},
+        })).rejects.toThrow("systemPrompt must not exceed 262144 UTF-8 bytes");
+
+        expect(threadStart).toHaveBeenCalledTimes(1);
+        expect(threadStart).toHaveBeenCalledWith(expect.objectContaining({
+            developerInstructions: exactlyAtLimit,
+        }));
+    });
+
+    it.each(["new", "resume", "load"] as const)(
+        "rejects invalid metadata before public %s-session side effects",
+        async (route) => {
+            const invalidCases: Array<[unknown, string]> = [
+                [42, "systemPrompt must be a string"],
+                [`${" ".repeat(256 * 1024)}x`, "systemPrompt must not exceed 262144 UTF-8 bytes"],
+            ];
+
+            for (const [systemPrompt, expectedMessage] of invalidCases) {
+                const mocks = setupServerValidationMocks();
+
+                await expect(invokeSessionRoute(mocks.agent, route, systemPrompt))
+                    .rejects.toThrow(expectedMessage);
+
+                expect(mocks.authRequired).not.toHaveBeenCalled();
+                expect(mocks.getAccount).not.toHaveBeenCalled();
+                expect(mocks.clientNewSession).not.toHaveBeenCalled();
+                expect(mocks.clientResumeSession).not.toHaveBeenCalled();
+                expect(mocks.clientLoadSession).not.toHaveBeenCalled();
+                expect(mocks.listSkills).not.toHaveBeenCalled();
+                expect(mocks.threadStart).not.toHaveBeenCalled();
+                expect(mocks.threadResume).not.toHaveBeenCalled();
+                expect(mocks.threadRead).not.toHaveBeenCalled();
+                expect(getPendingSessionOpenCount(mocks.agent)).toBe(0);
+            }
+        },
+    );
 });


### PR DESCRIPTION
## Summary

ACP clients such as Buzz need a way to install stable managed-agent instructions once instead of repeating them inside every ordinary user prompt. `codex-acp` currently has no advertised persistent-system-prompt capability, so clients cannot safely select that behavior.

This PR adds the Codex side of the negotiated contract:

- advertise `_meta.capabilities.persistentSystemPrompt: true` during initialization;
- accept `_meta.systemPrompt` on new, resumed, and loaded ACP sessions;
- normalize and validate the value before any thread/session side effect;
- pass valid content to Codex as `developerInstructions`;
- reject malformed values and prompts larger than 256 KiB;
- omit developer instructions when the value is absent or blank;
- cover new, resume, and load paths plus exact validation boundaries.

This keeps static client-owned instructions in Codex's developer-instruction layer while leaving ordinary user turns free of repeated base/system material.

## Companion work

**Hard dependency for the accepted Buzz path:** the companion Buzz contribution negotiates this capability, sends its assembled static context once during `session/new`, and suppresses legacy repetition on ordinary turns:

https://github.com/block/buzz/compare/main...Peakhunter:buzz:fix/acp-persistent-system-prompt?expand=1

The Buzz publication head is `1db51a13a60e09f0876c41e163fc082453c45456`. Its source tree is byte-identical to the live-tested candidate head.

## Related work

- Buzz issue [#3242](https://github.com/block/buzz/issues/3242) tracks repeated full-context injection. This coordinated change addresses its static Base/System portion for adapters that advertise persistent prompt support; dynamic thread-context deduplication remains separate.
- Buzz issue [#5342](https://github.com/block/buzz/issues/5342) tracks loss of channel-session continuity after a Buzz restart. Live acceptance reproduced it, but the failure occurs because Buzz does not persist and resume its channel-to-session mapping; this adapter already supports `session/resume` and `session/load` when a client invokes them.
- Buzz PR [#4183](https://github.com/block/buzz/pull/4183) addresses unsupported protocol-v1 adapters by sending standing context once through the legacy user-message path. The coordinated PRs here instead negotiate developer/system instruction transport with the adapter, preserving instruction authority.

## Scope

This change owns persistent developer instructions only. It does not persist a client's channel-to-ACP-session mapping across client application restarts, hide Codex sessions from ChatGPT, alter worker-pool sizing, deduplicate dynamic thread context, or change sandboxed outbound network/delivery policy.

## Validation

Automated verification at exact head `1cf677dbe2801c4dbab678fc9e479a4a7fd87aa6`:

- **363 tests passed**;
- **28 E2E tests skipped**;
- TypeScript typecheck passed;
- rebuilt entry SHA-256 matched the previously recorded candidate exactly: `11120fdbfb9de40e3ad42a800f25b89b95a4719d082400acd1dbd65d50712ff2`.

Supervised macOS acceptance with the coordinated Buzz candidate established:

- initialization advertised `persistentSystemPrompt: true`;
- two ordinary turns continued one main Codex session;
- static Buzz instructions appeared once in initial developer instructions;
- the static material appeared zero times in both ordinary user-prompt records;
- after the client application restarted, the newly created session received the static instructions once and its ordinary prompt remained free of repeated static material.

The restart test also confirmed an existing client-side limitation: Buzz currently creates a new ACP/Codex session after a Desktop restart because its channel-to-session mapping is process-local. That lifecycle behavior is intentionally outside this adapter PR.