### PR TITLE
perf: avoid returning unused thread history during session resume

### DIFF
--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -393,6 +393,7 @@ export class CodexAcpClient {
         const response = await this.codexClient.threadResume({
             config: await this.createSessionConfig(request.cwd, additionalDirectories, request.mcpServers ?? []),
             cwd: request.cwd,
+            excludeTurns: true,
             modelProvider: await this.getResumeModelProvider(),
             threadId: request.sessionId,
         });
@@ -417,6 +418,7 @@ export class CodexAcpClient {
         const response = await this.codexClient.threadResume({
             config: await this.createSessionConfig(request.cwd, additionalDirectories, request.mcpServers ?? []),
             cwd: request.cwd,
+            excludeTurns: true,
             modelProvider: await this.getResumeModelProvider(),
             threadId: request.sessionId,
         });

--- a/src/CodexAppServerClient.ts
+++ b/src/CodexAppServerClient.ts
@@ -974,7 +974,11 @@ export type CompactionCompletedNotification =
     | { method: "thread/compacted", params: Extract<ServerNotification, { method: "thread/compacted" }>["params"] }
     | { method: "item/completed", params: ItemCompletedNotification & { item: Extract<ItemCompletedNotification["item"], { type: "contextCompaction" }> } };
 
-type CodexRequest = DistributiveOmit<ClientRequest, "id">
+type StableCodexRequest = DistributiveOmit<ClientRequest, "id">
+
+type CodexRequest =
+    | Exclude<StableCodexRequest, { method: "thread/resume" }>
+    | { method: "thread/resume", params: ExperimentalThreadResumeParams }
 
 type DistributiveOmit<T, K extends keyof any> = T extends any
     ? Omit<T, K>
@@ -993,7 +997,7 @@ export interface ExperimentalThreadSettingsUpdateParams {
 }
 
 // The adapter opts into app-server's experimental API, while the checked-in
-// generated bindings intentionally contain only stable fields.
+// generated bindings currently contain only stable fields.
 type ExperimentalThreadResumeParams = ThreadResumeParams & {
     excludeTurns?: boolean;
 };

--- a/src/CodexAppServerClient.ts
+++ b/src/CodexAppServerClient.ts
@@ -526,7 +526,7 @@ export class CodexAppServerClient {
         return await this.sendRequest({ method: "thread/start", params: params });
     }
 
-    async threadResume(params: ThreadResumeParams): Promise<ThreadResumeResponse> {
+    async threadResume(params: ExperimentalThreadResumeParams): Promise<ThreadResumeResponse> {
         return await this.sendRequest({ method: "thread/resume", params: params });
     }
 
@@ -991,6 +991,12 @@ export interface ExperimentalThreadSettingsUpdateParams {
         };
     };
 }
+
+// The adapter opts into app-server's experimental API, while the checked-in
+// generated bindings intentionally contain only stable fields.
+type ExperimentalThreadResumeParams = ThreadResumeParams & {
+    excludeTurns?: boolean;
+};
 
 type McpServerStartupSnapshot = {
     status: McpServerStartupState;

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -4,12 +4,14 @@ import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {CODEX_API_KEY_ENV_VAR, OPENAI_API_KEY_ENV_VAR, type CodexAuthRequest} from "../../CodexAuthMethod";
 import type * as acp from "@agentclientprotocol/sdk";
 import {
+    createBaseTestFixture,
     createCodexMockTestFixture,
     createTestFixture,
     createTestModel,
     createTestSessionState,
     type TestFixture
 } from "../acp-test-utils";
+import type {MessageConnection} from "vscode-jsonrpc/node";
 import type {ServerNotification} from "../../app-server";
 import type {SessionState} from "../../CodexAcpServer";
 import {AgentMode} from "../../AgentMode";
@@ -577,6 +579,45 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         expect(threadReadSpy).toHaveBeenCalledWith({
             threadId: "thread-id",
             includeTurns: true,
+        });
+    });
+
+    it('sends excludeTurns through the app-server transport', async () => {
+        const sendRequest = vi.fn().mockResolvedValue({
+            thread: {id: "thread-id"},
+            model: "gpt-5",
+            modelProvider: "openai",
+            reasoningEffort: "medium",
+            serviceTier: null,
+        });
+        const connection = {
+            sendRequest,
+            onUnhandledNotification: () => {},
+            onNotification: () => {},
+            onRequest: () => {},
+            end: () => {},
+        } as unknown as MessageConnection;
+        const transportFixture = createBaseTestFixture({
+            connection,
+            getExitCode: () => null,
+        });
+
+        await transportFixture.getCodexAppServerClient().threadResume({
+            threadId: "thread-id",
+            excludeTurns: true,
+        });
+
+        expect(sendRequest).toHaveBeenCalledWith("thread/resume", {
+            threadId: "thread-id",
+            excludeTurns: true,
+        });
+        expect(transportFixture.getCodexConnectionEvents([])[0]).toEqual({
+            eventType: "request",
+            method: "thread/resume",
+            params: {
+                threadId: "thread-id",
+                excludeTurns: true,
+            },
         });
     });
 

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -533,6 +533,53 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         });
     });
 
+    it('excludes unused app-server turns when resuming and loading sessions', async () => {
+        const mockFixture = createCodexMockTestFixture();
+        const codexAcpClient = mockFixture.getCodexAcpClient();
+        const codexAppServerClient = mockFixture.getCodexAppServerClient();
+
+        vi.spyOn(codexAppServerClient, "skillsExtraRootsSet").mockResolvedValue(undefined);
+        vi.spyOn(codexAppServerClient, "listSkills").mockResolvedValue({data: []});
+        const threadResumeSpy = vi.spyOn(codexAppServerClient, "threadResume").mockResolvedValue({
+            thread: {id: "thread-id"} as any,
+            model: "gpt-5",
+            modelProvider: "openai",
+            reasoningEffort: "medium",
+            serviceTier: null,
+        } as any);
+        const threadReadSpy = vi.spyOn(codexAppServerClient, "threadRead").mockResolvedValue({
+            thread: {id: "thread-id"} as any,
+        });
+        vi.spyOn(codexAppServerClient, "listModels").mockResolvedValue({
+            data: [createTestModel({id: "gpt-5"})],
+            nextCursor: null,
+        });
+
+        await codexAcpClient.resumeSession({
+            sessionId: "resume-id",
+            cwd: "/workspace",
+        });
+        await codexAcpClient.loadSession({
+            sessionId: "load-id",
+            cwd: "/workspace",
+            mcpServers: [],
+        });
+
+        expect(threadResumeSpy).toHaveBeenNthCalledWith(1, expect.objectContaining({
+            threadId: "resume-id",
+            excludeTurns: true,
+        }));
+        expect(threadResumeSpy).toHaveBeenNthCalledWith(2, expect.objectContaining({
+            threadId: "load-id",
+            excludeTurns: true,
+        }));
+        expect(threadReadSpy).toHaveBeenCalledOnce();
+        expect(threadReadSpy).toHaveBeenCalledWith({
+            threadId: "thread-id",
+            includeTurns: true,
+        });
+    });
+
     it('restores collaboration mode for resumed and loaded sessions', async () => {
         const mockFixture = createCodexMockTestFixture();
         const codexAcpAgent = mockFixture.getCodexAcpAgent();


### PR DESCRIPTION
## Summary

- pass `excludeTurns: true` when ACP `session/resume` and `session/load` establish the app-server subscription
- keep `thread/read({ includeTurns: true })` unchanged for `session/load`, preserving full ACP history replay
- add a narrow local type for the experimental resume field and regression coverage for both lifecycle paths

## Why

`thread/resume` includes the reconstructed turn history by default. Neither ACP path consumes that response history: `session/resume` must not replay it, while `session/load` deliberately reads the authoritative full history with a subsequent `thread/read`.

In one observed run on a real legacy thread backed by a 486 MiB rollout (77 turns, 2,306 items), Codex 0.147.0 produced:

| Resume request | Response size | Response time | Client JSON parse |
| --- | ---: | ---: | ---: |
| default | 65,991,086 bytes | 1,332.77 ms | 32.61 ms |
| `excludeTurns: true` | 1,461 bytes | 1,079.24 ms | 0.02 ms |

This removes one unused large JSON response from both lifecycle paths. For `session/load`, the required full history still comes from `thread/read`, so the history and tool-call replay behavior introduced in #208 remains unchanged.

The adapter already opts into app-server experimental APIs and depends on `@openai/codex ^0.147.0`. The checked-in generated bindings currently omit experimental fields, so this uses the same local-type pattern already used for experimental thread settings instead of regenerating the whole experimental schema.

## Validation

- `npm run typecheck`
- `npm test` — 357 passed, 28 skipped, including a transport-level assertion for the experimental JSON-RPC parameter
- `npm run build`
- `npm run codex-test -- -p "Reply with exactly: resume-history-validation" -o summary` — completed with `end_turn` (49 Codex events, 8 ACP events)
- direct Codex 0.147.0 app-server comparison on an isolated copy of the real rollout
