### PR TITLE
feat: add versioned context compaction metadata

### DIFF
--- a/src/CodexToolCallMapper.ts
+++ b/src/CodexToolCallMapper.ts
@@ -32,6 +32,7 @@ import {
     createTerminalOutputMeta,
     type TerminalOutputMode,
 } from "./TerminalOutputMode";
+import {createContextCompactionMeta} from "./ContextCompactionMeta";
 
 type CodexItemStatus = CommandExecutionStatus | PatchApplyStatus | McpToolCallStatus | DynamicToolCallStatus | CollabAgentToolCallStatus;
 type AcpToolCallStatus = "pending" | "in_progress" | "completed" | "failed";
@@ -45,7 +46,7 @@ type CommandExecutionItem = ThreadItem & { type: "commandExecution" };
 type ContextCompactionItem = ThreadItem & { type: "contextCompaction" };
 type AcpToolCallEvent = Extract<UpdateSessionEvent, { sessionUpdate: "tool_call" }>;
 
-const CONTEXT_COMPACTION_META = { contextCompaction: true };
+const CONTEXT_COMPACTION_META = createContextCompactionMeta();
 
 function toAcpStatus(status: CodexItemStatus): AcpToolCallStatus {
     switch (status) {
@@ -230,8 +231,8 @@ export function createContextCompactionStartUpdate(
     return {
         sessionUpdate: "tool_call",
         toolCallId: item.id,
-        kind: "other",
-        title: "Context compacting",
+        kind: "think",
+        title: "Compact conversation",
         status: "in_progress",
         _meta: CONTEXT_COMPACTION_META,
     };
@@ -243,7 +244,7 @@ export function createContextCompactionCompleteUpdate(
     return {
         sessionUpdate: "tool_call_update",
         toolCallId: item.id,
-        title: "Context compacted",
+        title: "Compact conversation",
         status: "completed",
         _meta: CONTEXT_COMPACTION_META,
     };
@@ -255,8 +256,8 @@ export function createCompletedContextCompactionUpdate(
     return {
         sessionUpdate: "tool_call",
         toolCallId: item.id,
-        kind: "other",
-        title: "Context compacted",
+        kind: "think",
+        title: "Compact conversation",
         status: "completed",
         _meta: CONTEXT_COMPACTION_META,
     };

--- a/src/ContextCompactionMeta.ts
+++ b/src/ContextCompactionMeta.ts
@@ -1,0 +1,29 @@
+export const CONTEXT_COMPACTION_META_KEY = "contextCompaction";
+export const CONTEXT_COMPACTION_META_VERSION = 1;
+
+export type ContextCompactionTrigger = "manual" | "automatic";
+
+export interface ContextCompactionMetadata {
+    version: typeof CONTEXT_COMPACTION_META_VERSION;
+    trigger?: ContextCompactionTrigger;
+    preTokens?: number;
+    postTokens?: number;
+    durationMs?: number;
+    error?: string;
+}
+
+/**
+ * Provider-neutral metadata for a synthetic ACP context-compaction tool call.
+ * The standard toolCallId and status fields own lifecycle identity and phase;
+ * this extension carries only compaction-specific facts.
+ */
+export function createContextCompactionMeta(
+    metadata: Omit<ContextCompactionMetadata, "version"> = {},
+): Record<typeof CONTEXT_COMPACTION_META_KEY, ContextCompactionMetadata> {
+    return {
+        [CONTEXT_COMPACTION_META_KEY]: {
+            version: CONTEXT_COMPACTION_META_VERSION,
+            ...metadata,
+        },
+    };
+}

--- a/src/__tests__/CodexACPAgent/data/context-compaction-lifecycle.json
+++ b/src/__tests__/CodexACPAgent/data/context-compaction-lifecycle.json
@@ -6,11 +6,13 @@
       "update": {
         "sessionUpdate": "tool_call",
         "toolCallId": "context-compaction-id",
-        "kind": "other",
-        "title": "Context compacting",
+        "kind": "think",
+        "title": "Compact conversation",
         "status": "in_progress",
         "_meta": {
-          "contextCompaction": true
+          "contextCompaction": {
+            "version": 1
+          }
         }
       }
     }
@@ -24,10 +26,12 @@
       "update": {
         "sessionUpdate": "tool_call_update",
         "toolCallId": "context-compaction-id",
-        "title": "Context compacted",
+        "title": "Compact conversation",
         "status": "completed",
         "_meta": {
-          "contextCompaction": true
+          "contextCompaction": {
+            "version": 1
+          }
         }
       }
     }

--- a/src/__tests__/CodexACPAgent/data/load-session-history.json
+++ b/src/__tests__/CodexACPAgent/data/load-session-history.json
@@ -391,11 +391,13 @@
       "update": {
         "sessionUpdate": "tool_call",
         "toolCallId": "item-context-compaction-1",
-        "kind": "other",
-        "title": "Context compacted",
+        "kind": "think",
+        "title": "Compact conversation",
         "status": "completed",
         "_meta": {
-          "contextCompaction": true
+          "contextCompaction": {
+            "version": 1
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

- expose Codex context compaction through the shared synthetic ACP tool lifecycle
- replace the legacy boolean marker with versioned `_meta.contextCompaction` metadata
- align the title, kind, and lifecycle representation with claude-agent-acp
- keep the generated compaction summary internal to the agent

## Protocol

Compaction tool calls use `kind: "think"`, title `Compact conversation`, standard ACP lifecycle statuses, and `_meta.contextCompaction.version: 1`. The schema allows optional `trigger`, `preTokens`, `postTokens`, `durationMs`, and `error` fields.

## Testing

- `npm test -- --run` (400 passed, 28 skipped)
- `npm run typecheck`
