### PR TITLE
fix: preserve split UTF-8 in JSON-RPC reader

### DIFF
--- a/src/StdUtils.ts
+++ b/src/StdUtils.ts
@@ -1,4 +1,5 @@
 import {Readable, Writable} from "node:stream";
+import {StringDecoder} from "node:string_decoder";
 import {Emitter} from "vscode-jsonrpc/node";
 import type {DataCallback, Disposable, Message, MessageReader, MessageWriter, PartialMessageInfo} from "vscode-jsonrpc/node";
 import * as acp from "@agentclientprotocol/sdk";
@@ -33,8 +34,9 @@ export function createJSONRPCReader(readable: Readable): MessageReader {
     return {
         listen(callback: DataCallback): Disposable {
             let buf = '';
-            const onData = (chunk: Buffer) => {
-                buf += chunk.toString();
+            const decoder = new StringDecoder('utf8');
+            const onData = (chunk: Buffer | string) => {
+                buf += typeof chunk === 'string' ? chunk : decoder.write(chunk);
                 for (;;) {
                     const i = buf.indexOf('\n');
                     if (i < 0) break;

--- a/src/__tests__/StdUtils.test.ts
+++ b/src/__tests__/StdUtils.test.ts
@@ -1,0 +1,28 @@
+import {PassThrough} from "node:stream";
+import {describe, expect, it} from "vitest";
+import {createJSONRPCReader} from "../StdUtils";
+
+describe("createJSONRPCReader", () => {
+    it("preserves UTF-8 characters split across stream chunks", async () => {
+        const readable = new PassThrough();
+        const reader = createJSONRPCReader(readable);
+        const message = new Promise<unknown>((resolve) => {
+            reader.listen(resolve);
+        });
+        const bytes = Buffer.from('{"id":1,"result":"通用谓词解析器"}\n');
+        const character = Buffer.from("析");
+        const splitAt = bytes.indexOf(character);
+
+        readable.write(bytes.subarray(0, splitAt));
+        for (const byte of character) {
+            readable.write(Buffer.from([byte]));
+        }
+        readable.end(bytes.subarray(splitAt + character.length));
+
+        await expect(message).resolves.toMatchObject({
+            jsonrpc: "2.0",
+            id: 1,
+            result: "通用谓词解析器",
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- decode Codex app-server stdout with a stateful UTF-8 decoder
- preserve compatibility when the readable already emits strings
- add a regression test that delivers one Chinese character as three separate byte chunks

## Root cause

Calling Buffer.toString() independently for every stdout chunk replaces an incomplete multi-byte UTF-8 sequence with U+FFFD. Since stream chunk boundaries are arbitrary, valid JSON text could therefore be corrupted before JSON parsing.

## Validation

- npm test: 401 passed, 28 skipped
- npm run typecheck
- npm run build