### PR TITLE
fix: Restore native provider state after overrides

### DIFF
--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -59,6 +59,8 @@ import {arePathBasenamesEqual, arePathsEqual, isAbsolutePathLike} from "./PathUt
  * the `gateway` auth method; it maps to a Codex `model_providers` entry.
  */
 export const CUSTOM_GATEWAY_PROVIDER_ID = "custom-gateway";
+export const OPENAI_PROVIDER_ID = "openai";
+const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
 
 /**
  * The url-mode variant of the ACP `elicitation/create` request params.
@@ -332,21 +334,20 @@ export class CodexAcpClient {
     }
 
     /**
-     * `providers/list`: returns the single client-configurable custom gateway
-     * provider. `current` carries only non-secret routing (never headers), and is
-     * `null` when the provider is not configured/disabled.
+     * `providers/list`: returns Codex's OpenAI slot. With no ACP override, the
+     * slot reports native OpenAI routing; headers are never exposed.
      */
     listProviders(): acp.ProviderInfo[] {
         const gatewayConfig = this.gatewayConfig;
-        const current: acp.ProviderCurrentConfig | null = gatewayConfig
+        const current: acp.ProviderCurrentConfig = gatewayConfig
             ? {
                 apiType: gatewayApiTypeFromConfig(gatewayConfig),
                 baseUrl: gatewayConfig.config.base_url,
             }
-            : null;
+            : this.getNativeProviderConfig();
         return [
             {
-                providerId: CUSTOM_GATEWAY_PROVIDER_ID,
+                providerId: OPENAI_PROVIDER_ID,
                 supported: Object.keys(SUPPORTED_GATEWAY_PROTOCOLS),
                 required: false,
                 current,
@@ -354,15 +355,31 @@ export class CodexAcpClient {
         ];
     }
 
+    private getNativeProviderConfig(): acp.ProviderCurrentConfig {
+        const configuredProviderId = this.modelProvider ??
+            (typeof this.config["model_provider"] === "string" ? this.config["model_provider"] : null);
+        const configuredProviders = this.config["model_providers"];
+        if (configuredProviderId && configuredProviders && typeof configuredProviders === "object" && !Array.isArray(configuredProviders)) {
+            const configuredProvider = (configuredProviders as Record<string, unknown>)[configuredProviderId];
+            if (configuredProvider && typeof configuredProvider === "object" && !Array.isArray(configuredProvider)) {
+                const baseUrl = (configuredProvider as Record<string, unknown>)["base_url"];
+                if (typeof baseUrl === "string" && baseUrl.length > 0) {
+                    return {apiType: "openai", baseUrl};
+                }
+            }
+        }
+        return {apiType: "openai", baseUrl: DEFAULT_OPENAI_BASE_URL};
+    }
+
     /**
      * `providers/set`: replaces the full configuration for the custom gateway
      * provider. Rejects unknown provider ids with `invalid_params`.
      */
     setProvider(request: acp.SetProviderRequest): void {
-        if (request.providerId !== CUSTOM_GATEWAY_PROVIDER_ID) {
+        if (request.providerId !== OPENAI_PROVIDER_ID) {
             throw RequestError.invalidParams(
                 {providerId: request.providerId},
-                `Unknown providerId "${request.providerId}"; only "${CUSTOM_GATEWAY_PROVIDER_ID}" is configurable`,
+                `Unknown providerId "${request.providerId}"; only "${OPENAI_PROVIDER_ID}" is configurable`,
             );
         }
         this.applyGatewayConfig({
@@ -377,7 +394,7 @@ export class CodexAcpClient {
      * unknown provider id is idempotent success (RFD behavior §7).
      */
     disableProvider(request: acp.DisableProviderRequest): void {
-        if (request.providerId === CUSTOM_GATEWAY_PROVIDER_ID) {
+        if (request.providerId === OPENAI_PROVIDER_ID) {
             this.gatewayConfig = null;
         }
     }

--- a/src/__tests__/CodexACPAgent/providers.test.ts
+++ b/src/__tests__/CodexACPAgent/providers.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, it, vi} from "vitest";
 import * as acp from "@agentclientprotocol/sdk";
 import {createCodexMockTestFixture} from "../acp-test-utils";
-import {CUSTOM_GATEWAY_PROVIDER_ID} from "../../CodexAcpClient";
+import {CodexAcpClient, CUSTOM_GATEWAY_PROVIDER_ID, OPENAI_PROVIDER_ID} from "../../CodexAcpClient";
 
 function expectInvalidParams(fn: () => unknown): void {
     let caught: unknown;
@@ -23,18 +23,43 @@ describe("Configurable LLM providers (providers/*)", () => {
         expect(result.agentCapabilities?.providers).toEqual({});
     });
 
-    it("lists the custom gateway provider as unconfigured before any set", () => {
+    it("lists native OpenAI routing before any override", () => {
         const fixture = createCodexMockTestFixture();
         const response = fixture.getCodexAcpAgent().listProviders({});
         expect(response).toEqual({
             providers: [
                 {
-                    providerId: CUSTOM_GATEWAY_PROVIDER_ID,
+                    providerId: OPENAI_PROVIDER_ID,
                     supported: ["openai"],
                     required: false,
-                    current: null,
+                    current: {
+                        apiType: "openai",
+                        baseUrl: "https://api.openai.com/v1",
+                    },
                 },
             ],
+        });
+    });
+
+    it("restores the startup-configured proxy after the last override is disabled", () => {
+        const fixture = createCodexMockTestFixture();
+        const client = new CodexAcpClient(fixture.getCodexAppServerClient(), {
+            model_provider: "company-proxy",
+            model_providers: {
+                "company-proxy": {base_url: "https://proxy.example/openai/v1"},
+            },
+        });
+        client.setProvider({
+            providerId: OPENAI_PROVIDER_ID,
+            apiType: "openai",
+            baseUrl: "https://temporary.example/openai/v1",
+        });
+
+        client.disableProvider({providerId: OPENAI_PROVIDER_ID});
+
+        expect(client.listProviders()[0]!.current).toEqual({
+            apiType: "openai",
+            baseUrl: "https://proxy.example/openai/v1",
         });
     });
 
@@ -42,7 +67,7 @@ describe("Configurable LLM providers (providers/*)", () => {
         const fixture = createCodexMockTestFixture();
         const agent = fixture.getCodexAcpAgent();
         agent.setProvider({
-            providerId: CUSTOM_GATEWAY_PROVIDER_ID,
+            providerId: OPENAI_PROVIDER_ID,
             apiType: "openai",
             baseUrl: "https://llm-gateway.corp.example.com/openai/v1",
             headers: {Authorization: "Bearer super-secret"},
@@ -61,7 +86,7 @@ describe("Configurable LLM providers (providers/*)", () => {
         const fixture = createCodexMockTestFixture();
         const agent = fixture.getCodexAcpAgent();
         expectInvalidParams(() => agent.setProvider({
-            providerId: CUSTOM_GATEWAY_PROVIDER_ID,
+            providerId: OPENAI_PROVIDER_ID,
             apiType: "anthropic",
             baseUrl: "https://example.com",
         }));
@@ -81,24 +106,27 @@ describe("Configurable LLM providers (providers/*)", () => {
         const fixture = createCodexMockTestFixture();
         const agent = fixture.getCodexAcpAgent();
         expectInvalidParams(() => agent.setProvider({
-            providerId: CUSTOM_GATEWAY_PROVIDER_ID,
+            providerId: OPENAI_PROVIDER_ID,
             apiType: "openai",
             baseUrl: "   ",
         }));
     });
 
-    it("disables the custom gateway provider and encodes it as current: null", () => {
+    it("restores native OpenAI routing after disable", () => {
         const fixture = createCodexMockTestFixture();
         const agent = fixture.getCodexAcpAgent();
         agent.setProvider({
-            providerId: CUSTOM_GATEWAY_PROVIDER_ID,
+            providerId: OPENAI_PROVIDER_ID,
             apiType: "openai",
             baseUrl: "https://example.com",
         });
         expect(agent.listProviders({}).providers[0]!.current).not.toBeNull();
 
-        agent.disableProvider({providerId: CUSTOM_GATEWAY_PROVIDER_ID});
-        expect(agent.listProviders({}).providers[0]!.current).toBeNull();
+        agent.disableProvider({providerId: OPENAI_PROVIDER_ID});
+        expect(agent.listProviders({}).providers[0]!.current).toEqual({
+            apiType: "openai",
+            baseUrl: "https://api.openai.com/v1",
+        });
     });
 
     it("treats disabling an unknown providerId as idempotent success", () => {
@@ -106,7 +134,7 @@ describe("Configurable LLM providers (providers/*)", () => {
         const agent = fixture.getCodexAcpAgent();
         expect(() => agent.disableProvider({providerId: "not-a-real-provider"})).not.toThrow();
         // The known provider remains discoverable.
-        expect(agent.listProviders({}).providers[0]!.providerId).toBe(CUSTOM_GATEWAY_PROVIDER_ID);
+        expect(agent.listProviders({}).providers[0]!.providerId).toBe(OPENAI_PROVIDER_ID);
     });
 
     it("applies the configured gateway to Codex config on session creation", async () => {
@@ -120,7 +148,7 @@ describe("Configurable LLM providers (providers/*)", () => {
             .mockRejectedValue(new Error("stop after capturing config"));
 
         agent.setProvider({
-            providerId: CUSTOM_GATEWAY_PROVIDER_ID,
+            providerId: OPENAI_PROVIDER_ID,
             apiType: "openai",
             baseUrl: "https://llm-gateway.corp.example.com/openai/v1",
             headers: {Authorization: "Bearer super-secret"},


### PR DESCRIPTION
### Summary
- expose the native `openai` provider slot before ACP overrides
- apply custom provider routing while the slot is configured
- restore startup-configured proxy routing or the native OpenAI endpoint after disable
- cover native, startup proxy, validation, and routing transitions

### Testing
- `npm test` (401 passed, 28 skipped)
- `npm run typecheck`