### PR TITLE
feat(subagent-lifecycle): report coherent sub-agent and command updates

### DIFF
--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -41,6 +41,7 @@ import type {QuotaMeta} from "./QuotaMeta";
 import {logger} from "./Logger";
 import {sanitizeMcpServerName} from "./McpServerName";
 import {createResponseItemHistoryFallbackUpdates} from "./ResponseItemHistoryFallback";
+import {getSubAgentActivityTracker} from "./SubAgentActivityTracker";
 import {
     GOAL_CONTROL_ACTIONS,
     GOAL_CONTROL_METHOD,
@@ -59,7 +60,6 @@ import {
     type SessionSteerRequest,
 } from "./AcpExtensions";
 import {
-    createCollabAgentToolCallUpdate,
     createCommandExecutionCompleteUpdate,
     createCommandExecutionUpdate,
     createCompletedContextCompactionUpdate,
@@ -68,7 +68,6 @@ import {
     createImageGenerationUpdate,
     createImageViewUpdate,
     createMcpToolCallUpdate,
-    createSubAgentActivityUpdate,
     formatWebSearchTitle,
 } from "./CodexToolCallMapper";
 import {
@@ -245,7 +244,7 @@ export class CodexAcpServer {
         this.sessionFailureEpoch = randomUUID();
         this.clientInfo = null;
         this.clientCapabilities = null;
-        this.terminalOutputMode = "terminal_output_delta";
+        this.terminalOutputMode = "content";
         this.booleanConfigOptionsSupported = false;
         this.availableCommands = new CodexCommands(
             connection,
@@ -1576,6 +1575,7 @@ export class CodexAcpServer {
         return normalized.length > 0 ? normalized : null;
     }
 
+    // @spec: restored-sub-agent-tool-call-parity#replay-sub-agent-activity-with-live-structure
     private async createHistoryUpdates(item: ThreadItem, sessionState: SessionState): Promise<UpdateSessionEvent[]> {
         switch (item.type) {
             case "userMessage":
@@ -1584,7 +1584,7 @@ export class CodexAcpServer {
             case "sleep":
                 return [];
             case "subAgentActivity":
-                return [createSubAgentActivityUpdate(item, "completed", "tool_call")];
+                return getSubAgentActivityTracker(sessionState).mapSubAgentActivity(item, "completed");
             case "agentMessage": {
                 const meta = createCodexMessagePhaseMeta(item.phase);
                 return [{
@@ -1599,7 +1599,7 @@ export class CodexAcpServer {
             case "fileChange":
                 return [await createFileChangeUpdate(item)];
             case "commandExecution": {
-                const updates = [await createCommandExecutionUpdate(item)];
+                const updates = [await createCommandExecutionUpdate(item, sessionState.terminalOutputMode)];
                 const completeUpdate = createCommandExecutionCompleteUpdate(item, sessionState.terminalOutputMode);
                 if (completeUpdate) {
                     updates.push(completeUpdate);
@@ -1611,7 +1611,7 @@ export class CodexAcpServer {
             case "dynamicToolCall":
                 return [await createDynamicToolCallUpdate(item)];
             case "collabAgentToolCall":
-                return [createCollabAgentToolCallUpdate(item)];
+                return getSubAgentActivityTracker(sessionState).mapCollabAgentToolCall(item, "completed");
             case "webSearch":
                 return [this.createWebSearchUpdate(item)];
             case "imageView":
@@ -2553,9 +2553,9 @@ function mergeHistoryUpdates(
     const seen = new Set<string>();
     let fallbackIndex = 0;
 
-    const pushUpdate = (update: UpdateSessionEvent) => {
+    const pushUpdate = (update: UpdateSessionEvent, dedupe: boolean = true) => {
         const key = historyUpdateKey(update);
-        if (key && seen.has(key)) {
+        if (dedupe && key && seen.has(key)) {
             return;
         }
         if (key) {
@@ -2591,7 +2591,10 @@ function mergeHistoryUpdates(
 
     for (const update of threadUpdates) {
         flushFallbackBeforeMatchingDuplicate(update);
-        pushUpdate(update);
+        // Thread history is authoritative and can legitimately contain several
+        // progress updates for the same tool call. Only fallback records are
+        // deduplicated against those updates.
+        pushUpdate(update, false);
     }
 
     while (fallbackIndex < responseItemFallbackUpdates.length) {

--- a/src/CodexAppServerClient.ts
+++ b/src/CodexAppServerClient.ts
@@ -148,6 +148,7 @@ export class CodexAppServerClient {
     private readonly threadGoalClearedCaptures = new Map<string, Set<() => void>>();
     private readonly threadSettings = new Map<string, ThreadSettings>();
     private readonly staleTurnIds = new Map<string, Set<string>>();
+    private readonly childThreadParents = new Map<string, string>();
 
     constructor(connection: MessageConnection) {
         this.connection = connection;
@@ -184,6 +185,7 @@ export class CodexAppServerClient {
             if (this.handleStaleTurnNotification(serverNotification, routing)) {
                 return;
             }
+            this.recordChildThreadParent(serverNotification);
             this.recordTurnRouting(routing);
             if (this.handleStaleTurnNotification(serverNotification, routing)) {
                 return;
@@ -262,6 +264,12 @@ export class CodexAppServerClient {
         this.notificationHandlers.delete(threadId);
         this.approvalHandlers.delete(threadId);
         this.elicitationHandlers.delete(threadId);
+        this.childThreadParents.delete(threadId);
+        for (const [childThreadId, parentThreadId] of this.childThreadParents) {
+            if (parentThreadId === threadId) {
+                this.childThreadParents.delete(childThreadId);
+            }
+        }
     }
 
     async initialize(params: InitializeParams): Promise<InitializeResponse> {
@@ -687,10 +695,38 @@ export class CodexAppServerClient {
             if (handler) {
                 handler(notification);
             }
+            const parentThreadId = this.childThreadParents.get(threadId);
+            const parentHandler = parentThreadId ? this.notificationHandlers.get(parentThreadId) : undefined;
+            if (
+                parentHandler
+                && parentHandler !== handler
+                && isChildActivityNotification(notification)
+            ) {
+                parentHandler(notification);
+            }
             return;
         }
         for (const notificationHandler of this.notificationHandlers.values()) {
             notificationHandler(notification);
+        }
+    }
+
+    private recordChildThreadParent(notification: ServerNotification): void {
+        if (notification.method !== "item/started" && notification.method !== "item/completed") {
+            return;
+        }
+        const item = notification.params.item;
+        if (item.type === "subAgentActivity") {
+            this.childThreadParents.set(item.agentThreadId, notification.params.threadId);
+            return;
+        }
+        if (
+            item.type === "collabAgentToolCall"
+            && (item.tool === "spawnAgent" || item.tool === "resumeAgent")
+        ) {
+            for (const childThreadId of item.receiverThreadIds) {
+                this.childThreadParents.set(childThreadId, notification.params.threadId);
+            }
         }
     }
 
@@ -1016,6 +1052,14 @@ function isTurnCompletedNotification(notification: ServerNotification): notifica
     params: TurnCompletedNotification;
 } {
     return notification.method === "turn/completed";
+}
+
+function isChildActivityNotification(notification: ServerNotification): boolean {
+    if (notification.method === "turn/completed") {
+        return true;
+    }
+    return notification.method === "item/completed"
+        && notification.params.item.type === "agentMessage";
 }
 
 function isThreadStatusChangedNotification(notification: ServerNotification): notification is {

--- a/src/CodexEventHandler.ts
+++ b/src/CodexEventHandler.ts
@@ -39,9 +39,8 @@ import type { McpStartupCompleteEvent } from "./app-server/McpStartupCompleteEve
 import {toTokenCount} from "./TokenCount";
 import {
     commandExecutionUsesTerminalOutput,
-    createCollabAgentToolCallCompleteUpdate,
-    createCollabAgentToolCallUpdate,
     createCommandExecutionUpdate,
+    createCommandExecutionCompleteUpdate,
     createContextCompactionCompleteUpdate,
     createContextCompactionStartUpdate,
     createDynamicToolCallUpdate,
@@ -57,13 +56,13 @@ import {
     createFuzzyFileSearchComplete,
     createFuzzyFileSearchStartOrUpdate,
     createMcpToolCallUpdate,
-    createSubAgentActivityUpdate,
     createWebSearchCompleteUpdate,
     createWebSearchStartUpdate,
     fuzzyFileSearchToolCallId,
 } from "./CodexToolCallMapper";
 import { stripShellPrefix } from "./CommandUtils";
 import {createTerminalOutputMeta, type TerminalOutputMode} from "./TerminalOutputMode";
+import {getSubAgentActivityTracker} from "./SubAgentActivityTracker";
 import {
     createCodexMessagePhaseMeta,
     createAgentTextMessageChunk,
@@ -137,6 +136,8 @@ const STRUCTURED_CODEX_ERROR_CATEGORIES = {
     activeTurnNotSteerable: "provider_error",
 } satisfies Record<StructuredCodexErrorKind, SessionFailureCategory>;
 
+type UpdateResult = UpdateSessionEvent | UpdateSessionEvent[] | null;
+
 export class CodexEventHandler {
 
     private static readonly PLAN_UPDATE_INTERVAL_MS = 150;
@@ -163,7 +164,6 @@ export class CodexEventHandler {
     private readonly terminalCommandIds = new Set<string>();
     private readonly terminalCommandOutputIds = new Set<string>();
     private readonly agentMessagePhases = new Map<string, string | null>();
-    private readonly activeSubAgentActivities = new Set<string>();
 
     constructor(
         connection: AcpClientConnection,
@@ -294,8 +294,9 @@ export class CodexEventHandler {
 
     async handleNotification(notification: ServerNotification) {
         await this.flushPendingErrors();
-        const updateEvent = await this.createUpdateEvent(notification);
-        if (updateEvent) {
+        const result = await this.createUpdateEvent(notification);
+        const updateEvents = Array.isArray(result) ? result : result ? [result] : [];
+        for (const updateEvent of updateEvents) {
             await this.session.update(updateEvent);
         }
     }
@@ -333,7 +334,7 @@ export class CodexEventHandler {
         this.lastEmittedPlanTextByItemId.clear();
     }
 
-    private async createUpdateEvent(notification: ServerNotification): Promise<UpdateSessionEvent | null> {
+    private async createUpdateEvent(notification: ServerNotification): Promise<UpdateResult> {
         /*
         TODO split UpdateSessionEvent to improve completion
         createUpdateEvent({
@@ -359,6 +360,12 @@ export class CodexEventHandler {
                 await this.flushPendingErrors();
                 return null;
             case "turn/completed":
+                if (notification.params.threadId !== this.sessionState.sessionId) {
+                    return getSubAgentActivityTracker(this.sessionState).completeChildTurn(
+                        notification.params.threadId,
+                        notification.params.turn,
+                    );
+                }
                 await this.flushPendingPlanUpdates();
                 this.clearPlanTurnState();
                 this.sessionState.currentTurnId = null;
@@ -557,18 +564,21 @@ export class CodexEventHandler {
         return createAgentTextThoughtChunk(text, messageId);
     }
 
-    private async createItemEvent(event: ItemStartedNotification): Promise<UpdateSessionEvent | null> {
+    private async createItemEvent(event: ItemStartedNotification): Promise<UpdateResult> {
         switch (event.item.type) {
             case "fileChange":
                 return await createFileChangeUpdate(event.item);
             case "commandExecution": {
-                if (commandExecutionUsesTerminalOutput(event.item)) {
+                if (
+                    this.sessionState.terminalOutputMode !== "content"
+                    && commandExecutionUsesTerminalOutput(event.item)
+                ) {
                     this.terminalCommandIds.add(event.item.id);
                 } else {
                     this.terminalCommandIds.delete(event.item.id);
                     this.terminalCommandOutputIds.delete(event.item.id);
                 }
-                return await createCommandExecutionUpdate(event.item);
+                return await createCommandExecutionUpdate(event.item, this.sessionState.terminalOutputMode);
             }
             case "mcpToolCall":
                 return await createMcpToolCallUpdate(event.item);
@@ -583,15 +593,14 @@ export class CodexEventHandler {
                 this.activeImageGenerationItems.add(event.item.id);
                 return createImageGenerationStartUpdate(event.item);
             case "collabAgentToolCall":
-                return createCollabAgentToolCallUpdate(event.item);
+                return getSubAgentActivityTracker(this.sessionState).mapCollabAgentToolCall(event.item, "started");
             case "agentMessage":
                 this.rememberAgentMessagePhase(event.item);
                 return null;
             case "contextCompaction":
                 return createContextCompactionStartUpdate(event.item);
             case "subAgentActivity":
-                this.activeSubAgentActivities.add(event.item.id);
-                return createSubAgentActivityUpdate(event.item, "in_progress", "tool_call");
+                return getSubAgentActivityTracker(this.sessionState).mapSubAgentActivity(event.item, "started");
             case "sleep":
             case "userMessage":
             case "hookPrompt":
@@ -603,7 +612,7 @@ export class CodexEventHandler {
         }
     }
 
-    private async completeItemEvent(event: ItemCompletedNotification): Promise<UpdateSessionEvent | null> {
+    private async completeItemEvent(event: ItemCompletedNotification): Promise<UpdateResult> {
         switch (event.item.type) {
             case "fileChange":
             case "dynamicToolCall":
@@ -640,8 +649,15 @@ export class CodexEventHandler {
             case "webSearch":
                 return createWebSearchCompleteUpdate(event.item);
             case "collabAgentToolCall":
-                return createCollabAgentToolCallCompleteUpdate(event.item);
+                return getSubAgentActivityTracker(this.sessionState).mapCollabAgentToolCall(event.item, "completed");
             case "agentMessage":
+                if (event.threadId !== this.sessionState.sessionId) {
+                    getSubAgentActivityTracker(this.sessionState).recordChildMessage(
+                        event.threadId,
+                        event.item.text,
+                    );
+                    return null;
+                }
                 this.rememberAgentMessagePhase(event.item);
                 return null;
             case "plan": {
@@ -653,12 +669,8 @@ export class CodexEventHandler {
             case "contextCompaction":
                 return createContextCompactionCompleteUpdate(event.item);
             //ignored types
-            case "subAgentActivity": {
-                const sessionUpdate = this.activeSubAgentActivities.delete(event.item.id)
-                    ? "tool_call_update"
-                    : "tool_call";
-                return createSubAgentActivityUpdate(event.item, "completed", sessionUpdate);
-            }
+            case "subAgentActivity":
+                return getSubAgentActivityTracker(this.sessionState).mapSubAgentActivity(event.item, "completed");
             case "sleep":
             case "userMessage":
             case "hookPrompt":
@@ -768,7 +780,7 @@ export class CodexEventHandler {
     }
 
     private createCommandOutputDeltaEvent(event: CommandExecutionOutputDeltaNotification): UpdateSessionEvent {
-        if (this.terminalCommandIds.has(event.itemId) && event.delta.length > 0) {
+        if (event.delta.length > 0) {
             this.terminalCommandOutputIds.add(event.itemId);
         }
         return this.createCommandOutputEvent(event.itemId, event.delta, this.commandOutputMode(event.itemId));
@@ -779,6 +791,16 @@ export class CodexEventHandler {
         data: string,
         terminalOutputMode: TerminalOutputMode
     ): UpdateSessionEvent {
+        if (terminalOutputMode === "content") {
+            return {
+                sessionUpdate: "tool_call_update",
+                toolCallId: itemId,
+                content: [{
+                    type: "content",
+                    content: { type: "text", text: data },
+                }],
+            };
+        }
         return {
             sessionUpdate: "tool_call_update",
             toolCallId: itemId,
@@ -850,37 +872,16 @@ export class CodexEventHandler {
     }
 
     private completeCommandExecutionEvent(item: ThreadItem & { "type": "commandExecution" }): UpdateSessionEvent {
-        const update: UpdateSessionEvent = {
-            sessionUpdate: "tool_call_update",
-            toolCallId: item.id,
-            status: item.status === "completed" ? "completed" : "failed",
-            rawOutput: {
-                formatted_output: item.aggregatedOutput ?? "",
-                exit_code: item.exitCode
-            },
-        };
-
         const commandHadTerminal = this.terminalCommandIds.delete(item.id);
         const commandHadOutput = this.terminalCommandOutputIds.delete(item.id);
-        if (!commandHadTerminal) {
-            return update;
-        }
-        const terminalMeta: Record<string, unknown> = {};
-        if (!commandHadOutput && item.aggregatedOutput) {
-            Object.assign(
-                terminalMeta,
-                createTerminalOutputMeta(this.sessionState.terminalOutputMode, item.id, item.aggregatedOutput)
-            );
-        }
-        terminalMeta["terminal_exit"] = {
-            exit_code: item.exitCode,
-            signal: null,
-            terminal_id: item.id
-        };
-        return {
-            ...update,
-            _meta: terminalMeta,
-        };
+        return createCommandExecutionCompleteUpdate(
+            item,
+            this.sessionState.terminalOutputMode,
+            {
+                includeOutputContent: !commandHadOutput,
+                includeTerminalMeta: commandHadTerminal,
+            },
+        )!;
     }
 
     private async updatePlan(event: TurnPlanUpdatedNotification): Promise<UpdateSessionEvent> {

--- a/src/CodexToolCallMapper.ts
+++ b/src/CodexToolCallMapper.ts
@@ -78,10 +78,14 @@ export async function createFileChangeUpdate(
     };
 }
 
-export async function createCommandExecutionUpdate(item: CommandExecutionItem): Promise<UpdateSessionEvent> {
+// @spec: portable-command-output-by-default#emit-portable-command-output-without-terminal-extension
+export async function createCommandExecutionUpdate(
+    item: CommandExecutionItem,
+    terminalOutputMode: TerminalOutputMode = "content",
+): Promise<UpdateSessionEvent> {
     const commandAction = item.commandActions.length === 1 ? item.commandActions[0] : undefined;
     if (commandAction) {
-        return createCommandActionEvent(item.id, item.status, item.cwd, commandAction);
+        return createCommandActionEvent(item.id, item.status, item.cwd, commandAction, terminalOutputMode);
     }
     const command = stripShellPrefix(item.command);
     return createTerminalCommandEvent({
@@ -94,12 +98,14 @@ export async function createCommandExecutionUpdate(item: CommandExecutionItem): 
             command: item.command,
             cwd: item.cwd,
         },
-    }, item.id, item.cwd);
+    }, item.id, item.cwd, terminalOutputMode);
 }
 
+// @spec: portable-command-output-by-default#emit-portable-command-output-without-terminal-extension
 export function createCommandExecutionCompleteUpdate(
     item: CommandExecutionItem,
     terminalOutputMode: TerminalOutputMode,
+    options: { includeOutputContent?: boolean; includeTerminalMeta?: boolean } = {},
 ): UpdateSessionEvent | null {
     if (item.status === "inProgress") {
         return null;
@@ -115,12 +121,25 @@ export function createCommandExecutionCompleteUpdate(
         },
     };
 
+    if (terminalOutputMode === "content") {
+        const output = item.aggregatedOutput ?? "";
+        return {
+            ...update,
+            ...(options.includeOutputContent !== false && output.length > 0
+                ? { content: [createTextToolCallContent(output)] }
+                : {}),
+        };
+    }
+
     if (!commandExecutionUsesTerminalOutput(item)) {
+        return update;
+    }
+    if (options.includeTerminalMeta === false) {
         return update;
     }
 
     const terminalMeta: Record<string, unknown> = {};
-    if (item.aggregatedOutput) {
+    if (options.includeOutputContent !== false && item.aggregatedOutput) {
         Object.assign(
             terminalMeta,
             createTerminalOutputMeta(terminalOutputMode, item.id, item.aggregatedOutput),
@@ -540,7 +559,8 @@ export function createCommandActionEvent(
     id: string,
     status: CommandExecutionStatus,
     cwd: string,
-    commandAction: CommandAction
+    commandAction: CommandAction,
+    terminalOutputMode: TerminalOutputMode = "content",
 ): AcpToolCallEvent {
     const acpStatus = toAcpStatus(status);
     switch (commandAction.type) {
@@ -584,7 +604,7 @@ export function createCommandActionEvent(
                     command: commandAction.command,
                     cwd,
                 },
-            }, id, cwd);
+            }, id, cwd, terminalOutputMode);
     }
 }
 
@@ -593,11 +613,16 @@ export function commandExecutionUsesTerminalOutput(item: CommandExecutionItem): 
     return commandAction === undefined || commandAction.type === "unknown";
 }
 
+// Add synthetic terminal content only when the client negotiated the extension.
 function createTerminalCommandEvent(
     event: AcpToolCallEvent,
     terminalId: string,
     cwd: string,
+    terminalOutputMode: TerminalOutputMode,
 ): AcpToolCallEvent {
+    if (terminalOutputMode === "content") {
+        return event;
+    }
     const { rawInput, ...eventWithoutRawInput } = event;
     return {
         ...eventWithoutRawInput,
@@ -609,6 +634,13 @@ function createTerminalCommandEvent(
                 terminal_id: terminalId,
             },
         },
+    };
+}
+
+function createTextToolCallContent(text: string): ToolCallContent {
+    return {
+        type: "content",
+        content: { type: "text", text },
     };
 }
 

--- a/src/ResponseItemHistoryFallback.ts
+++ b/src/ResponseItemHistoryFallback.ts
@@ -56,6 +56,7 @@ export async function createResponseItemHistoryFallbackUpdates(
     return parseResponseItemHistoryFallback(contents, terminalOutputMode, toolCallIdsFromThread(thread));
 }
 
+// @spec: restored-sub-agent-tool-call-parity#replay-sub-agent-activity-with-live-structure
 export function parseResponseItemHistoryFallback(
     contents: string,
     terminalOutputMode: TerminalOutputMode,
@@ -106,6 +107,12 @@ export function parseResponseItemHistoryFallback(
                 break;
             case "function_call": {
                 const toolCallId = stringValue(item["call_id"]);
+                if (toolCallId && item["name"] === "wait_agent") {
+                    // The persisted wait result duplicates the sub-agent lifecycle item and would
+                    // otherwise render as an unrelated generic tool call after session loading.
+                    skippedToolCallIds.add(toolCallId);
+                    break;
+                }
                 if (toolCallId && existingToolCallIds.has(toolCallId)) {
                     skippedToolCallIds.add(toolCallId);
                     break;
@@ -113,7 +120,7 @@ export function parseResponseItemHistoryFallback(
                 if (toolCallId && emittedToolCallIds.has(toolCallId)) {
                     break;
                 }
-                const result = createFunctionCallUpdate(item);
+                const result = createFunctionCallUpdate(item, terminalOutputMode);
                 if (!result) {
                     break;
                 }
@@ -361,7 +368,10 @@ function textParts(value: unknown): string[] {
     });
 }
 
-function createFunctionCallUpdate(item: JsonRecord): LegacyFunctionCallUpdate | null {
+function createFunctionCallUpdate(
+    item: JsonRecord,
+    terminalOutputMode: TerminalOutputMode,
+): LegacyFunctionCallUpdate | null {
     const toolCallId = stringValue(item["call_id"]);
     const name = stringValue(item["name"]);
     if (!toolCallId || !name) {
@@ -375,7 +385,7 @@ function createFunctionCallUpdate(item: JsonRecord): LegacyFunctionCallUpdate | 
     const commandAction = command ? inferCommandAction(command, cwd) : null;
     if (commandAction) {
         return {
-            update: createCommandActionEvent(toolCallId, "inProgress", cwd, commandAction),
+            update: createCommandActionEvent(toolCallId, "inProgress", cwd, commandAction, terminalOutputMode),
             usesTerminal: false,
             isExecCommand,
         };
@@ -390,7 +400,7 @@ function createFunctionCallUpdate(item: JsonRecord): LegacyFunctionCallUpdate | 
         rawInput: rawInputForFunctionCall(name, args),
     };
 
-    if (!functionCallUsesTerminal(item)) {
+    if (terminalOutputMode === "content" || !functionCallUsesTerminal(item)) {
         return { update, usesTerminal: false, isExecCommand };
     }
 
@@ -401,6 +411,7 @@ function createFunctionCallUpdate(item: JsonRecord): LegacyFunctionCallUpdate | 
     };
 }
 
+// @spec: portable-command-output-by-default#emit-portable-command-output-without-terminal-extension
 function createFunctionCallOutputUpdate(
     item: JsonRecord,
     terminalOutputMode: TerminalOutputMode,
@@ -421,6 +432,14 @@ function createFunctionCallOutputUpdate(
             toolCallId,
             status,
             rawOutput: { output: item["output"] },
+            ...(execToolCallIds.has(toolCallId) && output.length > 0
+                ? {
+                    content: [{
+                        type: "content",
+                        content: { type: "text", text: output },
+                    }],
+                }
+                : {}),
         };
     }
 

--- a/src/SubAgentActivityTracker.ts
+++ b/src/SubAgentActivityTracker.ts
@@ -1,0 +1,383 @@
+import type { UpdateSessionEvent } from "./ACPSessionConnection";
+import type { CollabAgentState, ThreadItem, Turn } from "./app-server/v2";
+
+type CollabAgentToolCallItem = Extract<ThreadItem, { type: "collabAgentToolCall" }>;
+type SubAgentActivityItem = Extract<ThreadItem, { type: "subAgentActivity" }>;
+type AcpToolCallStatus = "in_progress" | "completed" | "failed";
+type Activity = {
+    agentThreadId: string;
+    toolCallId: string;
+    agentPath: string | null;
+    status: AcpToolCallStatus;
+};
+
+const trackers = new WeakMap<object, SubAgentActivityTracker>();
+
+export function getSubAgentActivityTracker(owner: object): SubAgentActivityTracker {
+    const existing = trackers.get(owner);
+    if (existing) {
+        return existing;
+    }
+    const tracker = new SubAgentActivityTracker();
+    trackers.set(owner, tracker);
+    return tracker;
+}
+
+export class SubAgentActivityTracker {
+    private readonly activities = new Map<string, Activity>();
+    private readonly seenSubAgentItems = new Set<string>();
+    private readonly childMessages = new Map<string, string>();
+
+    recordChildMessage(agentThreadId: string, text: string): void {
+        if (text.trim().length > 0) {
+            this.childMessages.set(agentThreadId, text);
+        }
+    }
+
+    // @spec: coherent-sub-agent-tool-call-lifecycle#report-a-live-sub-agent-run-coherently
+    completeChildTurn(agentThreadId: string, turn: Turn): UpdateSessionEvent[] {
+        const activity = this.activities.get(agentThreadId);
+        if (!activity || turn.status === "inProgress") {
+            return [];
+        }
+        const status: AcpToolCallStatus = turn.status === "completed" ? "completed" : "failed";
+        activity.status = status;
+        const result = this.childMessages.get(agentThreadId) ?? null;
+        this.childMessages.delete(agentThreadId);
+        const error = turn.error?.message ?? null;
+        const message = result ?? error;
+        return [{
+            sessionUpdate: "tool_call_update",
+            toolCallId: activity.toolCallId,
+            title: this.activityTitle(activity),
+            status,
+            ...(message ? {
+                content: [{
+                    type: "content",
+                    content: { type: "text", text: message },
+                }],
+            } : {}),
+            rawOutput: {
+                agentThreadId,
+                ...(activity.agentPath ? { agentPath: activity.agentPath } : {}),
+                turnId: turn.id,
+                turnStatus: turn.status,
+                result,
+                error: turn.error,
+            },
+            _meta: this.activityMeta(agentThreadId, activity.toolCallId),
+        }];
+    }
+
+    // @spec: coherent-sub-agent-tool-call-lifecycle#report-a-live-sub-agent-run-coherently
+    mapSubAgentActivity(
+        item: SubAgentActivityItem,
+        lifecycle: "started" | "completed",
+    ): UpdateSessionEvent[] {
+        if (lifecycle === "completed" && this.seenSubAgentItems.delete(item.id)) {
+            return [];
+        }
+        if (lifecycle === "started") {
+            this.seenSubAgentItems.add(item.id);
+        }
+
+        const existing = this.activities.get(item.agentThreadId);
+        switch (item.kind) {
+            case "started": {
+                if (existing && existing.status === "in_progress") {
+                    existing.agentPath = item.agentPath;
+                    return [this.createActivityUpdate(existing, {
+                        activity: item.kind,
+                        agentPath: item.agentPath,
+                    })];
+                }
+                return [this.createActivity(item.agentThreadId, item.id, item.agentPath, {
+                    activity: item.kind,
+                })];
+            }
+            case "interacted": {
+                if (!existing || existing.status !== "in_progress") {
+                    return [this.createActivity(item.agentThreadId, item.id, item.agentPath, {
+                        activity: item.kind,
+                    })];
+                }
+                existing.agentPath = item.agentPath;
+                return [this.createActivityUpdate(existing, {
+                    activity: item.kind,
+                    agentPath: item.agentPath,
+                })];
+            }
+            case "interrupted": {
+                if (!existing || existing.status !== "in_progress") {
+                    return [this.createActivity(item.agentThreadId, item.id, item.agentPath, {
+                        activity: item.kind,
+                    }, "failed")];
+                }
+                existing.status = "failed";
+                return [this.createActivityUpdate(existing, {
+                    activity: item.kind,
+                    agentPath: item.agentPath,
+                }, "failed")];
+            }
+        }
+    }
+
+    // @spec: coherent-sub-agent-tool-call-lifecycle#report-a-live-sub-agent-run-coherently
+    mapCollabAgentToolCall(
+        item: CollabAgentToolCallItem,
+        lifecycle: "started" | "completed",
+    ): UpdateSessionEvent[] {
+        const targetThreadIds = this.targetThreadIds(item);
+
+        switch (item.tool) {
+            case "spawnAgent":
+                return this.mapStartAction(item, targetThreadIds, lifecycle, "Start subagent");
+            case "resumeAgent":
+                return this.mapStartAction(item, targetThreadIds, lifecycle, "Resume subagent");
+            case "sendInput":
+            case "wait":
+            case "closeAgent":
+                if (lifecycle === "started") {
+                    return [];
+                }
+                return targetThreadIds.flatMap((threadId) => this.updateForControlAction(item, threadId));
+        }
+    }
+
+    private mapStartAction(
+        item: CollabAgentToolCallItem,
+        targetThreadIds: string[],
+        lifecycle: "started" | "completed",
+        failedTitle: string,
+    ): UpdateSessionEvent[] {
+        if (targetThreadIds.length === 0) {
+            if (lifecycle === "completed" && item.status === "failed") {
+                return [{
+                    sessionUpdate: "tool_call",
+                    toolCallId: item.id,
+                    kind: "other",
+                    title: failedTitle,
+                    status: "failed",
+                    rawInput: this.startRawInput(item),
+                    rawOutput: this.actionRawOutput(item, null),
+                    _meta: this.activityMeta(null, item.id),
+                }];
+            }
+            return [];
+        }
+
+        return targetThreadIds.flatMap((threadId, index) => {
+            const current = this.activities.get(threadId);
+            const needsNewRun = !current || current.status !== "in_progress";
+            if (needsNewRun) {
+                const toolCallId = targetThreadIds.length === 1 ? item.id : `${item.id}:${index}`;
+                const state = item.agentsStates[threadId] ?? null;
+                const status = this.startActionStatus(item, state);
+                return [this.createActivity(
+                    threadId,
+                    toolCallId,
+                    current?.agentPath ?? null,
+                    this.actionRawOutput(item, state),
+                    status,
+                    item,
+                )];
+            }
+
+            if (lifecycle === "started") {
+                return [];
+            }
+            const state = item.agentsStates[threadId] ?? null;
+            const status = this.stateStatus(state) ?? current.status;
+            current.status = status;
+            return [this.createActivityUpdate(current, this.actionRawOutput(item, state), status)];
+        });
+    }
+
+    private updateForControlAction(
+        item: CollabAgentToolCallItem,
+        threadId: string,
+    ): UpdateSessionEvent[] {
+        const state = item.agentsStates[threadId] ?? null;
+        let activity = this.activities.get(threadId);
+        if (!activity) {
+            const status = this.stateStatus(state) ?? "in_progress";
+            const toolCallId = `${item.id}:${encodeURIComponent(threadId)}`;
+            return [this.createActivity(threadId, toolCallId, null, this.actionRawOutput(item, state), status)];
+        }
+
+        let status = this.stateStatus(state) ?? activity.status;
+        if (item.tool === "closeAgent" && item.status === "completed" && status === "in_progress") {
+            status = "completed";
+        }
+        activity.status = status;
+        return [this.createActivityUpdate(activity, this.actionRawOutput(item, state), status, item.prompt)];
+    }
+
+    private createActivity(
+        agentThreadId: string,
+        toolCallId: string,
+        agentPath: string | null,
+        rawOutput: Record<string, unknown>,
+        status: AcpToolCallStatus = "in_progress",
+        startItem?: CollabAgentToolCallItem,
+    ): UpdateSessionEvent {
+        const activity: Activity = { agentThreadId, toolCallId, agentPath, status };
+        const rawInput = this.activityRawInput(activity, startItem);
+        this.activities.set(agentThreadId, activity);
+        return {
+            sessionUpdate: "tool_call",
+            toolCallId,
+            kind: "other",
+            title: this.activityTitle(activity),
+            status,
+            ...(rawInput ? { rawInput } : {}),
+            rawOutput: {
+                agentThreadId,
+                ...(agentPath ? { agentPath } : {}),
+                ...rawOutput,
+            },
+            _meta: this.activityMeta(agentThreadId, toolCallId),
+        };
+    }
+
+    private createActivityUpdate(
+        activity: Activity,
+        rawOutput: Record<string, unknown>,
+        status: AcpToolCallStatus = activity.status,
+        prompt: string | null = null,
+    ): UpdateSessionEvent {
+        const message = this.activityMessage(rawOutput, prompt);
+        return {
+            sessionUpdate: "tool_call_update",
+            toolCallId: activity.toolCallId,
+            title: this.activityTitle(activity),
+            status,
+            ...(message ? {
+                content: [{
+                    type: "content",
+                    content: { type: "text", text: message },
+                }],
+            } : {}),
+            rawOutput: {
+                agentThreadId: activity.agentThreadId,
+                ...(activity.agentPath ? { agentPath: activity.agentPath } : {}),
+                ...rawOutput,
+            },
+            _meta: this.activityMeta(activity.agentThreadId, activity.toolCallId),
+        };
+    }
+
+    private startRawInput(item: CollabAgentToolCallItem): Record<string, unknown> {
+        return {
+            prompt: item.prompt,
+            model: item.model,
+            reasoningEffort: item.reasoningEffort,
+        };
+    }
+
+    private actionRawOutput(
+        item: CollabAgentToolCallItem,
+        state: CollabAgentState | null,
+    ): Record<string, unknown> {
+        return {
+            action: item.tool,
+            actionStatus: item.status,
+            senderThreadId: item.senderThreadId,
+            receiverThreadIds: item.receiverThreadIds,
+            prompt: item.prompt,
+            agentState: state,
+        };
+    }
+
+    private startActionStatus(
+        item: CollabAgentToolCallItem,
+        state: CollabAgentState | null,
+    ): AcpToolCallStatus {
+        if (item.status === "failed") {
+            return "failed";
+        }
+        return this.stateStatus(state) ?? "in_progress";
+    }
+
+    private stateStatus(state: CollabAgentState | null): AcpToolCallStatus | null {
+        switch (state?.status) {
+            case "pendingInit":
+            case "running":
+                return "in_progress";
+            case "completed":
+            case "shutdown":
+                return "completed";
+            case "interrupted":
+            case "errored":
+            case "notFound":
+                return "failed";
+            case undefined:
+                return null;
+        }
+    }
+
+    private targetThreadIds(item: CollabAgentToolCallItem): string[] {
+        return Array.from(new Set([
+            ...item.receiverThreadIds,
+            ...Object.keys(item.agentsStates),
+        ]));
+    }
+
+    private activityTitle(activity: Activity): string {
+        return this.activityDescription(activity) ?? "Agent activity";
+    }
+
+    private activityDescription(activity: Activity): string | null {
+        // Use the canonical task name as the client-facing description.
+        const segments = activity.agentPath?.split("/").filter(Boolean);
+        const taskName = segments?.[segments.length - 1];
+        if (!taskName || taskName === "root") {
+            return null;
+        }
+        const readableTaskName = taskName.replace(/_+/g, " ").trim();
+        if (!readableTaskName) {
+            return null;
+        }
+        return `${readableTaskName.charAt(0).toUpperCase()}${readableTaskName.slice(1)}`;
+    }
+
+    private activityRawInput(
+        activity: Activity,
+        startItem?: CollabAgentToolCallItem,
+    ): Record<string, unknown> | null {
+        const description = this.activityDescription(activity);
+        if (!description && !startItem) {
+            return null;
+        }
+        return {
+            ...(description ? { description } : {}),
+            ...(startItem ? this.startRawInput(startItem) : {}),
+        };
+    }
+
+    private activityMeta(agentThreadId: string | null, runId: string): Record<string, unknown> {
+        return {
+            codex: {
+                toolName: "Agent",
+                subAgent: {
+                    agentThreadId,
+                    runId,
+                },
+            },
+        };
+    }
+
+    private activityMessage(rawOutput: Record<string, unknown>, prompt: string | null): string | null {
+        const state = rawOutput["agentState"];
+        if (state && typeof state === "object" && "message" in state && typeof state.message === "string") {
+            return state.message;
+        }
+        if (rawOutput["actionStatus"] === "failed") {
+            return `Subagent ${String(rawOutput["action"])} failed.`;
+        }
+        if (prompt) {
+            return `Sent follow-up to subagent: ${prompt}`;
+        }
+        return null;
+    }
+}

--- a/src/TerminalOutputMode.ts
+++ b/src/TerminalOutputMode.ts
@@ -1,7 +1,8 @@
 import type * as acp from "@agentclientprotocol/sdk";
 
-export type TerminalOutputMode = "terminal_output" | "terminal_output_delta";
+export type TerminalOutputMode = "content" | "terminal_output" | "terminal_output_delta";
 
+// @spec: portable-command-output-by-default#emit-portable-command-output-without-terminal-extension
 export function resolveTerminalOutputMode(
     clientCapabilities?: acp.ClientCapabilities | null
 ): TerminalOutputMode {
@@ -9,7 +10,10 @@ export function resolveTerminalOutputMode(
     if (meta?.["terminal_output"] === true) {
         return "terminal_output";
     }
-    return "terminal_output_delta";
+    if (meta?.["terminal_output_delta"] === true) {
+        return "terminal_output_delta";
+    }
+    return "content";
 }
 
 export function createTerminalOutputMeta(
@@ -18,6 +22,8 @@ export function createTerminalOutputMeta(
     data: string
 ): Record<string, unknown> {
     switch (mode) {
+        case "content":
+            return {};
         case "terminal_output":
             return {
                 terminal_output: {

--- a/src/__tests__/CodexACPAgent/collab-agent-events.test.ts
+++ b/src/__tests__/CodexACPAgent/collab-agent-events.test.ts
@@ -24,33 +24,35 @@ describe("CodexEventHandler - collab agent tool call events", () => {
         agentMode: AgentMode.DEFAULT_AGENT_MODE,
     });
 
-    it("maps live collab agent tool calls to ACP tool call updates", async () => {
+    // Covers one activity per subagent run, including controls, resume, and failed spawn.
+    // @spec: coherent-sub-agent-tool-call-lifecycle#report-a-live-sub-agent-run-coherently
+    it("folds collaboration controls into coherent subagent run activities", async () => {
         const notifications: ServerNotification[] = [
             {
-                method: "item/started",
+                method: "item/completed",
                 params: {
                     threadId: sessionId,
                     turnId: "turn-1",
-                    startedAtMs: 0,
+                    completedAtMs: 0,
                     item: {
-                        type: "collabAgentToolCall",
-                        id: "call-spawn-weather",
-                        tool: "spawnAgent",
-                        status: "inProgress",
-                        senderThreadId: "thread-main",
-                        receiverThreadIds: ["thread-paris"],
-                        prompt: "Find the current weather in Paris.",
-                        model: null,
-                        reasoningEffort: null,
-                        agentsStates: {
-                            "thread-paris": {
-                                status: "running",
-                                message: "Checking weather",
-                            },
-                        },
+                        type: "subAgentActivity",
+                        id: "activity-initial",
+                        kind: "started",
+                        agentThreadId: "thread-paris",
+                        agentPath: "/root/weather_audit",
                     },
                 },
             },
+            emptyWait("wait-1", "started"),
+            childMessage("child-result-1", "@agentclientprotocol/codex-acp"),
+            childTurnCompleted("child-turn-1"),
+            emptyWait("wait-1", "completed"),
+            collabStarted("resume-1", "resumeAgent", "running"),
+            collabCompleted("resume-1", "resumeAgent", "running"),
+            collabCompleted("send-1", "sendInput", "running", "Check alerts too."),
+            childMessage("child-result-2", "No alerts found."),
+            childTurnCompleted("child-turn-2"),
+            collabCompleted("close-1", "closeAgent", "shutdown"),
             {
                 method: "item/completed",
                 params: {
@@ -59,20 +61,15 @@ describe("CodexEventHandler - collab agent tool call events", () => {
                     completedAtMs: 0,
                     item: {
                         type: "collabAgentToolCall",
-                        id: "call-spawn-weather",
+                        id: "spawn-failed",
                         tool: "spawnAgent",
-                        status: "completed",
+                        status: "failed",
                         senderThreadId: "thread-main",
-                        receiverThreadIds: ["thread-paris"],
-                        prompt: "Find the current weather in Paris.",
+                        receiverThreadIds: [],
+                        prompt: "Try an unavailable worker.",
                         model: null,
                         reasoningEffort: null,
-                        agentsStates: {
-                            "thread-paris": {
-                                status: "completed",
-                                message: null,
-                            },
-                        },
+                        agentsStates: {},
                     },
                 },
             },
@@ -85,29 +82,143 @@ describe("CodexEventHandler - collab agent tool call events", () => {
         );
     });
 
-    it("maps live subagent activity to an ACP tool call", async () => {
-        const notifications: ServerNotification[] = [
-            {
+    function collabStarted(
+        id: string,
+        tool: "resumeAgent",
+        agentStatus: "running",
+    ): ServerNotification {
+        return {
+            method: "item/started",
+            params: {
+                threadId: sessionId,
+                turnId: "turn-1",
+                startedAtMs: 0,
+                item: collabItem(id, tool, "inProgress", agentStatus),
+            },
+        };
+    }
+
+    function emptyWait(id: string, lifecycle: "started" | "completed"): ServerNotification {
+        return lifecycle === "started"
+            ? {
+                method: "item/started",
+                params: {
+                    threadId: sessionId,
+                    turnId: "turn-1",
+                    startedAtMs: 0,
+                    item: {
+                        type: "collabAgentToolCall",
+                        id,
+                        tool: "wait",
+                        status: "inProgress",
+                        senderThreadId: "thread-main",
+                        receiverThreadIds: [],
+                        prompt: null,
+                        model: null,
+                        reasoningEffort: null,
+                        agentsStates: {},
+                    },
+                },
+            }
+            : {
                 method: "item/completed",
                 params: {
                     threadId: sessionId,
                     turnId: "turn-1",
                     completedAtMs: 0,
                     item: {
-                        type: "subAgentActivity",
-                        id: "call-spawn-weather",
-                        kind: "started",
-                        agentThreadId: "thread-paris",
-                        agentPath: "/root/weather_research",
+                        type: "collabAgentToolCall",
+                        id,
+                        tool: "wait",
+                        status: "completed",
+                        senderThreadId: "thread-main",
+                        receiverThreadIds: [],
+                        prompt: null,
+                        model: null,
+                        reasoningEffort: null,
+                        agentsStates: {},
                     },
                 },
+            };
+    }
+
+    function childMessage(id: string, text: string): ServerNotification {
+        return {
+            method: "item/completed",
+            params: {
+                threadId: "thread-paris",
+                turnId: "child-turn",
+                completedAtMs: 0,
+                item: {
+                    type: "agentMessage",
+                    id,
+                    text,
+                    phase: "final_answer",
+                    memoryCitation: null,
+                },
             },
-        ];
+        };
+    }
 
-        await setupPromptAndSendNotifications(mockFixture, sessionId, sessionState, notifications);
+    function childTurnCompleted(turnId: string): ServerNotification {
+        return {
+            method: "turn/completed",
+            params: {
+                threadId: "thread-paris",
+                turn: {
+                    id: turnId,
+                    items: [],
+                    itemsView: "notLoaded",
+                    status: "completed",
+                    error: null,
+                    startedAt: 0,
+                    completedAt: 1,
+                    durationMs: 1000,
+                },
+            },
+        };
+    }
 
-        await expect(`${mockFixture.getAcpConnectionDump([])}\n`).toMatchFileSnapshot(
-            "data/subagent-activity-flow.json"
-        );
-    });
+    function collabCompleted(
+        id: string,
+        tool: "wait" | "resumeAgent" | "sendInput" | "closeAgent",
+        agentStatus: "completed" | "running" | "shutdown",
+        prompt: string | null = null,
+    ): ServerNotification {
+        return {
+            method: "item/completed",
+            params: {
+                threadId: sessionId,
+                turnId: "turn-1",
+                completedAtMs: 0,
+                item: collabItem(id, tool, "completed", agentStatus, prompt),
+            },
+        };
+    }
+
+    function collabItem(
+        id: string,
+        tool: "wait" | "resumeAgent" | "sendInput" | "closeAgent",
+        status: "inProgress" | "completed",
+        agentStatus: "completed" | "running" | "shutdown",
+        prompt: string | null = null,
+    ): Extract<ServerNotification, { method: "item/completed" }>["params"]["item"] & { type: "collabAgentToolCall" } {
+        return {
+            type: "collabAgentToolCall",
+            id,
+            tool,
+            status,
+            senderThreadId: "thread-main",
+            receiverThreadIds: ["thread-paris"],
+            prompt,
+            model: null,
+            reasoningEffort: null,
+            agentsStates: {
+                "thread-paris": {
+                    status: agentStatus,
+                    message: agentStatus === "running" ? "Working" : null,
+                },
+            },
+        };
+    }
 });

--- a/src/__tests__/CodexACPAgent/data/collab-agent-tool-call-flow.json
+++ b/src/__tests__/CodexACPAgent/data/collab-agent-tool-call-flow.json
@@ -5,34 +5,24 @@
       "sessionId": "test-session-id",
       "update": {
         "sessionUpdate": "tool_call",
-        "toolCallId": "call-spawn-weather",
+        "toolCallId": "activity-initial",
         "kind": "other",
-        "title": "spawnAgent",
+        "title": "Weather audit",
         "status": "in_progress",
         "rawInput": {
-          "prompt": "Find the current weather in Paris.",
-          "senderThreadId": "thread-main",
-          "receiverThreadIds": [
-            "thread-paris"
-          ],
-          "agentsStates": {
-            "thread-paris": {
-              "status": "running",
-              "message": "Checking weather"
-            }
-          },
-          "model": null,
-          "reasoningEffort": null,
-          "status": "inProgress"
+          "description": "Weather audit"
+        },
+        "rawOutput": {
+          "agentThreadId": "thread-paris",
+          "agentPath": "/root/weather_audit",
+          "activity": "started"
         },
         "_meta": {
           "codex": {
-            "collaboration": {
-              "tool": "spawnAgent",
-              "senderThreadId": "thread-main",
-              "receiverThreadIds": [
-                "thread-paris"
-              ]
+            "toolName": "Agent",
+            "subAgent": {
+              "agentThreadId": "thread-paris",
+              "runId": "activity-initial"
             }
           }
         }
@@ -47,33 +37,286 @@
       "sessionId": "test-session-id",
       "update": {
         "sessionUpdate": "tool_call_update",
-        "toolCallId": "call-spawn-weather",
-        "title": "spawnAgent",
+        "toolCallId": "activity-initial",
+        "title": "Weather audit",
         "status": "completed",
+        "content": [
+          {
+            "type": "content",
+            "content": {
+              "type": "text",
+              "text": "@agentclientprotocol/codex-acp"
+            }
+          }
+        ],
+        "rawOutput": {
+          "agentThreadId": "thread-paris",
+          "agentPath": "/root/weather_audit",
+          "turnId": "child-turn-1",
+          "turnStatus": "completed",
+          "result": "@agentclientprotocol/codex-acp",
+          "error": null
+        },
+        "_meta": {
+          "codex": {
+            "toolName": "Agent",
+            "subAgent": {
+              "agentThreadId": "thread-paris",
+              "runId": "activity-initial"
+            }
+          }
+        }
+      }
+    }
+  ]
+}
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "resume-1",
+        "kind": "other",
+        "title": "Weather audit",
+        "status": "in_progress",
         "rawInput": {
-          "prompt": "Find the current weather in Paris.",
+          "description": "Weather audit",
+          "prompt": null,
+          "model": null,
+          "reasoningEffort": null
+        },
+        "rawOutput": {
+          "agentThreadId": "thread-paris",
+          "agentPath": "/root/weather_audit",
+          "action": "resumeAgent",
+          "actionStatus": "inProgress",
           "senderThreadId": "thread-main",
           "receiverThreadIds": [
             "thread-paris"
           ],
-          "agentsStates": {
-            "thread-paris": {
-              "status": "completed",
-              "message": null
-            }
-          },
-          "model": null,
-          "reasoningEffort": null,
-          "status": "completed"
+          "prompt": null,
+          "agentState": {
+            "status": "running",
+            "message": "Working"
+          }
         },
         "_meta": {
           "codex": {
-            "collaboration": {
-              "tool": "spawnAgent",
-              "senderThreadId": "thread-main",
-              "receiverThreadIds": [
-                "thread-paris"
-              ]
+            "toolName": "Agent",
+            "subAgent": {
+              "agentThreadId": "thread-paris",
+              "runId": "resume-1"
+            }
+          }
+        }
+      }
+    }
+  ]
+}
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": "resume-1",
+        "title": "Weather audit",
+        "status": "in_progress",
+        "content": [
+          {
+            "type": "content",
+            "content": {
+              "type": "text",
+              "text": "Working"
+            }
+          }
+        ],
+        "rawOutput": {
+          "agentThreadId": "thread-paris",
+          "agentPath": "/root/weather_audit",
+          "action": "resumeAgent",
+          "actionStatus": "completed",
+          "senderThreadId": "thread-main",
+          "receiverThreadIds": [
+            "thread-paris"
+          ],
+          "prompt": null,
+          "agentState": {
+            "status": "running",
+            "message": "Working"
+          }
+        },
+        "_meta": {
+          "codex": {
+            "toolName": "Agent",
+            "subAgent": {
+              "agentThreadId": "thread-paris",
+              "runId": "resume-1"
+            }
+          }
+        }
+      }
+    }
+  ]
+}
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": "resume-1",
+        "title": "Weather audit",
+        "status": "in_progress",
+        "content": [
+          {
+            "type": "content",
+            "content": {
+              "type": "text",
+              "text": "Working"
+            }
+          }
+        ],
+        "rawOutput": {
+          "agentThreadId": "thread-paris",
+          "agentPath": "/root/weather_audit",
+          "action": "sendInput",
+          "actionStatus": "completed",
+          "senderThreadId": "thread-main",
+          "receiverThreadIds": [
+            "thread-paris"
+          ],
+          "prompt": "Check alerts too.",
+          "agentState": {
+            "status": "running",
+            "message": "Working"
+          }
+        },
+        "_meta": {
+          "codex": {
+            "toolName": "Agent",
+            "subAgent": {
+              "agentThreadId": "thread-paris",
+              "runId": "resume-1"
+            }
+          }
+        }
+      }
+    }
+  ]
+}
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": "resume-1",
+        "title": "Weather audit",
+        "status": "completed",
+        "content": [
+          {
+            "type": "content",
+            "content": {
+              "type": "text",
+              "text": "No alerts found."
+            }
+          }
+        ],
+        "rawOutput": {
+          "agentThreadId": "thread-paris",
+          "agentPath": "/root/weather_audit",
+          "turnId": "child-turn-2",
+          "turnStatus": "completed",
+          "result": "No alerts found.",
+          "error": null
+        },
+        "_meta": {
+          "codex": {
+            "toolName": "Agent",
+            "subAgent": {
+              "agentThreadId": "thread-paris",
+              "runId": "resume-1"
+            }
+          }
+        }
+      }
+    }
+  ]
+}
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": "resume-1",
+        "title": "Weather audit",
+        "status": "completed",
+        "rawOutput": {
+          "agentThreadId": "thread-paris",
+          "agentPath": "/root/weather_audit",
+          "action": "closeAgent",
+          "actionStatus": "completed",
+          "senderThreadId": "thread-main",
+          "receiverThreadIds": [
+            "thread-paris"
+          ],
+          "prompt": null,
+          "agentState": {
+            "status": "shutdown",
+            "message": null
+          }
+        },
+        "_meta": {
+          "codex": {
+            "toolName": "Agent",
+            "subAgent": {
+              "agentThreadId": "thread-paris",
+              "runId": "resume-1"
+            }
+          }
+        }
+      }
+    }
+  ]
+}
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "spawn-failed",
+        "kind": "other",
+        "title": "Start subagent",
+        "status": "failed",
+        "rawInput": {
+          "prompt": "Try an unavailable worker.",
+          "model": null,
+          "reasoningEffort": null
+        },
+        "rawOutput": {
+          "action": "spawnAgent",
+          "actionStatus": "failed",
+          "senderThreadId": "thread-main",
+          "receiverThreadIds": [],
+          "prompt": "Try an unavailable worker.",
+          "agentState": null
+        },
+        "_meta": {
+          "codex": {
+            "toolName": "Agent",
+            "subAgent": {
+              "agentThreadId": null,
+              "runId": "spawn-failed"
             }
           }
         }

--- a/src/__tests__/CodexACPAgent/data/load-session-history.json
+++ b/src/__tests__/CodexACPAgent/data/load-session-history.json
@@ -194,21 +194,9 @@
         "kind": "execute",
         "title": "ls",
         "status": "completed",
-        "content": [
-          {
-            "type": "terminal",
-            "terminalId": "item-cmd-1"
-          }
-        ],
         "rawInput": {
           "command": "ls",
           "cwd": "/test/project"
-        },
-        "_meta": {
-          "terminal_info": {
-            "cwd": "/test/project",
-            "terminal_id": "item-cmd-1"
-          }
         }
       }
     }
@@ -227,17 +215,15 @@
           "formatted_output": "Added.txt\nREADME.md\n",
           "exit_code": 0
         },
-        "_meta": {
-          "terminal_output_delta": {
-            "data": "Added.txt\nREADME.md\n",
-            "terminal_id": "item-cmd-1"
-          },
-          "terminal_exit": {
-            "exit_code": 0,
-            "signal": null,
-            "terminal_id": "item-cmd-1"
+        "content": [
+          {
+            "type": "content",
+            "content": {
+              "type": "text",
+              "text": "Added.txt\nREADME.md\n"
+            }
           }
-        }
+        ]
       }
     }
   ]
@@ -408,21 +394,24 @@
       "sessionId": "session-1",
       "update": {
         "sessionUpdate": "tool_call",
-        "title": "Start subagent test_audit",
-        "kind": "other",
         "toolCallId": "item-subagent-1",
-        "status": "completed",
+        "kind": "other",
+        "title": "Test audit",
+        "status": "in_progress",
         "rawInput": {
+          "description": "Test audit"
+        },
+        "rawOutput": {
           "agentThreadId": "thread-child-1",
           "agentPath": "/root/test_audit",
-          "activityKind": "started"
+          "activity": "started"
         },
         "_meta": {
           "codex": {
-            "subagent": {
-              "threadId": "thread-child-1",
-              "path": "/root/test_audit",
-              "activity": "started"
+            "toolName": "Agent",
+            "subAgent": {
+              "agentThreadId": "thread-child-1",
+              "runId": "item-subagent-1"
             }
           }
         }

--- a/src/__tests__/CodexACPAgent/data/load-session-response-item-history-fallback.json
+++ b/src/__tests__/CodexACPAgent/data/load-session-response-item-history-fallback.json
@@ -189,7 +189,16 @@
         "status": "completed",
         "rawOutput": {
           "output": "Chunk ID: search123\nWall time: 0.0000 seconds\nProcess exited with code 0\nOutput:\nsrc/service.ts:export class Service {}\n"
-        }
+        },
+        "content": [
+          {
+            "type": "content",
+            "content": {
+              "type": "text",
+              "text": "Chunk ID: search123\nWall time: 0.0000 seconds\nProcess exited with code 0\nOutput:\nsrc/service.ts:export class Service {}\n"
+            }
+          }
+        ]
       }
     }
   ]
@@ -220,7 +229,16 @@
         "status": "failed",
         "rawOutput": {
           "output": "Chunk ID: search456\nWall time: 0.0000 seconds\nProcess exited with code 1\nOutput:\n"
-        }
+        },
+        "content": [
+          {
+            "type": "content",
+            "content": {
+              "type": "text",
+              "text": "Chunk ID: search456\nWall time: 0.0000 seconds\nProcess exited with code 1\nOutput:\n"
+            }
+          }
+        ]
       }
     }
   ]
@@ -256,7 +274,16 @@
         "status": "completed",
         "rawOutput": {
           "output": "Chunk ID: read123\nWall time: 0.0000 seconds\nProcess exited with code 0\nOutput:\n     1\tconsole.log('hi');\n"
-        }
+        },
+        "content": [
+          {
+            "type": "content",
+            "content": {
+              "type": "text",
+              "text": "Chunk ID: read123\nWall time: 0.0000 seconds\nProcess exited with code 0\nOutput:\n     1\tconsole.log('hi');\n"
+            }
+          }
+        ]
       }
     }
   ]
@@ -287,7 +314,16 @@
         "status": "completed",
         "rawOutput": {
           "output": "Chunk ID: abc123\nWall time: 0.0000 seconds\nProcess exited with code 0\nOutput:\nREADME.md\nsrc\n"
-        }
+        },
+        "content": [
+          {
+            "type": "content",
+            "content": {
+              "type": "text",
+              "text": "Chunk ID: abc123\nWall time: 0.0000 seconds\nProcess exited with code 0\nOutput:\nREADME.md\nsrc\n"
+            }
+          }
+        ]
       }
     }
   ]

--- a/src/__tests__/CodexACPAgent/data/portable-command-flow.json
+++ b/src/__tests__/CodexACPAgent/data/portable-command-flow.json
@@ -1,0 +1,102 @@
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "portable-ok",
+        "kind": "execute",
+        "title": "echo ok",
+        "status": "in_progress",
+        "rawInput": {
+          "command": "echo ok",
+          "cwd": "/test/project"
+        }
+      }
+    }
+  ]
+}
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": "portable-ok",
+        "content": [
+          {
+            "type": "content",
+            "content": {
+              "type": "text",
+              "text": "ok\n"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": "portable-ok",
+        "status": "completed",
+        "rawOutput": {
+          "formatted_output": "ok\n",
+          "exit_code": 0
+        }
+      }
+    }
+  ]
+}
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "portable-failed",
+        "kind": "execute",
+        "title": "false",
+        "status": "in_progress",
+        "rawInput": {
+          "command": "false",
+          "cwd": "/test/project"
+        }
+      }
+    }
+  ]
+}
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": "portable-failed",
+        "status": "failed",
+        "rawOutput": {
+          "formatted_output": "command failed\n",
+          "exit_code": 1
+        },
+        "content": [
+          {
+            "type": "content",
+            "content": {
+              "type": "text",
+              "text": "command failed\n"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/__tests__/CodexACPAgent/data/response-item-portable-command.json
+++ b/src/__tests__/CodexACPAgent/data/response-item-portable-command.json
@@ -1,0 +1,41 @@
+[
+  {
+    "kind": "execute",
+    "rawInput": {
+      "arguments": {
+        "cmd": "npm test",
+        "workdir": "/workspace",
+        "yield_time_ms": 1000,
+      },
+      "command": "npm test",
+      "cwd": "/workspace",
+    },
+    "sessionUpdate": "tool_call",
+    "status": "in_progress",
+    "title": "npm test",
+    "toolCallId": "call-portable",
+  },
+  {
+    "content": [
+      {
+        "content": {
+          "text": "Process exited with code 0
+Output:
+Tests passed
+",
+          "type": "text",
+        },
+        "type": "content",
+      },
+    ],
+    "rawOutput": {
+      "output": "Process exited with code 0
+Output:
+Tests passed
+",
+    },
+    "sessionUpdate": "tool_call_update",
+    "status": "completed",
+    "toolCallId": "call-portable",
+  },
+]

--- a/src/__tests__/CodexACPAgent/load-session.test.ts
+++ b/src/__tests__/CodexACPAgent/load-session.test.ts
@@ -7,6 +7,7 @@ import { createCodexMockTestFixture, createTestModel } from "../acp-test-utils";
 import type { Model, Thread, ThreadGoal } from "../../app-server/v2";
 
 describe("CodexACPAgent - loadSession", () => {
+    // @spec: restored-sub-agent-tool-call-parity#replay-sub-agent-activity-with-live-structure
     it("should replay history during loadSession", async () => {
         const fixture = createCodexMockTestFixture();
         const codexAcpAgent = fixture.getCodexAcpAgent();
@@ -453,6 +454,23 @@ describe("CodexACPAgent - loadSession", () => {
                         type: "function_call_output",
                         call_id: "call-ls",
                         output: "Chunk ID: abc123\nWall time: 0.0000 seconds\nProcess exited with code 0\nOutput:\nREADME.md\nsrc\n",
+                    },
+                },
+                {
+                    type: "response_item",
+                    payload: {
+                        type: "function_call",
+                        name: "wait_agent",
+                        arguments: JSON.stringify({ timeout_ms: 30_000 }),
+                        call_id: "call-wait-agent",
+                    },
+                },
+                {
+                    type: "response_item",
+                    payload: {
+                        type: "function_call_output",
+                        call_id: "call-wait-agent",
+                        output: JSON.stringify({ timed_out: false }),
                     },
                 },
                 {

--- a/src/__tests__/CodexACPAgent/response-item-history-fallback.test.ts
+++ b/src/__tests__/CodexACPAgent/response-item-history-fallback.test.ts
@@ -31,6 +31,21 @@ describe("ResponseItemHistoryFallback", () => {
         expect(toolCallUpdateStatuses(updates)).toEqual([]);
     });
 
+    // @spec: restored-sub-agent-tool-call-parity#replay-sub-agent-activity-with-live-structure
+    it("does not replay wait_agent as a separate restored tool call", () => {
+        const updates = parseResponseItemHistoryFallback(jsonl([
+            namedFunctionCall("call-wait", "wait_agent", { timeout_ms: 30_000 }),
+            functionCallOutput("call-wait", JSON.stringify({ timed_out: false })),
+            functionCall("call-command", "pwd"),
+            functionCallOutput("call-command", "/workspace\n"),
+        ]), "content");
+
+        expect(toolCallIds(updates)).toEqual(["call-command"]);
+        expect(toolCallUpdateStatuses(updates)).toEqual([
+            { toolCallId: "call-command", status: "completed" },
+        ]);
+    });
+
     it("does not duplicate adjacent reasoning from event and response item records", () => {
         const updates = parseResponseItemHistoryFallback(jsonl([
             {
@@ -96,6 +111,16 @@ describe("ResponseItemHistoryFallback", () => {
             { toolCallId: "call-read-ok", status: "completed" },
         ]);
     });
+
+    // @spec: portable-command-output-by-default#emit-portable-command-output-without-terminal-extension
+    it("recovers command history as portable content when no terminal extension is active", () => {
+        const updates = parseResponseItemHistoryFallback(jsonl([
+            functionCall("call-portable", "npm test"),
+            functionCallOutput("call-portable", "Process exited with code 0\nOutput:\nTests passed\n"),
+        ]), "content");
+
+        expect(updates).toMatchFileSnapshot("data/response-item-portable-command.json");
+    });
 });
 
 function jsonl(records: unknown[]): string {
@@ -103,16 +128,20 @@ function jsonl(records: unknown[]): string {
 }
 
 function functionCall(callId: string, cmd: string): unknown {
+    return namedFunctionCall(callId, "exec_command", {
+        cmd,
+        workdir: "/workspace",
+        yield_time_ms: 1000,
+    });
+}
+
+function namedFunctionCall(callId: string, name: string, args: unknown): unknown {
     return {
         type: "response_item",
         payload: {
             type: "function_call",
-            name: "exec_command",
-            arguments: JSON.stringify({
-                cmd,
-                workdir: "/workspace",
-                yield_time_ms: 1000,
-            }),
+            name,
+            arguments: JSON.stringify(args),
             call_id: callId,
         },
     };

--- a/src/__tests__/CodexACPAgent/terminal-output-events.test.ts
+++ b/src/__tests__/CodexACPAgent/terminal-output-events.test.ts
@@ -193,6 +193,123 @@ describe('CodexEventHandler - terminal output events', () => {
         );
     });
 
+    // @spec: portable-command-output-by-default#emit-portable-command-output-without-terminal-extension
+    it('should report portable command output without synthetic terminals', async () => {
+        const portableSessionState = createTestSessionState({
+            ...sessionState,
+            terminalOutputMode: 'content',
+        });
+        const notifications: ServerNotification[] = [
+            {
+                method: 'item/started',
+                params: {
+                    threadId: sessionId,
+                    turnId: 'turn-1',
+                    startedAtMs: 0,
+                    item: {
+                        type: 'commandExecution',
+                        id: 'portable-ok',
+                        pluginId: null,
+                        scriptPath: null,
+                        command: 'echo ok',
+                        cwd: '/test/project',
+                        processId: null,
+                        source: 'agent',
+                        status: 'inProgress',
+                        commandActions: [],
+                        aggregatedOutput: null,
+                        exitCode: null,
+                        durationMs: null,
+                    },
+                },
+            },
+            {
+                method: 'item/commandExecution/outputDelta',
+                params: {
+                    threadId: sessionId,
+                    turnId: 'turn-1',
+                    itemId: 'portable-ok',
+                    delta: 'ok\n',
+                },
+            },
+            {
+                method: 'item/completed',
+                params: {
+                    threadId: sessionId,
+                    turnId: 'turn-1',
+                    completedAtMs: 0,
+                    item: {
+                        type: 'commandExecution',
+                        id: 'portable-ok',
+                        pluginId: null,
+                        scriptPath: null,
+                        command: 'echo ok',
+                        cwd: '/test/project',
+                        processId: 'pid-ok',
+                        source: 'agent',
+                        status: 'completed',
+                        commandActions: [],
+                        aggregatedOutput: 'ok\n',
+                        exitCode: 0,
+                        durationMs: 10,
+                    },
+                },
+            },
+            {
+                method: 'item/started',
+                params: {
+                    threadId: sessionId,
+                    turnId: 'turn-1',
+                    startedAtMs: 0,
+                    item: {
+                        type: 'commandExecution',
+                        id: 'portable-failed',
+                        pluginId: null,
+                        scriptPath: null,
+                        command: 'false',
+                        cwd: '/test/project',
+                        processId: null,
+                        source: 'agent',
+                        status: 'inProgress',
+                        commandActions: [],
+                        aggregatedOutput: null,
+                        exitCode: null,
+                        durationMs: null,
+                    },
+                },
+            },
+            {
+                method: 'item/completed',
+                params: {
+                    threadId: sessionId,
+                    turnId: 'turn-1',
+                    completedAtMs: 0,
+                    item: {
+                        type: 'commandExecution',
+                        id: 'portable-failed',
+                        pluginId: null,
+                        scriptPath: null,
+                        command: 'false',
+                        cwd: '/test/project',
+                        processId: 'pid-failed',
+                        source: 'agent',
+                        status: 'failed',
+                        commandActions: [],
+                        aggregatedOutput: 'command failed\n',
+                        exitCode: 1,
+                        durationMs: 10,
+                    },
+                },
+            },
+        ];
+
+        await setupPromptAndSendNotifications(mockFixture, sessionId, portableSessionState, notifications);
+
+        await expect(mockFixture.getAcpConnectionDump([])).toMatchFileSnapshot(
+            'data/portable-command-flow.json'
+        );
+    });
+
     it('should send status update when dynamic tool call completes', async () => {
         const dynamicToolCompletedNotification: ServerNotification = {
             method: 'item/completed',

--- a/src/__tests__/TerminalOutputMode.test.ts
+++ b/src/__tests__/TerminalOutputMode.test.ts
@@ -19,8 +19,9 @@ describe("resolveTerminalOutputMode", () => {
         })).toBe("terminal_output_delta");
     });
 
-    it("keeps legacy terminal_output_delta when capabilities are absent", () => {
-        expect(resolveTerminalOutputMode(null)).toBe("terminal_output_delta");
-        expect(resolveTerminalOutputMode({})).toBe("terminal_output_delta");
+    // @spec: portable-command-output-by-default#emit-portable-command-output-without-terminal-extension
+    it("uses portable content when terminal extensions are absent", () => {
+        expect(resolveTerminalOutputMode(null)).toBe("content");
+        expect(resolveTerminalOutputMode({})).toBe("content");
     });
 });


### PR DESCRIPTION
## Issue
A delegated agent could appear as a foreground command followed by separate `wait` tool calls, even though those waits were control-plane operations for the same unit of work. This made ACP clients display several unrelated tool cards instead of one sub-agent activity.
<img width="739" height="518" alt="image" src="https://github.com/user-attachments/assets/7f7fd872-8d3c-4c38-9094-ec0e12a3d97d" />

Internal command executions also used ACP terminal content with a Codex item ID that was never created through ACP `terminal/create`. That behavior was not portable to clients without codex-acp-specific terminal handling.

The new mapping presents semantic work to the client while retaining the underlying Codex action details in structured output.

## Sub-agent lifecycle

| Codex event | ACP representation |
| --- | --- |
| Sub-agent started or spawned | New `Agent` tool call |
| `wait` | Update the active run |
| `sendInput` | Update the active run |
| `closeAgent` | Update the active run |
| Resume after a terminal state | New run ID correlated to the same child thread |
| Child final message and turn completion | Complete the active run |
| Spawn or resume failure | Failed `Agent` tool call |
| Tools executed by the child | Remain isolated on the child thread |

Every synthesized sub-agent event includes:

```json
{
  "_meta": {
    "codex": {
      "toolName": "Agent",
      "subAgent": {
        "agentThreadId": "<child-thread-id>",
        "runId": "<activity-tool-call-id>"
      }
    }
  }
}
```

## Summary

Improve how Codex app-server command execution and sub-agent activity are represented through ACP.

This change:

- Represents each sub-agent run as one coherent parent-visible ACP tool call.
- Folds `wait`, `sendInput`, and `closeAgent` control actions into updates on that activity.
- Creates a new activity when a completed child agent is resumed.
- Completes the activity from the child thread’s final message and turn result.
- Adds `_meta.codex.toolName: "Agent"` for deterministic client classification.
- Uses portable ACP content for internal command output unless the client explicitly advertises the legacy terminal-output extension.
- Applies the same behavior to live events, session history, and response-item fallback recovery.

This fix should closes #306 