### PR TITLE
fix: don't advertise skills the user disabled

### DIFF
--- a/src/CodexCommands.ts
+++ b/src/CodexCommands.ts
@@ -87,6 +87,9 @@ export class CodexCommands {
 
         for (const entry of skillsEntries) {
             for (const skill of entry.skills) {
+                // A skill the user disabled (`[[skills.config]] enabled = false` in
+                // ~/.codex/config.toml) is not available, so it should not be advertised.
+                if (!skill.enabled) continue;
                 const name = `$${skill.name}`;
                 if (commands.has(name)) continue;
                 const description = skill.shortDescription ?? skill.description ?? skill.name;
@@ -265,7 +268,7 @@ export class CodexCommands {
             }
             case "skills": {
                 const response = await this.runWithProcessCheck(() => this.codexAcpClient.listSkills(this.createSkillsListParams(sessionState)));
-                const skills = (response?.data ?? []).flatMap(entry => entry.skills);
+                const skills = (response?.data ?? []).flatMap(entry => entry.skills).filter(skill => skill.enabled);
                 const lines = skills.map(skill => {
                     const description = skill.shortDescription ?? skill.description ?? "";
                     return description ? `- ${skill.name}: ${description}` : `- ${skill.name}`;

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -1430,6 +1430,42 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         await expect(mockFixture.getAcpConnectionDump([])).toMatchFileSnapshot("data/available-commands-skills.json");
     });
 
+    it('should not advertise skills the user disabled', async () => {
+        const mockFixture = createCodexMockTestFixture();
+        const codexAcpAgent = mockFixture.getCodexAcpAgent();
+
+        vi.spyOn(mockFixture.getCodexAcpClient(), "listSkills").mockResolvedValue({
+            data: [{
+                cwd: "/workspace",
+                skills: [{
+                    name: "build",
+                    description: "Build the project",
+                    shortDescription: "Build",
+                    path: "/workspace",
+                    scope: "user",
+                    enabled: true
+                }, {
+                    name: "deploy",
+                    description: "Deploy the project",
+                    shortDescription: "Deploy",
+                    path: "/workspace",
+                    scope: "user",
+                    enabled: false
+                }],
+                errors: []
+            }]
+        });
+
+        // @ts-expect-error - exercising private helper
+        await codexAcpAgent.availableCommands.publish(createTestSessionState({
+            sessionId: "session-id",
+            cwd: "/workspace",
+            additionalDirectories: ["/workspace/extra"],
+        }));
+
+        await expect(mockFixture.getAcpConnectionDump([])).toMatchFileSnapshot("data/available-commands-skills-disabled.json");
+    });
+
     it('handles builtin slash command locally', async () => {
         const mockFixture = createCodexMockTestFixture();
         const codexAcpAgent = mockFixture.getCodexAcpAgent();

--- a/src/__tests__/CodexACPAgent/data/available-commands-skills-disabled.json
+++ b/src/__tests__/CodexACPAgent/data/available-commands-skills-disabled.json
@@ -1,0 +1,91 @@
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "session-id",
+      "update": {
+        "sessionUpdate": "available_commands_update",
+        "availableCommands": [
+          {
+            "name": "plan",
+            "description": "Turn plan mode on.",
+            "input": null,
+            "_meta": {
+              "commandAction": {
+                "kind": "setConfigOption",
+                "configId": "collaboration_mode",
+                "value": "plan",
+                "resetValue": "default",
+                "presentation": "state"
+              }
+            }
+          },
+          {
+            "name": "mcp",
+            "description": "List configured Model Context Protocol (MCP) tools.",
+            "input": null
+          },
+          {
+            "name": "skills",
+            "description": "List available skills.",
+            "input": null
+          },
+          {
+            "name": "status",
+            "description": "Display session configuration and token usage.",
+            "input": null
+          },
+          {
+            "name": "review",
+            "description": "Review uncommitted changes, or review with custom instructions.",
+            "input": {
+              "hint": "optional review instructions"
+            }
+          },
+          {
+            "name": "review-branch",
+            "description": "Review changes relative to a base branch.",
+            "input": {
+              "hint": "branch name"
+            }
+          },
+          {
+            "name": "review-commit",
+            "description": "Review a specific commit.",
+            "input": {
+              "hint": "commit sha"
+            }
+          },
+          {
+            "name": "compact",
+            "description": "Summarize conversation to avoid hitting the context limit.",
+            "input": null
+          },
+          {
+            "name": "goal",
+            "description": "Set a goal to keep pursuing.",
+            "input": {
+              "hint": "[<objective>|clear|pause|resume]"
+            },
+            "_meta": {
+              "commandAction": {
+                "kind": "prefixPrompt",
+                "presentation": "state"
+              }
+            }
+          },
+          {
+            "name": "logout",
+            "description": "Sign out of Codex. This option is available when you are logged in via ChatGPT.",
+            "input": null
+          },
+          {
+            "name": "$build",
+            "description": "Build",
+            "input": null
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #385.

`buildAvailableCommands()` iterated every skill returned by `skills/list` without checking `skill.enabled`, so a skill disabled via `[[skills.config]] enabled = false` in `~/.codex/config.toml` was still published to the client as a `$`-command. The `/skills` builtin listed them for the same reason.

A client that renders the advertised command list had no way to tell the skill was already turned off, so its UI ended up contradicting the user's own config — a user who disables a skill and reopens the session still sees it offered.

### Changes

- `buildAvailableCommands()`: skip entries with `enabled === false`
- `/skills` listing: same filter, so the two surfaces agree

### Test

Added `should not advertise skills the user disabled` in `CodexAcpClient.test.ts` — publishes a `skills/list` response with one enabled and one disabled skill and snapshots the resulting `available_commands_update` (`data/available-commands-skills-disabled.json`): `$build` is present, `$deploy` is not.

`npm run typecheck` clean; full suite 401 passed / 28 skipped.

### One thing worth knowing before merging

`enabled` is not the whole story for model visibility. Codex has a second, independent filter — `<skill-dir>/agents/openai.yaml` with `policy.allow_implicit_invocation: false` — and a skill with that set is absent from the model-visible prompt while `skills/list` still reports `enabled: true` (the bundled `review-agent` ships exactly this). So after this PR a policy-disabled skill is still advertised. That would need the policy state surfaced on the `skills/list` entry first, so I left it out of this change — happy to follow up if you'd like it tracked separately.

Verifying any of this locally costs no model turn: `codex debug prompt-input` renders the model-visible prompt list as JSON.