### PR TITLE
feat: expose typed session failures for AIR

### DIFF
--- a/src/AirExtension.ts
+++ b/src/AirExtension.ts
@@ -1,0 +1,14 @@
+/**
+ * Wire names for the versioned JetBrains AIR ACP extension.
+ *
+ * `jetbrains.air` is a protocol namespace, not user-facing branding: `jetbrains`
+ * owns the non-standard contract and `air` identifies the client that defines its
+ * rendering semantics. Keeping both levels prevents unrelated JetBrains ACP clients
+ * from accidentally interpreting or colliding with this metadata.
+ */
+export const JETBRAINS_META_KEY = "jetbrains";
+export const AIR_META_KEY = "air";
+export const AIR_EXTENSION_VERSION_KEY = "version";
+export const AIR_EXTENSION_CAPABILITIES_KEY = "capabilities";
+export const AIR_SESSION_FAILURE_KEY = "sessionFailure";
+export const AIR_EXTENSION_VERSION = 1;

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -92,6 +92,14 @@ import {
 } from "./ContentChunks";
 import {sameThreadGoalSnapshot, type ThreadGoalSnapshot, toThreadGoalSnapshot,} from "./ThreadGoalSnapshot";
 import {randomUUID} from "node:crypto";
+import {
+    AIR_EXTENSION_CAPABILITIES_KEY,
+    AIR_EXTENSION_VERSION,
+    AIR_EXTENSION_VERSION_KEY,
+    AIR_META_KEY,
+    AIR_SESSION_FAILURE_KEY,
+    JETBRAINS_META_KEY,
+} from "./AirExtension";
 
 const IMPLEMENT_PLAN_OPTION_ID = "implement_plan";
 const REVISE_PLAN_OPTION_ID = "revise_plan";
@@ -147,15 +155,15 @@ export interface SessionFailure {
 const CODEX_PROCESS_EXITED_ERROR_CODE = 1001;
 
 function clientSupportsTypedSessionFailures(capabilities: acp.ClientCapabilities | null): boolean {
-    const jetbrains = capabilities?._meta?.["jetbrains"] as Record<string, unknown> | undefined;
-    const air = jetbrains?.["air"] as Record<string, unknown> | undefined;
-    const version = air?.["version"];
-    const supported = air?.["capabilities"];
+    const jetbrains = capabilities?._meta?.[JETBRAINS_META_KEY] as Record<string, unknown> | undefined;
+    const air = jetbrains?.[AIR_META_KEY] as Record<string, unknown> | undefined;
+    const version = air?.[AIR_EXTENSION_VERSION_KEY];
+    const supported = air?.[AIR_EXTENSION_CAPABILITIES_KEY];
     return typeof version === "number"
         && Number.isInteger(version)
-        && version >= 1
+        && version >= AIR_EXTENSION_VERSION
         && Array.isArray(supported)
-        && supported.includes("sessionFailure");
+        && supported.includes(AIR_SESSION_FAILURE_KEY);
 }
 
 interface ActiveAuthState {
@@ -296,10 +304,10 @@ export class CodexAcpServer {
                     controlMethod: GOAL_CONTROL_METHOD,
                     actions: [...GOAL_CONTROL_ACTIONS],
                 },
-                jetbrains: {
-                    air: {
-                        version: 1,
-                        capabilities: ["sessionFailure"],
+                [JETBRAINS_META_KEY]: {
+                    [AIR_META_KEY]: {
+                        [AIR_EXTENSION_VERSION_KEY]: AIR_EXTENSION_VERSION,
+                        [AIR_EXTENSION_CAPABILITIES_KEY]: [AIR_SESSION_FAILURE_KEY],
                     },
                 },
             },

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -91,6 +91,7 @@ import {
     createUserMessageChunk,
 } from "./ContentChunks";
 import {sameThreadGoalSnapshot, type ThreadGoalSnapshot, toThreadGoalSnapshot,} from "./ThreadGoalSnapshot";
+import {randomUUID} from "node:crypto";
 
 const IMPLEMENT_PLAN_OPTION_ID = "implement_plan";
 const REVISE_PLAN_OPTION_ID = "revise_plan";
@@ -121,6 +122,40 @@ export interface SessionState {
     goalRevision: number;
     sessionTitle: string | null;
     sessionTitleSource: "unset" | "fallback" | "explicit" | "unknown";
+    sessionFailure?: SessionFailure;
+}
+
+export type SessionFailureCategory =
+    | "transport_lost" | "auth_required" | "rate_limited" | "quota_exhausted" | "overloaded"
+    | "context_exhausted" | "budget_exhausted" | "policy_denied" | "bad_request"
+    | "provider_error" | "internal_error";
+
+export type SessionFailureAction = "retry" | "reconnect" | "login" | "new_turn" | "new_session";
+
+export interface SessionFailure {
+    id: string;
+    revision: number;
+    phase: "active" | "cleared";
+    category: SessionFailureCategory;
+    source: "codex";
+    safeMessage: string;
+    retryable: boolean;
+    actions: SessionFailureAction[];
+    turnId?: string;
+}
+
+const CODEX_PROCESS_EXITED_ERROR_CODE = 1001;
+
+function clientSupportsTypedSessionFailures(capabilities: acp.ClientCapabilities | null): boolean {
+    const jetbrains = capabilities?._meta?.["jetbrains"] as Record<string, unknown> | undefined;
+    const air = jetbrains?.["air"] as Record<string, unknown> | undefined;
+    const version = air?.["version"];
+    const supported = air?.["capabilities"];
+    return typeof version === "number"
+        && Number.isInteger(version)
+        && version >= 1
+        && Array.isArray(supported)
+        && supported.includes("sessionFailure");
 }
 
 interface ActiveAuthState {
@@ -161,6 +196,7 @@ export class CodexAcpServer {
     private readonly defaultAuthRequest: CodexAuthRequest | null;
     private readonly getExitCode: () => number | null;
     private readonly getRecentStderr: () => string;
+    private readonly sessionFailureEpoch: string;
     private readonly availableCommands: CodexCommands;
     private clientInfo: acp.Implementation | null;
     private clientCapabilities: acp.ClientCapabilities | null;
@@ -198,6 +234,7 @@ export class CodexAcpServer {
         this.defaultAuthRequest = defaultAuthRequest ?? null;
         this.getExitCode = getExitCode ?? (() => null);
         this.getRecentStderr = getRecentStderr ?? (() => "");
+        this.sessionFailureEpoch = randomUUID();
         this.clientInfo = null;
         this.clientCapabilities = null;
         this.terminalOutputMode = "terminal_output_delta";
@@ -258,6 +295,12 @@ export class CodexAcpServer {
                     version: GOAL_EXTENSION_VERSION,
                     controlMethod: GOAL_CONTROL_METHOD,
                     actions: [...GOAL_CONTROL_ACTIONS],
+                },
+                jetbrains: {
+                    air: {
+                        version: 1,
+                        capabilities: ["sessionFailure"],
+                    },
                 },
             },
         };
@@ -1977,6 +2020,7 @@ export class CodexAcpServer {
             prompt: params.prompt,
         });
         const sessionState = this.getSessionState(params.sessionId);
+        let recoverableSessionFailure = sessionState.sessionFailure;
         sessionState.currentTurnId = null;
         sessionState.lastTokenUsage = null;
         const activePrompt = this.trackActivePrompt(params.sessionId);
@@ -1990,12 +2034,24 @@ export class CodexAcpServer {
         };
         const disposePromptRequestCancellation = this.observePromptRequestCancellation(signal, sessionState, activePrompt);
         let eventHandler: CodexEventHandler | null = null;
+        let promptNotificationsActive = true;
+        const clearRecoveredSessionFailure = async (handler: CodexEventHandler): Promise<void> => {
+            const current = sessionState.sessionFailure;
+            if (recoverableSessionFailure?.phase === "active"
+                && current?.phase === "active"
+                && current.id === recoverableSessionFailure.id
+                && current.revision === recoverableSessionFailure.revision) {
+                await handler.clearSessionFailure();
+            }
+        };
 
         try {
             const promptEventHandler = new CodexEventHandler(
                 this.connection,
                 sessionState,
                 clientSupportsPlanUpdates(this.clientCapabilities),
+                clientSupportsTypedSessionFailures(this.clientCapabilities),
+                this.sessionFailureEpoch,
             );
             eventHandler = promptEventHandler;
             const approvalHandler = new CodexApprovalHandler(this.connection, sessionState, activePrompt.signal);
@@ -2007,8 +2063,19 @@ export class CodexAcpServer {
             );
             await this.codexAcpClient.subscribeToSessionEvents(params.sessionId,
                 async (event) => {
+                    if (!promptNotificationsActive) {
+                        await promptEventHandler.handleSessionScopedNotification(event);
+                        return;
+                    }
+                    const completesActiveTurn = event.method === "turn/completed"
+                        && event.params.turn.id === sessionState.currentTurnId;
                     await elicitationHandler.handleNotification(event);
-                    return promptEventHandler.handleNotification(event);
+                    await promptEventHandler.handleNotification(event);
+                    if (completesActiveTurn) {
+                        // The prompt may remain open for plan approval after its turn has ended. Switch at
+                        // the causal boundary so a queued late error cannot enter the completed turn's buffer.
+                        promptNotificationsActive = false;
+                    }
                 },
                 approvalHandler,
                 elicitationHandler);
@@ -2059,8 +2126,14 @@ export class CodexAcpServer {
                 return this.cancelledPromptResponse(sessionState);
             }
             if (commandResult.handled) {
+                promptNotificationsActive = false;
                 logger.log("Prompt handled by a command");
                 await this.codexAcpClient.waitForSessionNotifications(params.sessionId);
+                await eventHandler.flushPendingErrors();
+                await eventHandler.flushPendingErrorsAsSessionScoped();
+                if (commandResult.turnCompleted) {
+                    await eventHandler.handleFailedTurn(commandResult.turnCompleted.turn);
+                }
                 if (commandResult.turnCompleted?.turn.status === "interrupted") {
                     return this.cancelledPromptResponse(sessionState);
                 }
@@ -2069,6 +2142,15 @@ export class CodexAcpServer {
                     // noinspection ExceptionCaughtLocallyJS
                     throw error;
                 }
+                const terminalFailure = this.terminalFailurePromptResponse(
+                    sessionState,
+                    eventHandler,
+                    commandResult.turnCompleted?.turn.id ?? sessionState.currentTurnId,
+                );
+                if (terminalFailure) {
+                    return terminalFailure;
+                }
+                await clearRecoveredSessionFailure(eventHandler);
                 return {
                     stopReason: "end_turn",
                     usage: this.buildPromptUsage(sessionState.lastTokenUsage),
@@ -2143,6 +2225,9 @@ export class CodexAcpServer {
             }
 
             await this.codexAcpClient.waitForSessionNotifications(params.sessionId);
+            await eventHandler.flushPendingErrors();
+            await eventHandler.handleFailedTurn(turnCompleted.turn);
+            promptNotificationsActive = false;
 
             if (turnCompleted.turn.status === "interrupted") {
                 await eventHandler.flushPendingPlanUpdates();
@@ -2153,6 +2238,14 @@ export class CodexAcpServer {
             if (error) {
                 // noinspection ExceptionCaughtLocallyJS
                 throw error;
+            }
+            const terminalFailure = this.terminalFailurePromptResponse(
+                sessionState,
+                eventHandler,
+                turnCompleted.turn.id,
+            );
+            if (terminalFailure) {
+                return terminalFailure;
             }
 
             await eventHandler.flushPendingPlanUpdates();
@@ -2183,6 +2276,7 @@ export class CodexAcpServer {
                         prompt: [{type: "text", text: "Implement the approved plan."}],
                     };
                     activePrompt.currentTurn = null;
+                    sessionState.currentTurnId = null;
                     const implementationPromise = this.runWithProcessCheck(
                         () => this.codexAcpClient.sendPrompt(
                             implementationRequest,
@@ -2200,6 +2294,10 @@ export class CodexAcpServer {
                                     return;
                                 }
                                 sessionState.currentTurnId = turnId;
+                                // Keep the approval-to-turn-start gap session-scoped. Once the new turn has
+                                // an identity, snapshot any unchanged session failure as its recovery baseline.
+                                recoverableSessionFailure = sessionState.sessionFailure;
+                                promptNotificationsActive = true;
                             },
                             () => this.promptShouldStop(params.sessionId, activePrompt),
                         ),
@@ -2220,6 +2318,9 @@ export class CodexAcpServer {
                     }
 
                     await this.codexAcpClient.waitForSessionNotifications(params.sessionId);
+                    await eventHandler.flushPendingErrors();
+                    await eventHandler.handleFailedTurn(turnCompleted.turn);
+                    promptNotificationsActive = false;
                     if (turnCompleted.turn.status === "interrupted") {
                         await eventHandler.flushPendingPlanUpdates();
                         return this.cancelledPromptResponse(sessionState);
@@ -2229,8 +2330,18 @@ export class CodexAcpServer {
                     if (implementationError) {
                         throw implementationError;
                     }
+                    const implementationFailure = this.terminalFailurePromptResponse(
+                        sessionState,
+                        eventHandler,
+                        turnCompleted.turn.id,
+                    );
+                    if (implementationFailure) {
+                        return implementationFailure;
+                    }
                 }
             }
+
+            await clearRecoveredSessionFailure(eventHandler);
 
             await this.publishFallbackSessionTitle(
                 sessionState,
@@ -2244,8 +2355,32 @@ export class CodexAcpServer {
             };
         } catch (err) {
             logger.error(`Prompt for session ${params.sessionId} failed`, err);
+            if (activePrompt.signal.aborted || this.sessionIsClosing(params.sessionId)) {
+                return this.cancelledPromptResponse(sessionState);
+            }
+            const isProcessExit = err instanceof RequestError
+                && err.code === CODEX_PROCESS_EXITED_ERROR_CODE;
+            const isUnexpectedFailure = !(err instanceof RequestError);
+            if (eventHandler !== null
+                && clientSupportsTypedSessionFailures(this.clientCapabilities)
+                && (isProcessExit || isUnexpectedFailure)) {
+                const category: SessionFailureCategory = isProcessExit ? "transport_lost" : "internal_error";
+                eventHandler.recordSyntheticTerminalFailure(category, sessionState.currentTurnId);
+                const failureResponse = this.terminalFailurePromptResponse(
+                    sessionState,
+                    eventHandler,
+                    sessionState.currentTurnId,
+                    true,
+                );
+                if (failureResponse !== null) {
+                    return failureResponse;
+                }
+            }
             throw err;
         } finally {
+            // The app-server subscription is session-scoped and outlives this prompt. Flip routing before
+            // awaiting disposal so queued late notifications cannot enter prompt-local buffers.
+            promptNotificationsActive = false;
             logger.log("Prompt completed", {sessionId: params.sessionId});
             await eventHandler?.dispose();
             disposePromptRequestCancellation();
@@ -2326,6 +2461,26 @@ export class CodexAcpServer {
         };
     }
 
+    private terminalFailurePromptResponse(
+        sessionState: SessionState,
+        eventHandler: CodexEventHandler,
+        turnId: string | null,
+        allowUnattributed = false,
+    ): acp.PromptResponse | null {
+        const failureMeta = eventHandler.getTerminalSessionFailureMeta(turnId, allowUnattributed);
+        if (failureMeta === null) {
+            return null;
+        }
+        return {
+            stopReason: "end_turn",
+            usage: this.buildPromptUsage(sessionState.lastTokenUsage),
+            _meta: {
+                ...this.buildQuotaMeta(sessionState),
+                ...failureMeta,
+            },
+        };
+    }
+
     private buildQuotaMeta(sessionState: SessionState): { quota: QuotaMeta } {
         const lastTokenUsage = sessionState.lastTokenUsage;
 
@@ -2357,7 +2512,7 @@ export class CodexAcpServer {
             return await operation();
         } catch (err) {
             const exitCode = this.getExitCode();
-            const requestErrorCode = 1001 // Just some magic number
+            const requestErrorCode = CODEX_PROCESS_EXITED_ERROR_CODE;
             if (exitCode == 3221225781) {
                 throw new RequestError(requestErrorCode, `VC++ redistributable should be installed`);
             }

--- a/src/CodexEventHandler.ts
+++ b/src/CodexEventHandler.ts
@@ -3,7 +3,11 @@ import type {
     FuzzyFileSearchSessionUpdatedNotification,
     ServerNotification
 } from "./app-server";
-import type {SessionState} from "./CodexAcpServer";
+import type {
+    SessionFailureAction,
+    SessionFailureCategory,
+    SessionState,
+} from "./CodexAcpServer";
 import {type PlanEntry, RequestError} from "@agentclientprotocol/sdk";
 import {ACPSessionConnection, type AcpClientConnection, type UpdateSessionEvent} from "./ACPSessionConnection";
 import type {
@@ -27,6 +31,7 @@ import type {
     ThreadGoalClearedNotification,
     ThreadGoalUpdatedNotification,
     ThreadTokenUsageUpdatedNotification,
+    Turn,
     TurnPlanUpdatedNotification,
     WarningNotification
 } from "./app-server/v2";
@@ -66,6 +71,7 @@ import {
 } from "./ContentChunks";
 import {sameThreadGoalSnapshot, type ThreadGoalSnapshot, toThreadGoalSnapshot} from "./ThreadGoalSnapshot";
 import {logger} from "./Logger";
+import {randomUUID} from "node:crypto";
 
 export { stripShellPrefix };
 
@@ -74,12 +80,33 @@ export type CompletedPlan = {
     text: string;
 };
 
+const SESSION_FAILURE_PRESENTATION: Record<SessionFailureCategory, {
+    message: string;
+    retryable: boolean;
+    actions: SessionFailureAction[];
+}> = {
+    transport_lost: {message: "Connection to Codex was lost.", retryable: true, actions: ["reconnect", "retry"]},
+    auth_required: {message: "Sign in to continue using Codex.", retryable: false, actions: ["login"]},
+    rate_limited: {message: "The Codex rate limit was reached.", retryable: true, actions: ["retry"]},
+    quota_exhausted: {message: "The Codex usage quota is exhausted.", retryable: false, actions: ["new_session"]},
+    overloaded: {message: "Codex is temporarily overloaded.", retryable: true, actions: ["retry"]},
+    context_exhausted: {message: "This conversation has reached its context limit.", retryable: false, actions: ["new_turn"]},
+    budget_exhausted: {message: "This session has reached its usage budget.", retryable: false, actions: ["new_session"]},
+    policy_denied: {message: "The request was blocked by provider policy.", retryable: false, actions: []},
+    bad_request: {message: "Codex could not process this request.", retryable: false, actions: ["new_turn"]},
+    provider_error: {message: "The model provider reported an error.", retryable: true, actions: ["retry"]},
+    internal_error: {message: "Codex encountered an internal error.", retryable: true, actions: ["retry"]},
+};
+
 export class CodexEventHandler {
 
     private static readonly PLAN_UPDATE_INTERVAL_MS = 150;
 
     private readonly sessionState: SessionState;
     private readonly supportsPlanUpdates: boolean;
+    private readonly supportsTypedSessionFailures: boolean;
+    private readonly sessionFailureEpoch: string;
+    private readonly pendingErrors: ErrorNotification[] = [];
     private failure: RequestError | null = null;
     private completedPlan: CompletedPlan | null = null;
     private readonly activeFuzzyFileSearchSessions = new Set<string>();
@@ -103,14 +130,121 @@ export class CodexEventHandler {
         connection: AcpClientConnection,
         sessionState: SessionState,
         supportsPlanUpdates = false,
+        supportsTypedSessionFailures = false,
+        sessionFailureEpoch: string = randomUUID(),
     ) {
         this.sessionState = sessionState;
         this.supportsPlanUpdates = supportsPlanUpdates;
+        this.supportsTypedSessionFailures = supportsTypedSessionFailures;
+        this.sessionFailureEpoch = sessionFailureEpoch;
         this.session = new ACPSessionConnection(connection, sessionState.sessionId);
     }
 
     getFailure(): RequestError | null {
         return this.failure;
+    }
+
+    getTerminalSessionFailureMeta(
+        turnId: string | null,
+        allowUnattributed = false,
+    ): Record<string, unknown> | null {
+        const failure = this.sessionState.sessionFailure;
+        if (!this.supportsTypedSessionFailures
+            || failure?.phase !== "active"
+            || (failure.turnId === undefined
+                ? !allowUnattributed
+                : turnId === null || failure.turnId !== turnId)) {
+            return null;
+        }
+        return this.createSessionFailureMeta(failure);
+    }
+
+    recordSyntheticTerminalFailure(category: SessionFailureCategory, turnId: string | null): void {
+        this.recordSessionFailure(category, turnId ?? undefined);
+    }
+
+    /**
+     * Handles notifications after the prompt-local handler has been disposed. The app-server subscription
+     * remains installed until the ACP session closes, so terminal errors need a durable session-level path
+     * instead of entering a turn buffer that will never be flushed.
+     */
+    async handleSessionScopedNotification(notification: ServerNotification): Promise<void> {
+        if (notification.method !== "error") {
+            await this.handleNotification(notification);
+            return;
+        }
+        if (!this.supportsTypedSessionFailures) {
+            // Preserve the legacy behavior for clients that did not negotiate typed failures.
+            await this.handleNotification(notification);
+            return;
+        }
+        if (notification.params.willRetry) {
+            await this.session.update(this.createSafeErrorDiagnostic(notification.params));
+            return;
+        }
+        const failure = this.recordSessionFailure(
+            this.sessionFailureCategory(notification.params.error.codexErrorInfo),
+            undefined,
+        );
+        await this.session.update(this.createSessionFailureUpdate(failure));
+    }
+
+    async flushPendingErrors(): Promise<void> {
+        if (this.sessionState.currentTurnId === null || this.pendingErrors.length === 0) {
+            return;
+        }
+        const errors = this.pendingErrors.splice(0);
+        for (const error of errors) {
+            const update = await this.createErrorEvent(error);
+            if (update) {
+                await this.session.update(update);
+            }
+        }
+    }
+
+    async flushPendingErrorsAsSessionScoped(): Promise<void> {
+        if (!this.supportsTypedSessionFailures || this.pendingErrors.length === 0) {
+            return;
+        }
+        const errors = this.pendingErrors.splice(0);
+        for (const error of errors) {
+            await this.handleSessionScopedNotification({method: "error", params: error});
+        }
+    }
+
+    async clearSessionFailure(): Promise<void> {
+        const active = this.sessionState.sessionFailure;
+        if (!this.supportsTypedSessionFailures || active?.phase !== "active") {
+            return;
+        }
+        const cleared = {
+            ...active,
+            revision: active.revision + 1,
+            phase: "cleared" as const,
+        };
+        await this.session.update(this.createSessionFailureUpdate(cleared));
+        this.sessionState.sessionFailure = cleared;
+    }
+
+    async handleFailedTurn(turn: Turn): Promise<void> {
+        const activeFailure = this.sessionState.sessionFailure;
+        if (!this.supportsTypedSessionFailures
+            || turn.status !== "failed"
+            || this.failure !== null
+            || (activeFailure?.phase === "active" && activeFailure.turnId === turn.id)) {
+            return;
+        }
+        const error = turn.error ?? {
+            message: "Turn failed",
+            codexErrorInfo: null,
+            additionalDetails: null,
+        };
+        this.recordTypedSessionFailure({
+            threadId: this.sessionState.sessionId,
+            turnId: turn.id,
+            willRetry: false,
+            error,
+        });
     }
 
     takeCompletedPlan(): CompletedPlan | null {
@@ -120,6 +254,7 @@ export class CodexEventHandler {
     }
 
     async handleNotification(notification: ServerNotification) {
+        await this.flushPendingErrors();
         const updateEvent = await this.createUpdateEvent(notification);
         if (updateEvent) {
             await this.session.update(updateEvent);
@@ -144,6 +279,14 @@ export class CodexEventHandler {
     async dispose(): Promise<void> {
         if (this.disposed) return;
         await this.flushPendingPlanUpdates();
+        if (this.pendingErrors.length > 0) {
+            logger.log("Discarding app-server errors that arrived before a turn started", {
+                sessionId: this.sessionState.sessionId,
+                count: this.pendingErrors.length,
+                turnIds: this.pendingErrors.map(error => error.turnId),
+            });
+            this.pendingErrors.splice(0);
+        }
         this.disposed = true;
         this.cancelPlanUpdateTimer();
         this.pendingPlanItemIds.clear();
@@ -174,6 +317,7 @@ export class CodexEventHandler {
                 return await this.createErrorEvent(notification.params);
             case "turn/started":
                 this.sessionState.currentTurnId = notification.params.turn.id;
+                await this.flushPendingErrors();
                 return null;
             case "turn/completed":
                 await this.flushPendingPlanUpdates();
@@ -713,9 +857,29 @@ export class CodexEventHandler {
         }
     }
 
-    private async createErrorEvent(params: ErrorNotification): Promise<UpdateSessionEvent> {
+    private async createErrorEvent(params: ErrorNotification): Promise<UpdateSessionEvent | null> {
         const error = params.error.codexErrorInfo;
+        if (this.sessionState.currentTurnId === null) {
+            this.pendingErrors.push(params);
+            logger.log("Buffered app-server error until the active turn is known", {
+                sessionId: this.sessionState.sessionId,
+                turnId: params.turnId,
+                willRetry: params.willRetry,
+            });
+            return null;
+        }
+        if (params.turnId !== this.sessionState.currentTurnId) {
+            if (this.supportsTypedSessionFailures) {
+                return this.createSafeErrorDiagnostic(params);
+            }
+            return this.createCodexSessionInfoUpdate({
+                error: {...params.error, turnId: params.turnId, willRetry: params.willRetry},
+            });
+        }
         if (params.willRetry) {
+            if (this.supportsTypedSessionFailures) {
+                return this.createSafeErrorDiagnostic(params);
+            }
             return this.createCodexSessionInfoUpdate({
                 error: {
                     ...params.error,
@@ -723,7 +887,14 @@ export class CodexEventHandler {
                     willRetry: true,
                 },
             });
-        } else if (error === "usageLimitExceeded") {
+        }
+        if (this.supportsTypedSessionFailures) {
+            // app-server guarantees willRetry=false interrupts this turn; the terminal failure is
+            // returned once on PromptResponse._meta rather than duplicated as a session update.
+            this.recordTypedSessionFailure(params);
+            return null;
+        }
+        if (error === "usageLimitExceeded") {
             this.failure = RequestError.internalError(
                 this.createTurnErrorData(params.error),
             );
@@ -733,6 +904,93 @@ export class CodexEventHandler {
                 : RequestError.authRequired(this.createTurnErrorData(params.error), params.error.message);
         }
         return createAgentTextMessageChunk(`${params.error.message}\n\n`);
+    }
+
+    private createSafeErrorDiagnostic(params: ErrorNotification): UpdateSessionEvent {
+        const category = this.sessionFailureCategory(params.error.codexErrorInfo);
+        return this.createCodexSessionInfoUpdate({
+            error: {
+                category,
+                message: SESSION_FAILURE_PRESENTATION[category].message,
+                turnId: params.turnId,
+                willRetry: params.willRetry,
+            },
+        });
+    }
+
+    private recordTypedSessionFailure(params: ErrorNotification): void {
+        const category = this.sessionFailureCategory(params.error.codexErrorInfo);
+        this.recordSessionFailure(category, params.turnId);
+    }
+
+    private recordSessionFailure(
+        category: SessionFailureCategory,
+        turnId: string | undefined,
+    ): NonNullable<SessionState["sessionFailure"]> {
+        const presentation = SESSION_FAILURE_PRESENTATION[category];
+        const previous = this.sessionState.sessionFailure;
+        const id = previous?.phase === "active"
+            ? previous.id
+            : turnId === undefined
+                ? `${this.sessionState.sessionId}:error:${this.sessionFailureEpoch}`
+                : `${turnId}:error`;
+        const failure: NonNullable<SessionState["sessionFailure"]> = {
+            id,
+            revision: previous?.id === id ? previous.revision + 1 : 1,
+            phase: "active" as const,
+            category,
+            source: "codex",
+            safeMessage: presentation.message,
+            retryable: presentation.retryable,
+            actions: presentation.actions,
+            ...(turnId === undefined ? {} : {turnId}),
+        };
+        this.sessionState.sessionFailure = failure;
+        return failure;
+    }
+
+    private createSessionFailureMeta(
+        failure: NonNullable<SessionState["sessionFailure"]>,
+    ): Record<string, unknown> {
+        return {
+            jetbrains: {
+                air: {
+                    version: 1,
+                    sessionFailure: failure,
+                },
+            },
+        };
+    }
+
+    private createSessionFailureUpdate(
+        failure: NonNullable<SessionState["sessionFailure"]>,
+    ): UpdateSessionEvent {
+        return {
+            sessionUpdate: "session_info_update",
+            _meta: this.createSessionFailureMeta(failure),
+        };
+    }
+
+    private sessionFailureCategory(error: CodexErrorInfo | null): SessionFailureCategory {
+        if (this.isAuthenticationRequiredError(error)) return "auth_required";
+        if (this.getHttpStatusCode(error) === 429) return "rate_limited";
+        if (typeof error === "object" && error !== null) {
+            if ("httpConnectionFailed" in error || "responseStreamConnectionFailed" in error ||
+                "responseStreamDisconnected" in error || "responseTooManyFailedAttempts" in error) {
+                return "transport_lost";
+            }
+            return "provider_error";
+        }
+        switch (error) {
+            case "usageLimitExceeded": return "quota_exhausted";
+            case "serverOverloaded": return "overloaded";
+            case "contextWindowExceeded": return "context_exhausted";
+            case "sessionBudgetExceeded": return "budget_exhausted";
+            case "cyberPolicy": return "policy_denied";
+            case "badRequest": return "bad_request";
+            case "internalServerError": return "internal_error";
+            default: return "provider_error";
+        }
     }
 
     private isAuthenticationRequiredError(error: CodexErrorInfo | null): boolean {

--- a/src/CodexEventHandler.ts
+++ b/src/CodexEventHandler.ts
@@ -98,6 +98,38 @@ const SESSION_FAILURE_PRESENTATION: Record<SessionFailureCategory, {
     internal_error: {message: "Codex encountered an internal error.", retryable: true, actions: ["retry"]},
 };
 
+type StringCodexErrorInfo = Extract<CodexErrorInfo, string>;
+type StructuredCodexErrorInfo = Exclude<CodexErrorInfo, string>;
+type KeysOfUnion<T> = T extends unknown ? keyof T : never;
+type StructuredCodexErrorKind = KeysOfUnion<StructuredCodexErrorInfo>;
+
+/**
+ * Exhaustive against the generated app-server union: a schema update cannot silently fall through
+ * to provider_error. The runtime lookup still has a fallback for a newer app-server talking to an
+ * older codex-acp build.
+ */
+const STRING_CODEX_ERROR_CATEGORIES = {
+    contextWindowExceeded: "context_exhausted",
+    sessionBudgetExceeded: "budget_exhausted",
+    usageLimitExceeded: "quota_exhausted",
+    serverOverloaded: "overloaded",
+    cyberPolicy: "policy_denied",
+    internalServerError: "internal_error",
+    unauthorized: "auth_required",
+    badRequest: "bad_request",
+    threadRollbackFailed: "provider_error",
+    sandboxError: "provider_error",
+    other: "provider_error",
+} satisfies Record<StringCodexErrorInfo, SessionFailureCategory>;
+
+const STRUCTURED_CODEX_ERROR_CATEGORIES = {
+    httpConnectionFailed: "transport_lost",
+    responseStreamConnectionFailed: "transport_lost",
+    responseStreamDisconnected: "transport_lost",
+    responseTooManyFailedAttempts: "transport_lost",
+    activeTurnNotSteerable: "provider_error",
+} satisfies Record<StructuredCodexErrorKind, SessionFailureCategory>;
+
 export class CodexEventHandler {
 
     private static readonly PLAN_UPDATE_INTERVAL_MS = 150;
@@ -974,23 +1006,17 @@ export class CodexEventHandler {
     private sessionFailureCategory(error: CodexErrorInfo | null): SessionFailureCategory {
         if (this.isAuthenticationRequiredError(error)) return "auth_required";
         if (this.getHttpStatusCode(error) === 429) return "rate_limited";
-        if (typeof error === "object" && error !== null) {
-            if ("httpConnectionFailed" in error || "responseStreamConnectionFailed" in error ||
-                "responseStreamDisconnected" in error || "responseTooManyFailedAttempts" in error) {
-                return "transport_lost";
+        if (typeof error === "string") {
+            return STRING_CODEX_ERROR_CATEGORIES[error] ?? "provider_error";
+        }
+        if (error !== null) {
+            for (const kind of Object.keys(STRUCTURED_CODEX_ERROR_CATEGORIES) as StructuredCodexErrorKind[]) {
+                if (kind in error) {
+                    return STRUCTURED_CODEX_ERROR_CATEGORIES[kind] ?? "provider_error";
+                }
             }
-            return "provider_error";
         }
-        switch (error) {
-            case "usageLimitExceeded": return "quota_exhausted";
-            case "serverOverloaded": return "overloaded";
-            case "contextWindowExceeded": return "context_exhausted";
-            case "sessionBudgetExceeded": return "budget_exhausted";
-            case "cyberPolicy": return "policy_denied";
-            case "badRequest": return "bad_request";
-            case "internalServerError": return "internal_error";
-            default: return "provider_error";
-        }
+        return "provider_error";
     }
 
     private isAuthenticationRequiredError(error: CodexErrorInfo | null): boolean {
@@ -998,18 +1024,10 @@ export class CodexEventHandler {
     }
 
     private getHttpStatusCode(error: CodexErrorInfo | null): number | null {
-        if (error !== null && typeof error === "object") {
-            if ("httpConnectionFailed" in error) {
-                return error.httpConnectionFailed.httpStatusCode;
-            } else if ("responseStreamConnectionFailed" in error) {
-                return error.responseStreamConnectionFailed.httpStatusCode;
-            } else if ("responseStreamDisconnected" in error) {
-                return error.responseStreamDisconnected.httpStatusCode;
-            } else if ("responseTooManyFailedAttempts" in error) {
-                return error.responseTooManyFailedAttempts.httpStatusCode;
-            }
-        }
-        return null;
+        if (error === null || typeof error !== "object") return null;
+        const details: unknown = Object.values(error)[0];
+        if (details === null || typeof details !== "object" || !("httpStatusCode" in details)) return null;
+        return typeof details.httpStatusCode === "number" ? details.httpStatusCode : null;
     }
 
     private createTurnErrorData(error: ErrorNotification["error"]): {

--- a/src/CodexEventHandler.ts
+++ b/src/CodexEventHandler.ts
@@ -72,6 +72,13 @@ import {
 import {sameThreadGoalSnapshot, type ThreadGoalSnapshot, toThreadGoalSnapshot} from "./ThreadGoalSnapshot";
 import {logger} from "./Logger";
 import {randomUUID} from "node:crypto";
+import {
+    AIR_EXTENSION_VERSION,
+    AIR_EXTENSION_VERSION_KEY,
+    AIR_META_KEY,
+    AIR_SESSION_FAILURE_KEY,
+    JETBRAINS_META_KEY,
+} from "./AirExtension";
 
 export { stripShellPrefix };
 
@@ -985,10 +992,10 @@ export class CodexEventHandler {
         failure: NonNullable<SessionState["sessionFailure"]>,
     ): Record<string, unknown> {
         return {
-            jetbrains: {
-                air: {
-                    version: 1,
-                    sessionFailure: failure,
+            [JETBRAINS_META_KEY]: {
+                [AIR_META_KEY]: {
+                    [AIR_EXTENSION_VERSION_KEY]: AIR_EXTENSION_VERSION,
+                    [AIR_SESSION_FAILURE_KEY]: failure,
                 },
             },
         };

--- a/src/__tests__/CodexACPAgent/auth-error-events.test.ts
+++ b/src/__tests__/CodexACPAgent/auth-error-events.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
+import * as acp from "@agentclientprotocol/sdk";
 import type { ErrorNotification, TurnCompletedNotification } from "../../app-server/v2";
 import type { SessionState } from "../../CodexAcpServer";
 import {
     createCodexMockTestFixture,
     createTestSessionState,
 } from "../acp-test-utils";
+import {logger} from "../../Logger";
+import {CodexEventHandler} from "../../CodexEventHandler";
+import type {AcpClientConnection} from "../../ACPSessionConnection";
+import {CodexCommands, type CommandHandleResult} from "../../CodexCommands";
 
 const configuredAuthFailureCases: Array<{
     name: string;
@@ -63,7 +68,617 @@ const configuredAuthFailureCases: Array<{
     },
 ];
 
+const typedFailureCapabilities: acp.ClientCapabilities = {
+    _meta: {jetbrains: {air: {version: 1, capabilities: ["sessionFailure"]}}},
+};
+
 describe("CodexEventHandler - auth error events", () => {
+    it("publishes a typed terminal failure instead of assistant text when AIR negotiated it", async () => {
+        const {result, updates} = await runPromptWithError(createTestSessionState({
+            sessionId: "typed-failure-session",
+            account: { type: "apiKey" },
+        }), {
+            message: "raw upstream payload must not be shown",
+            codexErrorInfo: "serverOverloaded",
+            additionalDetails: "secret raw details",
+        }, false, typedFailureCapabilities);
+
+        expect(result).toMatchObject({
+            stopReason: "end_turn",
+            _meta: {
+                jetbrains: {
+                    air: {
+                        version: 1,
+                        sessionFailure: {
+                            id: "turn-id:error",
+                            revision: 1,
+                            phase: "active",
+                            category: "overloaded",
+                            source: "codex",
+                            safeMessage: "Codex is temporarily overloaded.",
+                            retryable: true,
+                            actions: ["retry"],
+                            turnId: "turn-id",
+                        },
+                    },
+                },
+            },
+        });
+        expect(JSON.stringify(result)).not.toContain("raw upstream payload");
+        expect(JSON.stringify(result)).not.toContain("secret raw details");
+        expect(updates).toEqual([]);
+
+        const wire = JSON.parse(JSON.stringify({jsonrpc: "2.0", id: 1, result}));
+        expect(wire.result._meta.jetbrains.air.sessionFailure).toEqual(
+            expect.objectContaining({id: "turn-id:error", category: "overloaded"}),
+        );
+    });
+
+    it("does not attach a foreign turn failure to the active prompt", async () => {
+        const {result, updates} = await runPromptWithError(createTestSessionState({
+            sessionId: "foreign-turn-session",
+            account: { type: "apiKey" },
+        }), {
+            message: "another turn failed",
+            codexErrorInfo: "serverOverloaded",
+            additionalDetails: "secret foreign-turn details",
+        }, false, typedFailureCapabilities, "foreign-turn");
+
+        expect(result).toMatchObject({stopReason: "end_turn"});
+        expect(JSON.stringify(updates)).not.toContain("sessionFailure");
+        expect(JSON.stringify(updates)).not.toContain("another turn failed");
+        expect(JSON.stringify(updates)).not.toContain("secret foreign-turn details");
+        expect(updates).toEqual([{
+            sessionUpdate: "session_info_update",
+            _meta: {
+                codex: {
+                    error: {
+                        category: "overloaded",
+                        message: "Codex is temporarily overloaded.",
+                        turnId: "foreign-turn",
+                        willRetry: false,
+                    },
+                },
+            },
+        }]);
+    });
+
+    it("does not attach a foreign error that arrives before the active turn id", async () => {
+        const {result, updates} = await runPromptWithError(createTestSessionState({
+            sessionId: "early-foreign-turn-session",
+            account: { type: "apiKey" },
+        }), {
+            message: "a delayed previous turn failure",
+            codexErrorInfo: "serverOverloaded",
+            additionalDetails: null,
+        }, false, typedFailureCapabilities, "foreign-turn", true);
+
+        expect(result).toMatchObject({stopReason: "end_turn"});
+        expect(JSON.stringify(updates)).not.toContain("sessionFailure");
+    });
+
+    it("buffers a current-turn error until the active turn id is known", async () => {
+        const log = vi.spyOn(logger, "log");
+        const {result, updates} = await runPromptWithError(createTestSessionState({
+            sessionId: "early-current-turn-session",
+            account: { type: "apiKey" },
+        }), {
+            message: "current turn failed early",
+            codexErrorInfo: "serverOverloaded",
+            additionalDetails: null,
+        }, false, typedFailureCapabilities, "turn-id", true);
+
+        expect(result).toMatchObject({
+            stopReason: "end_turn",
+            _meta: {jetbrains: {air: {sessionFailure: {turnId: "turn-id", category: "overloaded"}}}},
+        });
+        expect(updates).toEqual([]);
+        const logText = JSON.stringify(log.mock.calls);
+        expect(logText).toContain("Buffered app-server error");
+        expect(logText).not.toContain("current turn failed early");
+        log.mockRestore();
+    });
+
+    it("does not publish a terminal failure while Codex will retry", async () => {
+        const {result, updates} = await runPromptWithError(createTestSessionState({
+            sessionId: "typed-retrying-session",
+            account: { type: "apiKey" },
+        }), {
+            message: "raw retry payload",
+            codexErrorInfo: "serverOverloaded",
+            additionalDetails: "secret retry details",
+        }, true, typedFailureCapabilities);
+
+        expect(result).toMatchObject({stopReason: "end_turn"});
+        expect(JSON.stringify(updates)).not.toContain("sessionFailure");
+        expect(JSON.stringify(updates)).not.toContain("raw retry payload");
+        expect(JSON.stringify(updates)).not.toContain("secret retry details");
+        expect(updates).toEqual([{
+            sessionUpdate: "session_info_update",
+            _meta: {
+                codex: {
+                    error: {
+                        category: "overloaded",
+                        message: "Codex is temporarily overloaded.",
+                        turnId: "turn-id",
+                        willRetry: true,
+                    },
+                },
+            },
+        }]);
+    });
+
+    it("publishes a safe rate-limit diagnostic while Codex retries HTTP 429", async () => {
+        const {result, updates} = await runPromptWithError(createTestSessionState({
+            sessionId: "typed-rate-limit-retry-session",
+            account: { type: "apiKey" },
+        }), {
+            message: "raw 429 retry payload",
+            codexErrorInfo: {responseStreamDisconnected: {httpStatusCode: 429}},
+            additionalDetails: "secret rate-limit details",
+        }, true, typedFailureCapabilities);
+
+        expect(result).toMatchObject({stopReason: "end_turn"});
+        expect(JSON.stringify(updates)).not.toContain("raw 429 retry payload");
+        expect(JSON.stringify(updates)).not.toContain("secret rate-limit details");
+        expect(updates).toEqual([{
+            sessionUpdate: "session_info_update",
+            _meta: {
+                codex: {
+                    error: {
+                        category: "rate_limited",
+                        message: "The Codex rate limit was reached.",
+                        turnId: "turn-id",
+                        willRetry: true,
+                    },
+                },
+            },
+        }]);
+    });
+
+    it("returns a typed auth failure without forwarding provider details", async () => {
+        const {result, updates} = await runPromptWithError(createTestSessionState({
+            sessionId: "typed-auth-session",
+            account: null,
+            authConfigured: false,
+        }), {
+            message: "raw authentication payload",
+            codexErrorInfo: "unauthorized",
+            additionalDetails: "secret authentication details",
+        }, false, typedFailureCapabilities);
+
+        expect(result).toMatchObject({
+            stopReason: "end_turn",
+            _meta: {jetbrains: {air: {sessionFailure: {category: "auth_required"}}}},
+        });
+        expect(JSON.stringify(result)).not.toContain("raw authentication payload");
+        expect(JSON.stringify(result)).not.toContain("secret authentication details");
+        expect(updates).toEqual([]);
+    });
+
+    it("accepts a newer additive typed-failure capability version", async () => {
+        const {result, updates} = await runPromptWithError(createTestSessionState({
+            sessionId: "newer-capability-session",
+            account: { type: "apiKey" },
+        }), {
+            message: "raw newer-version error",
+            codexErrorInfo: "serverOverloaded",
+            additionalDetails: null,
+        }, false, {_meta: {jetbrains: {air: {version: 2, capabilities: ["sessionFailure"]}}}});
+
+        expect(result).toMatchObject({
+            stopReason: "end_turn",
+            _meta: {jetbrains: {air: {version: 1, sessionFailure: {category: "overloaded"}}}},
+        });
+        expect(JSON.stringify(result)).not.toContain("raw newer-version error");
+        expect(updates).toEqual([]);
+    });
+
+    it.each([null, "1", 1.1, 0, -1])("ignores malformed AIR capability version %s", async (version) => {
+        const {result, updates} = await runPromptWithError(createTestSessionState({
+            sessionId: `malformed-version-${String(version)}`,
+            account: {type: "apiKey"},
+        }), {
+            message: "legacy fallback",
+            codexErrorInfo: "serverOverloaded",
+            additionalDetails: null,
+        }, false, {_meta: {jetbrains: {air: {version, capabilities: ["sessionFailure"]}}}} as acp.ClientCapabilities);
+
+        expect(result).toMatchObject({stopReason: "end_turn"});
+        expect(JSON.stringify(result)).not.toContain("sessionFailure");
+        expect(updates).toEqual([expect.objectContaining({sessionUpdate: "agent_message_chunk"})]);
+    });
+
+    it.each([
+        ["transport_lost", {responseStreamDisconnected: {httpStatusCode: 503}}],
+        ["auth_required", "unauthorized"],
+        ["rate_limited", {responseStreamDisconnected: {httpStatusCode: 429}}],
+        ["quota_exhausted", "usageLimitExceeded"],
+        ["overloaded", "serverOverloaded"],
+        ["context_exhausted", "contextWindowExceeded"],
+        ["budget_exhausted", "sessionBudgetExceeded"],
+        ["policy_denied", "cyberPolicy"],
+        ["bad_request", "badRequest"],
+        ["internal_error", "internalServerError"],
+        ["provider_error", "other"],
+    ] as const)("maps a terminal Codex error to %s", async (category, codexErrorInfo) => {
+        const {result, updates} = await runPromptWithError(createTestSessionState({
+            sessionId: `category-${category}`,
+            account: { type: "apiKey" },
+        }), {
+            message: "raw error",
+            codexErrorInfo,
+            additionalDetails: null,
+        }, false, typedFailureCapabilities);
+
+        expect(result).toMatchObject({
+            _meta: {jetbrains: {air: {sessionFailure: {category}}}},
+        });
+        expect(updates).toEqual([]);
+    });
+
+    it("clears the active failure with the same id and a greater revision after recovery", async () => {
+        const sessionState = createTestSessionState({
+            sessionId: "recovered-session",
+            account: { type: "apiKey" },
+            sessionFailure: {
+                id: "failed-turn:error",
+                revision: 3,
+                phase: "active",
+                category: "overloaded",
+                source: "codex",
+                safeMessage: "Codex is temporarily overloaded.",
+                retryable: true,
+                actions: ["retry"],
+                turnId: "failed-turn",
+            },
+        });
+
+        const {result, updates} = await runSuccessfulPrompt(sessionState, typedFailureCapabilities);
+
+        expect(result).toMatchObject({stopReason: "end_turn"});
+        expect(updates).toHaveLength(1);
+        expect(updates[0]).toMatchObject({
+            sessionUpdate: "session_info_update",
+            _meta: {
+                jetbrains: {
+                    air: {
+                        sessionFailure: {
+                            id: "failed-turn:error",
+                            revision: 4,
+                            phase: "cleared",
+                        },
+                    },
+                },
+            },
+        });
+        expect(sessionState.sessionFailure).toMatchObject({revision: 4, phase: "cleared"});
+    });
+
+    it("keeps one failure id across failed retry turns and clears it after recovery", async () => {
+        const sessionState = createTestSessionState({
+            sessionId: "retry-chain-session",
+            account: {type: "apiKey"},
+        });
+
+        const first = await runPromptWithError(sessionState, {
+            message: "first failure",
+            codexErrorInfo: "serverOverloaded",
+            additionalDetails: null,
+        }, false, typedFailureCapabilities, "turn-1", false, "turn-1");
+        const second = await runPromptWithError(sessionState, {
+            message: "second failure",
+            codexErrorInfo: "internalServerError",
+            additionalDetails: null,
+        }, false, typedFailureCapabilities, "turn-2", false, "turn-2");
+        const recovered = await runSuccessfulPrompt(sessionState, typedFailureCapabilities, "turn-3");
+
+        expect(first.result).toMatchObject({
+            _meta: {jetbrains: {air: {sessionFailure: {id: "turn-1:error", revision: 1, phase: "active"}}}},
+        });
+        expect(second.result).toMatchObject({
+            _meta: {jetbrains: {air: {sessionFailure: {
+                id: "turn-1:error",
+                revision: 2,
+                phase: "active",
+                turnId: "turn-2",
+            }}}},
+        });
+        expect(first.updates).toEqual([]);
+        expect(second.updates).toEqual([]);
+        expect(recovered.updates[0]).toMatchObject({
+            _meta: {jetbrains: {air: {sessionFailure: {id: "turn-1:error", revision: 3, phase: "cleared"}}}},
+        });
+    });
+
+    it("publishes a typed failure when a failed completion has no error notification", async () => {
+        const sessionState = createTestSessionState({
+            sessionId: "failed-completion-session",
+            account: {type: "apiKey"},
+        });
+        const {result, updates} = await runPromptWithCompletedTurn(
+            sessionState,
+            typedFailureCapabilities,
+            createTurn("failed", "failed-turn", {
+                message: "raw completion payload",
+                codexErrorInfo: "serverOverloaded",
+                additionalDetails: "secret completion details",
+            }),
+        );
+
+        expect(result).toMatchObject({
+            stopReason: "end_turn",
+            _meta: {jetbrains: {air: {sessionFailure: {
+                id: "failed-turn:error",
+                category: "overloaded",
+                turnId: "failed-turn",
+            }}}},
+        });
+        expect(updates).toEqual([]);
+        expect(JSON.stringify(result)).not.toContain("raw completion payload");
+        expect(JSON.stringify(result)).not.toContain("secret completion details");
+    });
+
+    it("publishes a late idle error through the session-scoped subscription", async () => {
+        const mockFixture = createCodexMockTestFixture();
+        const codexAcpAgent = mockFixture.getCodexAcpAgent();
+        const codexAppServerClient = mockFixture.getCodexAppServerClient();
+        const sessionState = createTestSessionState({
+            sessionId: "idle-error-session",
+            account: {type: "apiKey"},
+        });
+        await codexAcpAgent.initialize({
+            protocolVersion: acp.PROTOCOL_VERSION,
+            clientCapabilities: typedFailureCapabilities,
+        });
+        vi.spyOn(codexAcpAgent, "getSessionState").mockReturnValue(sessionState);
+        vi.spyOn(codexAppServerClient, "turnStart").mockResolvedValue({
+            turn: createTurn("inProgress", "completed-turn"),
+        });
+        vi.spyOn(codexAppServerClient, "awaitTurnCompleted").mockResolvedValue({
+            threadId: sessionState.sessionId,
+            turn: createTurn("completed", "completed-turn"),
+        });
+
+        await codexAcpAgent.prompt({
+            sessionId: sessionState.sessionId,
+            prompt: [{type: "text", text: "finish before the late error"}],
+        });
+        mockFixture.clearAcpConnectionDump();
+
+        mockFixture.sendServerNotification({
+            method: "error",
+            params: {
+                threadId: sessionState.sessionId,
+                turnId: "completed-turn",
+                willRetry: false,
+                error: {
+                    message: "raw late provider failure",
+                    codexErrorInfo: "serverOverloaded",
+                    additionalDetails: "secret late details",
+                },
+            },
+        });
+        await mockFixture.getCodexAcpClient().waitForSessionNotifications(sessionState.sessionId);
+
+        const updates = mockFixture.getAcpConnectionEvents([]).map(event => event.args[0].update);
+        expect(updates).toEqual([{
+            sessionUpdate: "session_info_update",
+            _meta: {
+                jetbrains: {
+                    air: {
+                        version: 1,
+                        sessionFailure: {
+                            id: expect.stringMatching(/^idle-error-session:error:[0-9a-f-]+$/),
+                            revision: 1,
+                            phase: "active",
+                            category: "overloaded",
+                            source: "codex",
+                            safeMessage: "Codex is temporarily overloaded.",
+                            retryable: true,
+                            actions: ["retry"],
+                        },
+                    },
+                },
+            },
+        }]);
+        expect(JSON.stringify(updates)).not.toContain("raw late provider failure");
+        expect(JSON.stringify(updates)).not.toContain("secret late details");
+    });
+
+    it("keeps a retrying late idle error diagnostic-only", async () => {
+        const mockFixture = createCodexMockTestFixture();
+        const codexAcpAgent = mockFixture.getCodexAcpAgent();
+        const codexAppServerClient = mockFixture.getCodexAppServerClient();
+        const sessionState = createTestSessionState({
+            sessionId: "idle-retry-session",
+            account: {type: "apiKey"},
+        });
+        await codexAcpAgent.initialize({
+            protocolVersion: acp.PROTOCOL_VERSION,
+            clientCapabilities: typedFailureCapabilities,
+        });
+        vi.spyOn(codexAcpAgent, "getSessionState").mockReturnValue(sessionState);
+        vi.spyOn(codexAppServerClient, "turnStart").mockResolvedValue({
+            turn: createTurn("inProgress", "completed-turn"),
+        });
+        vi.spyOn(codexAppServerClient, "awaitTurnCompleted").mockResolvedValue({
+            threadId: sessionState.sessionId,
+            turn: createTurn("completed", "completed-turn"),
+        });
+        await codexAcpAgent.prompt({
+            sessionId: sessionState.sessionId,
+            prompt: [{type: "text", text: "finish before retry diagnostic"}],
+        });
+        mockFixture.clearAcpConnectionDump();
+
+        mockFixture.sendServerNotification({
+            method: "error",
+            params: {
+                threadId: sessionState.sessionId,
+                turnId: "completed-turn",
+                willRetry: true,
+                error: {
+                    message: "raw retry detail",
+                    codexErrorInfo: "serverOverloaded",
+                    additionalDetails: "secret retry detail",
+                },
+            },
+        });
+        await mockFixture.getCodexAcpClient().waitForSessionNotifications(sessionState.sessionId);
+
+        const updates = mockFixture.getAcpConnectionEvents([]).map(event => event.args[0].update);
+        expect(updates).toEqual([{
+            sessionUpdate: "session_info_update",
+            _meta: {
+                codex: {
+                    error: {
+                        category: "overloaded",
+                        message: "Codex is temporarily overloaded.",
+                        turnId: "completed-turn",
+                        willRetry: true,
+                    },
+                },
+            },
+        }]);
+        expect(sessionState.sessionFailure).toBeUndefined();
+        expect(JSON.stringify(updates)).not.toContain("raw retry detail");
+        expect(JSON.stringify(updates)).not.toContain("secret retry detail");
+    });
+
+    it("drains a terminal error that arrives during a local slash command", async () => {
+        const commandResult = deferred<CommandHandleResult>();
+        const commandSpy = vi.spyOn(CodexCommands.prototype, "tryHandleCommand")
+            .mockReturnValue(commandResult.promise);
+        try {
+            const mockFixture = createCodexMockTestFixture();
+            const codexAcpAgent = mockFixture.getCodexAcpAgent();
+            const sessionState = createTestSessionState({
+                sessionId: "local-command-error-session",
+                account: {type: "apiKey"},
+            });
+            await codexAcpAgent.initialize({
+                protocolVersion: acp.PROTOCOL_VERSION,
+                clientCapabilities: typedFailureCapabilities,
+            });
+            vi.spyOn(codexAcpAgent, "getSessionState").mockReturnValue(sessionState);
+
+            const promptPromise = codexAcpAgent.prompt({
+                sessionId: sessionState.sessionId,
+                prompt: [{type: "text", text: "/status"}],
+            });
+            await vi.waitFor(() => expect(commandSpy).toHaveBeenCalled());
+            mockFixture.sendServerNotification({
+                method: "error",
+                params: {
+                    threadId: sessionState.sessionId,
+                    turnId: "late-provider-turn",
+                    willRetry: false,
+                    error: {
+                        message: "raw slash command failure",
+                        codexErrorInfo: "serverOverloaded",
+                        additionalDetails: "secret slash command detail",
+                    },
+                },
+            });
+            await mockFixture.getCodexAcpClient().waitForSessionNotifications(sessionState.sessionId);
+            expect(sessionState.sessionFailure).toBeUndefined();
+
+            commandResult.resolve({handled: true});
+            await expect(promptPromise).resolves.toMatchObject({stopReason: "end_turn"});
+
+            const updates = mockFixture.getAcpConnectionEvents([]).map(event => event.args[0].update);
+            expect(updates).toEqual([{
+                sessionUpdate: "session_info_update",
+                _meta: {
+                    jetbrains: {
+                        air: {
+                            version: 1,
+                            sessionFailure: {
+                                id: expect.stringMatching(/^local-command-error-session:error:[0-9a-f-]+$/),
+                                revision: 1,
+                                phase: "active",
+                                category: "overloaded",
+                                source: "codex",
+                                safeMessage: "Codex is temporarily overloaded.",
+                                retryable: true,
+                                actions: ["retry"],
+                            },
+                        },
+                    },
+                },
+            }]);
+            expect(sessionState.sessionFailure).toMatchObject({phase: "active", revision: 1});
+            expect(sessionState.sessionFailure).not.toHaveProperty("turnId");
+            expect(JSON.stringify(updates)).not.toContain("raw slash command failure");
+            expect(JSON.stringify(updates)).not.toContain("secret slash command detail");
+        } finally {
+            commandSpy.mockRestore();
+        }
+    });
+
+    it("uses a new session-scoped failure id after recreating the consumer", async () => {
+        const createFailureId = async (): Promise<string> => {
+            const state = createTestSessionState({
+                sessionId: "restored-session",
+                account: {type: "apiKey"},
+            });
+            const updates: Array<{_meta?: Record<string, unknown>}> = [];
+            const connection = {
+                notify: vi.fn(async (_method: unknown, params: {update: {_meta?: Record<string, unknown>}}) => {
+                    updates.push(params.update);
+                }),
+            } as unknown as AcpClientConnection;
+            const handler = new CodexEventHandler(connection, state, false, true);
+            await handler.handleSessionScopedNotification({
+                method: "error",
+                params: {
+                    threadId: state.sessionId,
+                    turnId: "old-turn",
+                    willRetry: false,
+                    error: {
+                        message: "provider failed",
+                        codexErrorInfo: "serverOverloaded",
+                        additionalDetails: null,
+                    },
+                },
+            });
+            return (updates[0]!._meta as {
+                jetbrains: {air: {sessionFailure: {id: string}}};
+            }).jetbrains.air.sessionFailure.id;
+        };
+
+        const firstId = await createFailureId();
+        const restartedId = await createFailureId();
+
+        expect(firstId).toMatch(/^restored-session:error:[0-9a-f-]+$/);
+        expect(restartedId).toMatch(/^restored-session:error:[0-9a-f-]+$/);
+        expect(restartedId).not.toBe(firstId);
+    });
+
+    it("preserves negotiated prompt validation RequestErrors", async () => {
+        const mockFixture = createCodexMockTestFixture();
+        const codexAcpAgent = mockFixture.getCodexAcpAgent();
+        const sessionState = createTestSessionState({
+            sessionId: "typed-validation-session",
+            account: {type: "apiKey"},
+            supportedInputModalities: ["text"],
+        });
+        await codexAcpAgent.initialize({
+            protocolVersion: acp.PROTOCOL_VERSION,
+            clientCapabilities: typedFailureCapabilities,
+        });
+        vi.spyOn(codexAcpAgent, "getSessionState").mockReturnValue(sessionState);
+
+        await expect(codexAcpAgent.prompt({
+            sessionId: sessionState.sessionId,
+            prompt: [{type: "image", mimeType: "image/png", data: "AA=="}],
+        })).rejects.toMatchObject({
+            code: -32600,
+        });
+        expect(sessionState.sessionFailure).toBeUndefined();
+    });
+
     it("keeps the prompt alive for a retryable HTTP 401", async () => {
         const {result: response, updates} = await runPromptWithError(createTestSessionState({
             sessionId: "retrying-session",
@@ -147,14 +762,26 @@ async function runPromptWithError(
     sessionState: SessionState,
     turnError: ErrorNotification["error"],
     willRetry = false,
+    clientCapabilities?: acp.ClientCapabilities,
+    errorTurnId = "turn-id",
+    errorBeforeTurnStarts = false,
+    activeTurnId = "turn-id",
 ): Promise<{result: unknown; updates: unknown[]}> {
     const mockFixture = createCodexMockTestFixture();
     const codexAcpAgent = mockFixture.getCodexAcpAgent();
     const codexAppServerClient = mockFixture.getCodexAppServerClient();
+    if (clientCapabilities) {
+        await codexAcpAgent.initialize({
+            protocolVersion: acp.PROTOCOL_VERSION,
+            clientCapabilities,
+        });
+    }
+    const turnStarted = deferred<{turn: ReturnType<typeof createTurn>}>();
+    if (!errorBeforeTurnStarts) {
+        turnStarted.resolve({turn: createTurn("inProgress", activeTurnId)});
+    }
     const turnCompleted = deferred<TurnCompletedNotification>();
-    const turnStartSpy = vi.spyOn(codexAppServerClient, "turnStart").mockResolvedValue({
-        turn: createTurn("inProgress"),
-    });
+    const turnStartSpy = vi.spyOn(codexAppServerClient, "turnStart").mockReturnValue(turnStarted.promise);
     vi.spyOn(codexAppServerClient, "awaitTurnCompleted").mockReturnValue(turnCompleted.promise);
     vi.spyOn(codexAcpAgent, "getSessionState").mockReturnValue(sessionState);
 
@@ -167,20 +794,34 @@ async function runPromptWithError(
         expect(turnStartSpy).toHaveBeenCalled();
     });
 
-    mockFixture.sendServerNotification({
+    const errorNotification = {
         method: "error",
         params: {
             threadId: sessionState.sessionId,
-            turnId: "turn-id",
+            turnId: errorTurnId,
             willRetry,
             error: turnError,
         },
-    });
+    } as const;
+    if (errorBeforeTurnStarts) {
+        mockFixture.sendServerNotification(errorNotification);
+        await new Promise(resolve => setImmediate(resolve));
+        turnStarted.resolve({turn: createTurn("inProgress", activeTurnId)});
+        await vi.waitFor(() => {
+            expect(sessionState.currentTurnId).toBe(activeTurnId);
+        });
+    } else {
+        mockFixture.sendServerNotification(errorNotification);
+    }
 
-    turnCompleted.resolve({
+    const completedNotification: TurnCompletedNotification = {
         threadId: sessionState.sessionId,
-        turn: createTurn("completed"),
-    });
+        turn: !willRetry && errorTurnId === activeTurnId
+            ? createTurn("failed", activeTurnId, turnError)
+            : createTurn("completed", activeTurnId),
+    };
+    mockFixture.sendServerNotification({method: "turn/completed", params: completedNotification});
+    turnCompleted.resolve(completedNotification);
 
     let result: unknown;
     try {
@@ -194,13 +835,61 @@ async function runPromptWithError(
     };
 }
 
-function createTurn(status: "inProgress" | "completed") {
+async function runSuccessfulPrompt(
+    sessionState: SessionState,
+    clientCapabilities: acp.ClientCapabilities,
+    turnId = "turn-id",
+): Promise<{result: unknown; updates: unknown[]}> {
+    return runPromptWithCompletedTurn(sessionState, clientCapabilities, createTurn("completed", turnId));
+}
+
+async function runPromptWithCompletedTurn(
+    sessionState: SessionState,
+    clientCapabilities: acp.ClientCapabilities,
+    completedTurn: ReturnType<typeof createTurn>,
+): Promise<{result: unknown; updates: unknown[]}> {
+    const mockFixture = createCodexMockTestFixture();
+    const codexAcpAgent = mockFixture.getCodexAcpAgent();
+    const codexAppServerClient = mockFixture.getCodexAppServerClient();
+    await codexAcpAgent.initialize({
+        protocolVersion: acp.PROTOCOL_VERSION,
+        clientCapabilities,
+    });
+    vi.spyOn(codexAppServerClient, "turnStart").mockResolvedValue({
+        turn: createTurn("inProgress", completedTurn.id),
+    });
+    vi.spyOn(codexAppServerClient, "awaitTurnCompleted").mockResolvedValue({
+        threadId: sessionState.sessionId,
+        turn: completedTurn,
+    });
+    vi.spyOn(codexAcpAgent, "getSessionState").mockReturnValue(sessionState);
+
+    let result: unknown;
+    try {
+        result = await codexAcpAgent.prompt({
+            sessionId: sessionState.sessionId,
+            prompt: [{type: "text", text: "retry"}],
+        });
+    } catch (error) {
+        result = error;
+    }
     return {
-        id: "turn-id",
+        result,
+        updates: mockFixture.getAcpConnectionEvents([]).map(event => event.args[0].update),
+    };
+}
+
+function createTurn(
+    status: "inProgress" | "completed" | "failed",
+    id = "turn-id",
+    error: ErrorNotification["error"] | null = null,
+) {
+    return {
+        id,
         items: [],
         itemsView: "notLoaded" as const,
         status,
-        error: null,
+        error,
         startedAt: null,
         completedAt: null,
         durationMs: null,

--- a/src/__tests__/CodexACPAgent/auth-error-events.test.ts
+++ b/src/__tests__/CodexACPAgent/auth-error-events.test.ts
@@ -300,7 +300,13 @@ describe("CodexEventHandler - auth error events", () => {
         ["policy_denied", "cyberPolicy"],
         ["bad_request", "badRequest"],
         ["internal_error", "internalServerError"],
+        ["provider_error", "threadRollbackFailed"],
+        ["provider_error", "sandboxError"],
         ["provider_error", "other"],
+        ["transport_lost", {httpConnectionFailed: {httpStatusCode: null}}],
+        ["transport_lost", {responseStreamConnectionFailed: {httpStatusCode: 503}}],
+        ["transport_lost", {responseTooManyFailedAttempts: {httpStatusCode: 503}}],
+        ["provider_error", {activeTurnNotSteerable: {turnKind: "review"}}],
     ] as const)("maps a terminal Codex error to %s", async (category, codexErrorInfo) => {
         const {result, updates} = await runPromptWithError(createTestSessionState({
             sessionId: `category-${category}`,

--- a/src/__tests__/CodexACPAgent/initialize.test.ts
+++ b/src/__tests__/CodexACPAgent/initialize.test.ts
@@ -70,6 +70,12 @@ describe('CodexACPAgent - initialize', () => {
                     controlMethod: "_session/goal",
                     actions: ["set", "pause", "resume", "clear"],
                 },
+                jetbrains: {
+                    air: {
+                        version: 1,
+                        capabilities: ["sessionFailure"],
+                    },
+                },
             },
         });
     });

--- a/src/__tests__/CodexACPAgent/plan-review-events.test.ts
+++ b/src/__tests__/CodexACPAgent/plan-review-events.test.ts
@@ -13,7 +13,24 @@ type TurnCompletion = {
         id: string;
         items: never[];
         itemsView: "notLoaded";
-        status: "completed";
+        status: "completed" | "failed";
+        error: null | {
+            message: string;
+            codexErrorInfo: "serverOverloaded";
+            additionalDetails: string | null;
+        };
+        startedAt: null;
+        completedAt: null;
+        durationMs: null;
+    };
+};
+
+type TurnStartResponse = {
+    turn: {
+        id: string;
+        items: never[];
+        itemsView: "notLoaded";
+        status: "inProgress";
         error: null;
         startedAt: null;
         completedAt: null;
@@ -38,14 +55,27 @@ describe("CodexACPAgent - plan review", () => {
         vi.clearAllMocks();
     });
 
-    async function startPlanPrompt(permissionOptionId: string | null) {
+    async function startPlanPrompt(
+        permissionOptionId: string | null,
+        options: {
+            typedFailures?: boolean;
+            emitCompletionNotification?: boolean;
+            implementationStart?: Promise<TurnStartResponse>;
+            permissionResponse?: acp.RequestPermissionResponse | Promise<acp.RequestPermissionResponse>;
+        } = {},
+    ) {
         await fixture.getCodexAcpAgent().initialize({
             protocolVersion: acp.PROTOCOL_VERSION,
-            clientCapabilities: {plan: {}},
+            clientCapabilities: {
+                plan: {},
+                ...(options.typedFailures
+                    ? {_meta: {jetbrains: {air: {version: 1, capabilities: ["sessionFailure"]}}}}
+                    : {}),
+            },
         });
-        fixture.setPermissionResponse(permissionOptionId === null
+        fixture.setPermissionResponse(options.permissionResponse ?? (permissionOptionId === null
             ? {outcome: {outcome: "cancelled"}}
-            : {outcome: {outcome: "selected", optionId: permissionOptionId}});
+            : {outcome: {outcome: "selected", optionId: permissionOptionId}}));
 
         const sessionState = createTestSessionState({
             sessionId,
@@ -68,7 +98,7 @@ describe("CodexACPAgent - plan review", () => {
                     durationMs: null,
                 },
             })
-            .mockResolvedValueOnce({
+            .mockImplementationOnce(() => options.implementationStart ?? Promise.resolve({
                 turn: {
                     id: "implementation-turn",
                     items: [],
@@ -79,7 +109,7 @@ describe("CodexACPAgent - plan review", () => {
                     completedAt: null,
                     durationMs: null,
                 },
-            });
+            }));
         vi.spyOn(fixture.getCodexAppServerClient(), "awaitTurnCompleted")
             .mockImplementation((_threadId, turnId) => turnId === "plan-turn"
                 ? planTurn.promise
@@ -113,7 +143,7 @@ describe("CodexACPAgent - plan review", () => {
                 },
             },
         });
-        planTurn.resolve({
+        const completion: TurnCompletion = {
             threadId: sessionId,
             turn: {
                 id: "plan-turn",
@@ -125,7 +155,11 @@ describe("CodexACPAgent - plan review", () => {
                 completedAt: null,
                 durationMs: null,
             },
-        });
+        };
+        if (options.emitCompletionNotification) {
+            fixture.sendServerNotification({method: "turn/completed", params: completion});
+        }
+        planTurn.resolve(completion);
 
         return {promptPromise, sessionState, turnStart, implementationTurn};
     }
@@ -207,5 +241,237 @@ describe("CodexACPAgent - plan review", () => {
         await expect(promptPromise).resolves.toMatchObject({stopReason: "end_turn"});
         expect(turnStart).toHaveBeenCalledTimes(1);
         expect(sessionState.collaborationMode).toBe(PLAN_COLLABORATION_MODE);
+    });
+
+    it("routes a terminal error during plan approval as a session-scoped failure", async () => {
+        const permission = deferred<acp.RequestPermissionResponse>();
+        const {promptPromise, sessionState, turnStart} = await startPlanPrompt(null, {
+            typedFailures: true,
+            emitCompletionNotification: true,
+            permissionResponse: permission.promise,
+        });
+        await vi.waitFor(() => {
+            expect(fixture.getAcpConnectionEvents([])).toContainEqual({
+                method: "requestPermission",
+                args: [expect.objectContaining({sessionId})],
+            });
+        });
+        fixture.clearAcpConnectionDump();
+
+        fixture.sendServerNotification({
+            method: "error",
+            params: {
+                threadId: sessionId,
+                turnId: "plan-turn",
+                willRetry: false,
+                error: {
+                    message: "raw post-turn approval error",
+                    codexErrorInfo: "serverOverloaded",
+                    additionalDetails: "secret approval detail",
+                },
+            },
+        });
+        await fixture.getCodexAcpClient().waitForSessionNotifications(sessionId);
+
+        const updates = fixture.getAcpConnectionEvents([])
+            .filter(event => event.method === "sessionUpdate")
+            .map(event => event.args[0].update);
+        expect(updates).toEqual([{
+            sessionUpdate: "session_info_update",
+            _meta: {
+                jetbrains: {
+                    air: {
+                        version: 1,
+                        sessionFailure: {
+                            id: expect.stringMatching(/^plan-review-session:error:[0-9a-f-]+$/),
+                            revision: 1,
+                            phase: "active",
+                            category: "overloaded",
+                            source: "codex",
+                            safeMessage: "Codex is temporarily overloaded.",
+                            retryable: true,
+                            actions: ["retry"],
+                        },
+                    },
+                },
+            },
+        }]);
+        expect(JSON.stringify(updates)).not.toContain("raw post-turn approval error");
+        expect(JSON.stringify(updates)).not.toContain("secret approval detail");
+        expect(turnStart).toHaveBeenCalledTimes(1);
+
+        permission.resolve({outcome: {outcome: "cancelled"}});
+        await expect(promptPromise).resolves.toMatchObject({stopReason: "end_turn"});
+        expect(sessionState.sessionFailure).toMatchObject({phase: "active", revision: 1});
+    });
+
+    it("clears an unchanged plan-approval failure after successful implementation", async () => {
+        const permission = deferred<acp.RequestPermissionResponse>();
+        const {promptPromise, sessionState, turnStart, implementationTurn} = await startPlanPrompt(null, {
+            typedFailures: true,
+            emitCompletionNotification: true,
+            permissionResponse: permission.promise,
+        });
+        await vi.waitFor(() => expect(fixture.getAcpConnectionEvents([])
+            .some(event => event.method === "requestPermission")).toBe(true));
+        fixture.clearAcpConnectionDump();
+
+        fixture.sendServerNotification({
+            method: "error",
+            params: {
+                threadId: sessionId,
+                turnId: "plan-turn",
+                willRetry: false,
+                error: {
+                    message: "late plan failure",
+                    codexErrorInfo: "serverOverloaded",
+                    additionalDetails: null,
+                },
+            },
+        });
+        await fixture.getCodexAcpClient().waitForSessionNotifications(sessionId);
+        const activeId = sessionState.sessionFailure!.id;
+
+        permission.resolve({outcome: {outcome: "selected", optionId: "implement_plan"}});
+        await vi.waitFor(() => expect(turnStart).toHaveBeenCalledTimes(2));
+        implementationTurn.resolve({
+            threadId: sessionId,
+            turn: {
+                id: "implementation-turn",
+                items: [],
+                itemsView: "notLoaded",
+                status: "completed",
+                error: null,
+                startedAt: null,
+                completedAt: null,
+                durationMs: null,
+            },
+        });
+        await expect(promptPromise).resolves.toMatchObject({stopReason: "end_turn"});
+
+        const failures = fixture.getAcpConnectionEvents([])
+            .filter(event => event.method === "sessionUpdate")
+            .map(event => event.args[0].update?._meta?.jetbrains?.air?.sessionFailure)
+            .filter(Boolean);
+        expect(failures).toEqual([
+            expect.objectContaining({id: activeId, phase: "active", revision: 1}),
+            expect.objectContaining({id: activeId, phase: "cleared", revision: 2}),
+        ]);
+        expect(sessionState.sessionFailure).toMatchObject({id: activeId, phase: "cleared", revision: 2});
+    });
+
+    it("keeps an implementation failure terminal on the prompt response", async () => {
+        const {promptPromise, sessionState, turnStart, implementationTurn} = await startPlanPrompt("implement_plan", {
+            typedFailures: true,
+            emitCompletionNotification: true,
+        });
+        await vi.waitFor(() => expect(turnStart).toHaveBeenCalledTimes(2));
+        fixture.clearAcpConnectionDump();
+        const implementationError = {
+            message: "raw implementation failure",
+            codexErrorInfo: "serverOverloaded" as const,
+            additionalDetails: "secret implementation detail",
+        };
+        fixture.sendServerNotification({
+            method: "error",
+            params: {
+                threadId: sessionId,
+                turnId: "implementation-turn",
+                willRetry: false,
+                error: implementationError,
+            },
+        });
+        const failedCompletion: TurnCompletion = {
+            threadId: sessionId,
+            turn: {
+                id: "implementation-turn",
+                items: [],
+                itemsView: "notLoaded",
+                status: "failed",
+                error: implementationError,
+                startedAt: null,
+                completedAt: null,
+                durationMs: null,
+            },
+        };
+        fixture.sendServerNotification({method: "turn/completed", params: failedCompletion});
+        implementationTurn.resolve(failedCompletion);
+
+        const response = await promptPromise;
+        expect(response).toMatchObject({
+            stopReason: "end_turn",
+            _meta: {jetbrains: {air: {sessionFailure: {
+                id: "implementation-turn:error",
+                phase: "active",
+                category: "overloaded",
+                turnId: "implementation-turn",
+            }}}},
+        });
+        expect(JSON.stringify(response)).not.toContain("raw implementation failure");
+        expect(JSON.stringify(response)).not.toContain("secret implementation detail");
+        expect(sessionState.sessionFailure).toMatchObject({phase: "active", revision: 1});
+        expect(JSON.stringify(fixture.getAcpConnectionEvents([]))).not.toContain('"phase":"cleared"');
+    });
+
+    it("keeps the approval-to-implementation-start gap session-scoped", async () => {
+        const permission = deferred<acp.RequestPermissionResponse>();
+        const implementationStart = deferred<TurnStartResponse>();
+        const {promptPromise, sessionState, turnStart, implementationTurn} = await startPlanPrompt(null, {
+            typedFailures: true,
+            emitCompletionNotification: true,
+            permissionResponse: permission.promise,
+            implementationStart: implementationStart.promise,
+        });
+        await vi.waitFor(() => expect(fixture.getAcpConnectionEvents([])
+            .some(event => event.method === "requestPermission")).toBe(true));
+        permission.resolve({outcome: {outcome: "selected", optionId: "implement_plan"}});
+        await vi.waitFor(() => expect(turnStart).toHaveBeenCalledTimes(2));
+        expect(sessionState.currentTurnId).toBeNull();
+        fixture.clearAcpConnectionDump();
+
+        fixture.sendServerNotification({
+            method: "error",
+            params: {
+                threadId: sessionId,
+                turnId: "implementation-turn",
+                willRetry: false,
+                error: {
+                    message: "failure before implementation start",
+                    codexErrorInfo: "serverOverloaded",
+                    additionalDetails: null,
+                },
+            },
+        });
+        await fixture.getCodexAcpClient().waitForSessionNotifications(sessionId);
+        expect(sessionState.sessionFailure).toMatchObject({phase: "active", revision: 1});
+        expect(sessionState.sessionFailure).not.toHaveProperty("turnId");
+
+        implementationStart.resolve({
+            turn: {
+                id: "implementation-turn",
+                items: [],
+                itemsView: "notLoaded",
+                status: "inProgress",
+                error: null,
+                startedAt: null,
+                completedAt: null,
+                durationMs: null,
+            },
+        });
+        implementationTurn.resolve({
+            threadId: sessionId,
+            turn: {
+                id: "implementation-turn",
+                items: [],
+                itemsView: "notLoaded",
+                status: "completed",
+                error: null,
+                startedAt: null,
+                completedAt: null,
+                durationMs: null,
+            },
+        });
+        await expect(promptPromise).resolves.toMatchObject({stopReason: "end_turn"});
+        expect(sessionState.sessionFailure).toMatchObject({phase: "cleared", revision: 2});
     });
 });

--- a/src/__tests__/CodexACPAgent/typed-session-failure-wire.test.ts
+++ b/src/__tests__/CodexACPAgent/typed-session-failure-wire.test.ts
@@ -1,0 +1,205 @@
+import {describe, expect, it, vi} from "vitest";
+import * as acp from "@agentclientprotocol/sdk";
+import {CodexAppServerClient} from "../../CodexAppServerClient";
+import {CodexAcpClient} from "../../CodexAcpClient";
+import {CodexAcpServer} from "../../CodexAcpServer";
+import {createTestSessionState} from "../acp-test-utils";
+import {createMockConnections} from "./test-utils";
+
+const typedFailureCapabilities: acp.ClientCapabilities = {
+    _meta: {jetbrains: {air: {version: 1, capabilities: ["sessionFailure"]}}},
+};
+
+describe("typed session failures over ACP transport", () => {
+    it("returns a sanitized process-exit failure in the decoded prompt response", async () => {
+        const fixture = createWireFixture({
+            exitCode: 1,
+            stderr: "secret process stderr must stay server-side",
+        });
+        await fixture.initialize();
+        const sessionState = createTestSessionState({
+            sessionId: "wire-process-exit",
+            account: {type: "apiKey"},
+        });
+        vi.spyOn(fixture.server, "getSessionState").mockReturnValue(sessionState);
+        vi.spyOn(fixture.appServer, "turnStart").mockRejectedValue(
+            new Error("raw transport rejection must not cross ACP"),
+        );
+
+        const response = await fixture.client.prompt({
+            sessionId: sessionState.sessionId,
+            prompt: [{type: "text", text: "trigger process failure"}],
+        });
+
+        expect(response).toMatchObject({
+            stopReason: "end_turn",
+            _meta: {
+                jetbrains: {
+                    air: {
+                        version: 1,
+                        sessionFailure: {
+                            category: "transport_lost",
+                            safeMessage: "Connection to Codex was lost.",
+                            retryable: true,
+                            actions: ["reconnect", "retry"],
+                        },
+                    },
+                },
+            },
+        });
+        expect(JSON.stringify(response)).not.toContain("secret process stderr");
+        expect(JSON.stringify(response)).not.toContain("raw transport rejection");
+        expect(fixture.updates).toEqual([]);
+    });
+
+    it("keeps the legacy process-exit rejection when the capability is absent", async () => {
+        const fixture = createWireFixture({
+            exitCode: 1,
+            stderr: "legacy process stderr",
+        });
+        await fixture.initialize({});
+        const sessionState = createTestSessionState({
+            sessionId: "wire-legacy-process-exit",
+            account: {type: "apiKey"},
+        });
+        vi.spyOn(fixture.server, "getSessionState").mockReturnValue(sessionState);
+        vi.spyOn(fixture.appServer, "turnStart").mockRejectedValue(new Error("transport closed"));
+
+        await expect(fixture.client.prompt({
+            sessionId: sessionState.sessionId,
+            prompt: [{type: "text", text: "keep legacy rejection"}],
+        })).rejects.toThrow("Codex process has exited with code 1:\nlegacy process stderr");
+        expect(fixture.updates).toEqual([]);
+    });
+
+    it("delivers an idle terminal error as a decoded session update", async () => {
+        const fixture = createWireFixture();
+        await fixture.initialize();
+        const sessionState = createTestSessionState({
+            sessionId: "wire-idle-error",
+            account: {type: "apiKey"},
+        });
+        vi.spyOn(fixture.server, "getSessionState").mockReturnValue(sessionState);
+        vi.spyOn(fixture.appServer, "turnStart").mockResolvedValue({
+            turn: createTurn("inProgress"),
+        });
+        vi.spyOn(fixture.appServer, "awaitTurnCompleted").mockResolvedValue({
+            threadId: sessionState.sessionId,
+            turn: createTurn("completed"),
+        });
+
+        await fixture.client.prompt({
+            sessionId: sessionState.sessionId,
+            prompt: [{type: "text", text: "complete before late error"}],
+        });
+        fixture.updates.splice(0);
+
+        fixture.sendServerNotification({
+            method: "error",
+            params: {
+                threadId: sessionState.sessionId,
+                turnId: "turn-id",
+                willRetry: false,
+                error: {
+                    message: "raw idle provider detail",
+                    codexErrorInfo: "serverOverloaded",
+                    additionalDetails: "secret idle detail",
+                },
+            },
+        });
+        await fixture.codexClient.waitForSessionNotifications(sessionState.sessionId);
+        await vi.waitFor(() => expect(fixture.updates).toHaveLength(1));
+
+        expect(fixture.updates[0]).toMatchObject({
+            sessionId: sessionState.sessionId,
+            update: {
+                sessionUpdate: "session_info_update",
+                _meta: {
+                    jetbrains: {
+                        air: {
+                            sessionFailure: {
+                                id: expect.stringMatching(/^wire-idle-error:error:[0-9a-f-]+$/),
+                                category: "overloaded",
+                                safeMessage: "Codex is temporarily overloaded.",
+                            },
+                        },
+                    },
+                },
+            },
+        });
+        const wireFailure = (fixture.updates[0]!.update._meta as {
+            jetbrains: {air: {sessionFailure: Record<string, unknown>}};
+        }).jetbrains.air.sessionFailure;
+        expect(wireFailure).not.toHaveProperty("turnId");
+        expect(JSON.stringify(fixture.updates)).not.toContain("raw idle provider detail");
+        expect(JSON.stringify(fixture.updates)).not.toContain("secret idle detail");
+    });
+});
+
+function createWireFixture(options: {exitCode?: number | null; stderr?: string} = {}) {
+    const mockConnections = createMockConnections();
+    const appServer = new CodexAppServerClient(mockConnections.mockCodexConnection);
+    const codexClient = new CodexAcpClient(appServer);
+    vi.spyOn(appServer, "initialize").mockResolvedValue({codexHome: null} as never);
+
+    const clientToAgent = new TransformStream<Uint8Array, Uint8Array>();
+    const agentToClient = new TransformStream<Uint8Array, Uint8Array>();
+    const updates: acp.SessionNotification[] = [];
+    let server!: CodexAcpServer;
+    const client = new acp.ClientSideConnection(
+        () => ({
+            requestPermission: () => ({outcome: {outcome: "cancelled" as const}}),
+            sessionUpdate: (params: acp.SessionNotification) => {
+                updates.push(params);
+            },
+        }),
+        acp.ndJsonStream(clientToAgent.writable, agentToClient.readable),
+    );
+    new acp.AgentSideConnection(
+        (connection) => {
+            server = new CodexAcpServer(
+                connection,
+                codexClient,
+                undefined,
+                () => options.exitCode ?? null,
+                () => options.stderr ?? "",
+            );
+            return server;
+        },
+        acp.ndJsonStream(agentToClient.writable, clientToAgent.readable),
+    );
+
+    return {
+        client,
+        codexClient,
+        appServer,
+        updates,
+        get server(): CodexAcpServer {
+            return server;
+        },
+        async initialize(clientCapabilities: acp.ClientCapabilities = typedFailureCapabilities): Promise<void> {
+            await client.initialize({
+                protocolVersion: acp.PROTOCOL_VERSION,
+                clientCapabilities,
+            });
+        },
+        sendServerNotification(notification: Record<string, unknown>): void {
+            const handler = mockConnections.getUnhandledNotificationHandler();
+            if (!handler) throw new Error("App-server notification handler was not installed");
+            handler(notification);
+        },
+    };
+}
+
+function createTurn(status: "inProgress" | "completed") {
+    return {
+        id: "turn-id",
+        items: [],
+        itemsView: "notLoaded" as const,
+        status,
+        error: null,
+        startedAt: null,
+        completedAt: null,
+        durationMs: null,
+    };
+}

--- a/src/__tests__/acp-test-utils.ts
+++ b/src/__tests__/acp-test-utils.ts
@@ -244,7 +244,7 @@ export function removeDirectoryWithRetry(directory: string): void {
 export interface CodexMockTestFixture extends TestFixture {
     sendServerNotification(notification: ServerNotification | Record<string, unknown>): void,
     sendServerRequest<T>(method: string, params: unknown): Promise<T>,
-    setPermissionResponse(response: RequestPermissionResponse): void,
+    setPermissionResponse(response: RequestPermissionResponse | Promise<RequestPermissionResponse>): void,
     setElicitationResponse(response: CreateElicitationResponse | Promise<CreateElicitationResponse>): void,
 }
 
@@ -260,7 +260,7 @@ export function createCodexMockTestFixture(): CodexMockTestFixture {
     const requestHandlers = new Map<string, (params: unknown) => Promise<unknown>>();
 
     // State for controlling permission responses
-    const permissionState: { response: RequestPermissionResponse } = {
+    const permissionState: { response: RequestPermissionResponse | Promise<RequestPermissionResponse> } = {
         response: { outcome: { outcome: 'cancelled' } }
     };
     const elicitationState: { response: CreateElicitationResponse | Promise<CreateElicitationResponse> } = {
@@ -324,7 +324,7 @@ export function createCodexMockTestFixture(): CodexMockTestFixture {
             }
             return await handler(params) as T;
         },
-        setPermissionResponse(response: RequestPermissionResponse): void {
+        setPermissionResponse(response: RequestPermissionResponse | Promise<RequestPermissionResponse>): void {
             permissionState.response = response;
         },
         setElicitationResponse(response: CreateElicitationResponse | Promise<CreateElicitationResponse>): void {


### PR DESCRIPTION
## Summary

- Negotiate the JetBrains AIR `sessionFailure` extension when the client advertises an integer version `>= 1` and the capability name.
- Return turn-terminal failures only on `PromptResponse._meta`; publish late, idle, and otherwise session-scoped failures through `session/update`.
- Keep legacy ACP cancellation and `RequestError` behavior for capability-off clients.
- Emit bounded fixed safe messages without provider details, stderr, paths, headers, tokens, or stack traces.

## Recovery contract

Failures use `_meta.jetbrains.air.sessionFailure` with a stable id, monotonic revision, phase, category, source, safe message, retryability, and optional real turn attribution. Turn failures use the completed app-server turn id. Session-scoped ids include a per-server epoch so an AIR replay tombstone cannot suppress a new outage after process restart.

AIR owns localized action presentation. Codex supplies typed category and retryability facts. A successful prompt clears only the exact failure revision that was active when that recovery attempt started; a newer failure is never cleared accidentally.

The event routing covers the boundaries that previously lost or misattributed errors: before turn start, after `turn/completed`, during plan approval, between approval and implementation `turnStart`, during implementation, after prompt return, process exit, and local slash commands that complete without creating a turn.

## Validation

- 394 passed, 28 skipped.
- Build passed.
- Typecheck passed.
- Diff check passed.
- In-memory NDJSON tests cover initialize negotiation, terminal `PromptResponse` metadata, session-scoped updates, process exit, capability-off behavior, restart-safe ids, and plan/slash-command races.
