### PR TITLE
feat: switch providers for loaded Codex sessions

### DIFF
--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -356,6 +356,12 @@ export class CodexAcpClient {
                 baseUrl: gatewayConfig.config.base_url,
             }
             : this.getNativeProviderConfig();
+        logger.log("providers/list", {
+            providerId: OPENAI_PROVIDER_ID,
+            overrideActive: gatewayConfig !== null,
+            apiType: current.apiType,
+            baseUrl: current.baseUrl,
+        });
         return [
             {
                 providerId: OPENAI_PROVIDER_ID,
@@ -398,6 +404,12 @@ export class CodexAcpClient {
             baseUrl: request.baseUrl,
             headers: request.headers,
         });
+        logger.log("providers/set applied", {
+            providerId: request.providerId,
+            apiType: request.apiType,
+            baseUrl: request.baseUrl,
+            headerNames: Object.keys(request.headers ?? {}),
+        });
     }
 
     /**
@@ -405,9 +417,24 @@ export class CodexAcpClient {
      * unknown provider id is idempotent success (RFD behavior §7).
      */
     disableProvider(request: acp.DisableProviderRequest): void {
+        const overrideWasActive = this.gatewayConfig !== null;
         if (request.providerId === OPENAI_PROVIDER_ID) {
             this.gatewayConfig = null;
         }
+        const current = this.gatewayConfig
+            ? {
+                apiType: gatewayApiTypeFromConfig(this.gatewayConfig),
+                baseUrl: this.gatewayConfig.config.base_url,
+            }
+            : this.getNativeProviderConfig();
+        logger.log("providers/disable applied", {
+            providerId: request.providerId,
+            knownProvider: request.providerId === OPENAI_PROVIDER_ID,
+            overrideWasActive,
+            overrideActive: this.gatewayConfig !== null,
+            restoredApiType: current.apiType,
+            restoredBaseUrl: current.baseUrl,
+        });
     }
 
     async getAccount(): Promise<GetAccountResponse> {
@@ -590,6 +617,19 @@ export class CodexAcpClient {
         mcpServers: Array<McpServer>
     ): Promise<JsonObject> {
         const sessionRoots = [projectPath, ...additionalDirectories];
+        const activeProvider = this.gatewayConfig
+            ? {
+                apiType: gatewayApiTypeFromConfig(this.gatewayConfig),
+                baseUrl: this.gatewayConfig.config.base_url,
+            }
+            : this.getNativeProviderConfig();
+        logger.log("Creating session config", {
+            projectPath,
+            overrideActive: this.gatewayConfig !== null,
+            modelProvider: this.getModelProvider(),
+            apiType: activeProvider.apiType,
+            baseUrl: activeProvider.baseUrl,
+        });
         const mergedConfig = {
             ...mergeGatewayConfig(this.config, this.gatewayConfig),
             projects: Object.fromEntries(sessionRoots.map(root => [root, {

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -7,12 +7,14 @@ import {type CodexAuthRequest, getCodexAuthMethods, isCodexAuthRequest} from "./
 import {clientSupportsUrlElicitation} from "./ElicitationCapabilities";
 import {
     CodexAcpClient,
+    type JsonObject,
     OPENAI_PROVIDER_ID,
     type SessionMetadata,
     type SessionMetadataWithThread,
     type UrlElicitationRequester
 } from "./CodexAcpClient";
-import type {McpStartupResult} from "./CodexAppServerClient";
+import {CodexAppServerClient, type McpStartupResult} from "./CodexAppServerClient";
+import {type CodexConnection, startCodexConnection} from "./CodexJsonRpcConnection";
 import {type AcpClientConnection, ACPSessionConnection, type UpdateSessionEvent} from "./ACPSessionConnection";
 import type {InputModality, ReasoningEffort} from "./app-server";
 import type {Account, Model, ReasoningEffortOption, Thread, ThreadGoal, ThreadItem, UserInput} from "./app-server/v2";
@@ -93,6 +95,7 @@ import {
 } from "./ContentChunks";
 import {sameThreadGoalSnapshot, type ThreadGoalSnapshot, toThreadGoalSnapshot,} from "./ThreadGoalSnapshot";
 import {randomUUID} from "node:crypto";
+import {once} from "node:events";
 import {
     AIR_AGENT_FILE_CHANGE_REPORT_KEY,
     AIR_EXTENSION_CAPABILITIES_KEY,
@@ -215,6 +218,15 @@ interface ActivePrompt {
     complete: () => void;
 }
 
+export interface CodexProcessState {
+    connection: CodexConnection;
+    codexPath: string | undefined;
+    config: JsonObject | undefined;
+    modelProvider: string | undefined;
+    stderr: string;
+    stderrProcess?: CodexConnection["process"];
+}
+
 export class CodexAcpServer {
     private static readonly MODEL_NAME_TOKEN_OVERRIDES: Record<string, string> = {
         gpt: "GPT",
@@ -243,7 +255,7 @@ export class CodexAcpServer {
     private readonly sessionGenerations: Map<string, number>;
     private readonly sessionOpenGenerations: Map<string, number>;
     private readonly goalControlGenerations: Map<string, number>;
-    private readonly restartCodexClient: (() => Promise<CodexAcpClient>) | null;
+    private readonly codexProcessState: CodexProcessState | null;
     private initializeRequest: acp.InitializeRequest | null = null;
     private providerUpdate: Promise<void> | null = null;
 
@@ -253,7 +265,7 @@ export class CodexAcpServer {
         defaultAuthRequest?: CodexAuthRequest,
         getExitCode?: () => number | null,
         getRecentStderr?: () => string,
-        restartCodexClient?: () => Promise<CodexAcpClient>,
+        codexProcessState?: CodexProcessState,
     ) {
         this.sessions = new Map();
         this.pendingMcpStartupSessions = new Map();
@@ -267,9 +279,10 @@ export class CodexAcpServer {
         this.connection = connection;
         this.codexAcpClient = codexAcpClient;
         this.defaultAuthRequest = defaultAuthRequest ?? null;
-        this.getExitCode = getExitCode ?? (() => null);
-        this.getRecentStderr = getRecentStderr ?? (() => "");
-        this.restartCodexClient = restartCodexClient ?? null;
+        this.codexProcessState = codexProcessState ?? null;
+        this.captureStderr();
+        this.getExitCode = getExitCode ?? (() => this.codexProcessState?.connection.process.exitCode ?? null);
+        this.getRecentStderr = getRecentStderr ?? (() => this.codexProcessState?.stderr ?? "");
         this.sessionFailureEpoch = randomUUID();
         this.clientInfo = null;
         this.clientCapabilities = null;
@@ -877,7 +890,7 @@ export class CodexAcpServer {
     private async enqueueProviderUpdate(apply: (client: CodexAcpClient) => void): Promise<void> {
         const previous = this.providerUpdate?.catch(() => undefined) ?? Promise.resolve();
         const update = previous.then(async () => {
-            if (this.sessions.size === 0 || this.restartCodexClient === null) {
+            if (this.sessions.size === 0) {
                 return;
             }
 
@@ -925,6 +938,47 @@ export class CodexAcpServer {
                 this.providerUpdate = null;
             }
         }
+    }
+
+    private captureStderr(): void {
+        const state = this.codexProcessState;
+        if (state === null || state.stderrProcess === state.connection.process) {
+            return;
+        }
+        state.stderrProcess = state.connection.process;
+        state.connection.process.stderr.addListener("data", (data: Buffer) => {
+            state.stderr = (state.stderr + data.toString()).slice(-2 * 1024);
+        });
+    }
+
+    private async restartCodexClient(): Promise<CodexAcpClient> {
+        const state = this.codexProcessState;
+        if (state === null) {
+            throw new Error("Codex process state is unavailable");
+        }
+
+        const previous = state.connection;
+        const exited = previous.process.exitCode === null
+            ? once(previous.process, "exit")
+            : Promise.resolve();
+        previous.process.stdin.end();
+        const forceKill = setTimeout(() => {
+            if (previous.process.exitCode === null) {
+                logger.log("Codex still running 2s after provider restart; terminating process");
+                previous.process.kill();
+            }
+        }, 2000);
+        await exited;
+        clearTimeout(forceKill);
+
+        state.stderr = "";
+        state.connection = startCodexConnection(state.codexPath);
+        this.captureStderr();
+        return new CodexAcpClient(
+            new CodexAppServerClient(state.connection.connection),
+            state.config,
+            state.modelProvider,
+        );
     }
 
     private async waitForProviderUpdate(): Promise<void> {

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -681,7 +681,9 @@ export class CodexAcpServer {
     }
 
     async loadSession(params: acp.LoadSessionRequest): Promise<LegacyLoadSessionResponse> {
-        await this.waitForProviderUpdate();
+        if (this.providerUpdate !== null) {
+            await this.providerUpdate;
+        }
         logger.log("Loading session...", {sessionId: params.sessionId});
         const {
             sessionId,
@@ -705,7 +707,9 @@ export class CodexAcpServer {
     }
 
     async resumeSession(params: acp.ResumeSessionRequest): Promise<LegacyResumeSessionResponse> {
-        await this.waitForProviderUpdate();
+        if (this.providerUpdate !== null) {
+            await this.providerUpdate;
+        }
         logger.log("Resuming session...", {sessionId: params.sessionId});
         const [sessionId, modelState, modeState] = await this.getOrCreateSession(params);
 
@@ -814,7 +818,9 @@ export class CodexAcpServer {
     async newSession(
         params: acp.NewSessionRequest,
     ): Promise<LegacyNewSessionResponse> {
-        await this.waitForProviderUpdate();
+        if (this.providerUpdate !== null) {
+            await this.providerUpdate;
+        }
         logger.log("Starting new session...");
         const [sessionId, modelState, modeState] = await this.getOrCreateSession(params);
 
@@ -979,13 +985,6 @@ export class CodexAcpServer {
             state.config,
             state.modelProvider,
         );
-    }
-
-    private async waitForProviderUpdate(): Promise<void> {
-        const update = this.providerUpdate;
-        if (update !== null) {
-            await update;
-        }
     }
 
     private async refreshSessionsAuthState(authProvider: string | null): Promise<void> {
@@ -2228,7 +2227,9 @@ export class CodexAcpServer {
         signal?: AbortSignal,
         onTurnStarted?: () => void,
     ): Promise<acp.PromptResponse> {
-        await this.waitForProviderUpdate();
+        if (this.providerUpdate !== null) {
+            await this.providerUpdate;
+        }
         logger.log("Prompt received", {
             sessionId: params.sessionId,
             prompt: params.prompt,

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -7,6 +7,7 @@ import {type CodexAuthRequest, getCodexAuthMethods, isCodexAuthRequest} from "./
 import {clientSupportsUrlElicitation} from "./ElicitationCapabilities";
 import {
     CodexAcpClient,
+    OPENAI_PROVIDER_ID,
     type SessionMetadata,
     type SessionMetadataWithThread,
     type UrlElicitationRequester
@@ -130,6 +131,7 @@ export interface SessionState {
     authProvider: string | null;
     cwd: string;
     additionalDirectories: string[];
+    mcpServers?: Array<acp.McpServer>;
     fastModeEnabled: boolean;
     currentModelSupportsFast: boolean;
     sessionMcpServers?: Array<string>;
@@ -213,6 +215,8 @@ interface ActivePrompt {
     complete: () => void;
 }
 
+export type RestartCodexClient = () => Promise<CodexAcpClient>;
+
 export class CodexAcpServer {
     private static readonly MODEL_NAME_TOKEN_OVERRIDES: Record<string, string> = {
         gpt: "GPT",
@@ -220,13 +224,13 @@ export class CodexAcpServer {
         codex: "Codex",
     };
 
-    private readonly codexAcpClient: CodexAcpClient;
+    private codexAcpClient: CodexAcpClient;
     private readonly connection: AcpClientConnection;
     private readonly defaultAuthRequest: CodexAuthRequest | null;
     private readonly getExitCode: () => number | null;
     private readonly getRecentStderr: () => string;
     private readonly sessionFailureEpoch: string;
-    private readonly availableCommands: CodexCommands;
+    private availableCommands: CodexCommands;
     private clientInfo: acp.Implementation | null;
     private clientCapabilities: acp.ClientCapabilities | null;
     private terminalOutputMode: TerminalOutputMode;
@@ -241,6 +245,9 @@ export class CodexAcpServer {
     private readonly sessionGenerations: Map<string, number>;
     private readonly sessionOpenGenerations: Map<string, number>;
     private readonly goalControlGenerations: Map<string, number>;
+    private readonly restartCodexClient: RestartCodexClient | null;
+    private initializeRequest: acp.InitializeRequest | null = null;
+    private providerUpdate: Promise<void> | null = null;
 
     constructor(
         connection: AcpClientConnection,
@@ -248,6 +255,7 @@ export class CodexAcpServer {
         defaultAuthRequest?: CodexAuthRequest,
         getExitCode?: () => number | null,
         getRecentStderr?: () => string,
+        restartCodexClient?: RestartCodexClient,
     ) {
         this.sessions = new Map();
         this.pendingMcpStartupSessions = new Map();
@@ -263,14 +271,19 @@ export class CodexAcpServer {
         this.defaultAuthRequest = defaultAuthRequest ?? null;
         this.getExitCode = getExitCode ?? (() => null);
         this.getRecentStderr = getRecentStderr ?? (() => "");
+        this.restartCodexClient = restartCodexClient ?? null;
         this.sessionFailureEpoch = randomUUID();
         this.clientInfo = null;
         this.clientCapabilities = null;
         this.terminalOutputMode = "terminal_output_delta";
         this.booleanConfigOptionsSupported = false;
-        this.availableCommands = new CodexCommands(
-            connection,
-            codexAcpClient,
+        this.availableCommands = this.createAvailableCommands(codexAcpClient);
+    }
+
+    private createAvailableCommands(client: CodexAcpClient): CodexCommands {
+        return new CodexCommands(
+            this.connection,
+            client,
             (operation) => this.runWithProcessCheck(operation),
             () => this.refreshSessionsAuthState(null)
         );
@@ -282,6 +295,7 @@ export class CodexAcpServer {
         logger.log("Initialize request received");
         this.clientInfo = _params.clientInfo ?? null;
         this.clientCapabilities = _params.clientCapabilities ?? null;
+        this.initializeRequest = _params;
         this.terminalOutputMode = resolveTerminalOutputMode(_params.clientCapabilities);
         this.booleanConfigOptionsSupported = clientSupportsBooleanConfigOptions(_params.clientCapabilities);
         await this.runWithProcessCheck(() => this.codexAcpClient.initialize(_params));
@@ -593,6 +607,7 @@ export class CodexAcpServer {
             authProvider: authProvider,
             cwd: request.cwd,
             additionalDirectories: sessionMetadata.additionalDirectories,
+            mcpServers: requestedMcpServers,
             fastModeEnabled: sessionMetadata.currentServiceTier === "fast",
             currentModelSupportsFast: currentModelSupportsFast,
             sessionMcpServers: sessionMcpServers,
@@ -655,6 +670,7 @@ export class CodexAcpServer {
     }
 
     async loadSession(params: acp.LoadSessionRequest): Promise<LegacyLoadSessionResponse> {
+        await this.waitForProviderUpdate();
         logger.log("Loading session...", {sessionId: params.sessionId});
         const {
             sessionId,
@@ -678,6 +694,7 @@ export class CodexAcpServer {
     }
 
     async resumeSession(params: acp.ResumeSessionRequest): Promise<LegacyResumeSessionResponse> {
+        await this.waitForProviderUpdate();
         logger.log("Resuming session...", {sessionId: params.sessionId});
         const [sessionId, modelState, modeState] = await this.getOrCreateSession(params);
 
@@ -786,6 +803,7 @@ export class CodexAcpServer {
     async newSession(
         params: acp.NewSessionRequest,
     ): Promise<LegacyNewSessionResponse> {
+        await this.waitForProviderUpdate();
         logger.log("Starting new session...");
         const [sessionId, modelState, modeState] = await this.getOrCreateSession(params);
 
@@ -843,14 +861,79 @@ export class CodexAcpServer {
         return { providers: this.codexAcpClient.listProviders() };
     }
 
-    setProvider(params: acp.SetProviderRequest): acp.SetProviderResponse {
+    async setProvider(params: acp.SetProviderRequest): Promise<acp.SetProviderResponse> {
         this.codexAcpClient.setProvider(params);
+        await this.enqueueProviderUpdate((client) => client.setProvider(params));
         return { };
     }
 
-    disableProvider(params: acp.DisableProviderRequest): acp.DisableProviderResponse {
+    async disableProvider(params: acp.DisableProviderRequest): Promise<acp.DisableProviderResponse> {
         this.codexAcpClient.disableProvider(params);
+        if (params.providerId !== OPENAI_PROVIDER_ID) {
+            return { };
+        }
+        await this.enqueueProviderUpdate((client) => client.disableProvider(params));
         return { };
+    }
+
+    private async enqueueProviderUpdate(apply: (client: CodexAcpClient) => void): Promise<void> {
+        const previous = this.providerUpdate?.catch(() => undefined) ?? Promise.resolve();
+        const update = previous.then(async () => {
+            if (this.sessions.size === 0 || this.restartCodexClient === null) {
+                return;
+            }
+
+            const activePrompts = [...this.activePrompts.values()].map(prompt => prompt.completion);
+            if (activePrompts.length > 0) {
+                logger.log("Waiting for active prompts before provider restart", {count: activePrompts.length});
+                await Promise.all(activePrompts);
+            }
+
+            logger.log("Restarting Codex app-server for provider update", {sessionCount: this.sessions.size});
+            const replacement = await this.restartCodexClient();
+            apply(replacement);
+            if (this.initializeRequest === null) {
+                throw new Error("Cannot restart Codex app-server before ACP initialization");
+            }
+            await replacement.initialize(this.initializeRequest);
+            this.codexAcpClient = replacement;
+            this.availableCommands = this.createAvailableCommands(replacement);
+
+            const resumeErrors: unknown[] = [];
+            for (const session of this.sessions.values()) {
+                try {
+                    await replacement.resumeSession({
+                        sessionId: session.sessionId,
+                        cwd: session.cwd,
+                        additionalDirectories: session.additionalDirectories,
+                        mcpServers: session.mcpServers ?? [],
+                    });
+                    session.authProvider = replacement.getModelProvider();
+                    logger.log("Resumed session after provider restart", {sessionId: session.sessionId});
+                } catch (error) {
+                    resumeErrors.push(error);
+                    logger.error(`Failed to resume session ${session.sessionId} after provider restart`, error);
+                }
+            }
+            if (resumeErrors.length > 0) {
+                throw new AggregateError(resumeErrors, `Failed to resume ${resumeErrors.length} session(s) after provider restart`);
+            }
+        });
+        this.providerUpdate = update;
+        try {
+            await update;
+        } finally {
+            if (this.providerUpdate === update) {
+                this.providerUpdate = null;
+            }
+        }
+    }
+
+    private async waitForProviderUpdate(): Promise<void> {
+        const update = this.providerUpdate;
+        if (update !== null) {
+            await update;
+        }
     }
 
     private async refreshSessionsAuthState(authProvider: string | null): Promise<void> {
@@ -1482,6 +1565,7 @@ export class CodexAcpServer {
             authProvider: authProvider,
             cwd: request.cwd,
             additionalDirectories: sessionMetadata.additionalDirectories,
+            mcpServers: requestedMcpServers,
             fastModeEnabled: sessionMetadata.currentServiceTier === "fast",
             currentModelSupportsFast: currentModelSupportsFast,
             sessionMcpServers: sessionMcpServers,
@@ -2092,6 +2176,7 @@ export class CodexAcpServer {
         signal?: AbortSignal,
         onTurnStarted?: () => void,
     ): Promise<acp.PromptResponse> {
+        await this.waitForProviderUpdate();
         logger.log("Prompt received", {
             sessionId: params.sessionId,
             prompt: params.prompt,

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -215,8 +215,6 @@ interface ActivePrompt {
     complete: () => void;
 }
 
-export type RestartCodexClient = () => Promise<CodexAcpClient>;
-
 export class CodexAcpServer {
     private static readonly MODEL_NAME_TOKEN_OVERRIDES: Record<string, string> = {
         gpt: "GPT",
@@ -245,7 +243,7 @@ export class CodexAcpServer {
     private readonly sessionGenerations: Map<string, number>;
     private readonly sessionOpenGenerations: Map<string, number>;
     private readonly goalControlGenerations: Map<string, number>;
-    private readonly restartCodexClient: RestartCodexClient | null;
+    private readonly restartCodexClient: (() => Promise<CodexAcpClient>) | null;
     private initializeRequest: acp.InitializeRequest | null = null;
     private providerUpdate: Promise<void> | null = null;
 
@@ -255,7 +253,7 @@ export class CodexAcpServer {
         defaultAuthRequest?: CodexAuthRequest,
         getExitCode?: () => number | null,
         getRecentStderr?: () => string,
-        restartCodexClient?: RestartCodexClient,
+        restartCodexClient?: () => Promise<CodexAcpClient>,
     ) {
         this.sessions = new Map();
         this.pendingMcpStartupSessions = new Map();

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -18,6 +18,7 @@ class Logger {
         try {
             fs.mkdirSync(logDir, {recursive: true});
             this.logFilePath = path.join(logDir, "app-server.log");
+            this.log("Logger initialized", {logFilePath: this.logFilePath});
         } catch (ex) {
             console.error("Failed to initialize logger directory", ex);
             this.logFilePath = null;
@@ -32,7 +33,7 @@ class Logger {
         if (!this.logFilePath) return;
         try {
             const timestamp = this.formatTimestamp(new Date());
-            const serializedContext = context ? ` ${JSON.stringify(context)}` : "";
+            const serializedContext = ` ${JSON.stringify({pid: process.pid, ...context})}`;
 
             if (!message.startsWith('[')) message = `[SYS] ${message}`;
             const line = `${timestamp} ${message}${serializedContext}`;

--- a/src/__tests__/CodexACPAgent/providers.test.ts
+++ b/src/__tests__/CodexACPAgent/providers.test.ts
@@ -1,15 +1,10 @@
 import {describe, expect, it, vi} from "vitest";
 import * as acp from "@agentclientprotocol/sdk";
-import {createCodexMockTestFixture} from "../acp-test-utils";
+import {createCodexMockTestFixture, createTestSessionState} from "../acp-test-utils";
 import {CodexAcpClient, CUSTOM_GATEWAY_PROVIDER_ID, OPENAI_PROVIDER_ID} from "../../CodexAcpClient";
 
-function expectInvalidParams(fn: () => unknown): void {
-    let caught: unknown;
-    try {
-        fn();
-    } catch (err) {
-        caught = err;
-    }
+async function expectInvalidParams(fn: () => unknown): Promise<void> {
+    const caught = await Promise.resolve().then(fn).catch((err: unknown) => err);
     expect(caught).toBeInstanceOf(acp.RequestError);
     expect((caught as acp.RequestError).code).toBe(-32602);
 }
@@ -82,30 +77,30 @@ describe("Configurable LLM providers (providers/*)", () => {
         expect(JSON.stringify(provider)).not.toContain("super-secret");
     });
 
-    it("rejects an unsupported apiType with invalid_params", () => {
+    it("rejects an unsupported apiType with invalid_params", async () => {
         const fixture = createCodexMockTestFixture();
         const agent = fixture.getCodexAcpAgent();
-        expectInvalidParams(() => agent.setProvider({
+        await expectInvalidParams(() => agent.setProvider({
             providerId: OPENAI_PROVIDER_ID,
             apiType: "anthropic",
             baseUrl: "https://example.com",
         }));
     });
 
-    it("rejects an unknown providerId with invalid_params", () => {
+    it("rejects an unknown providerId with invalid_params", async () => {
         const fixture = createCodexMockTestFixture();
         const agent = fixture.getCodexAcpAgent();
-        expectInvalidParams(() => agent.setProvider({
+        await expectInvalidParams(() => agent.setProvider({
             providerId: "does-not-exist",
             apiType: "openai",
             baseUrl: "https://example.com",
         }));
     });
 
-    it("rejects a malformed baseUrl with invalid_params", () => {
+    it("rejects a malformed baseUrl with invalid_params", async () => {
         const fixture = createCodexMockTestFixture();
         const agent = fixture.getCodexAcpAgent();
-        expectInvalidParams(() => agent.setProvider({
+        await expectInvalidParams(() => agent.setProvider({
             providerId: OPENAI_PROVIDER_ID,
             apiType: "openai",
             baseUrl: "   ",
@@ -171,6 +166,132 @@ describe("Configurable LLM providers (providers/*)", () => {
                 }),
             }),
         }));
+    });
+
+    it("keeps native session creation unchanged when the providers API is unused", async () => {
+        const restart = vi.fn();
+        const fixture = createCodexMockTestFixture(restart);
+        const agent = fixture.getCodexAcpAgent();
+        const codexAcpClient = fixture.getCodexAcpClient();
+        const codexAppServerClient = fixture.getCodexAppServerClient();
+
+        vi.spyOn(codexAcpClient, "authRequired").mockResolvedValue(false);
+        const threadStartSpy = vi.spyOn(codexAppServerClient, "threadStart")
+            .mockRejectedValue(new Error("stop after capturing config"));
+
+        await expect(agent.newSession({cwd: "/workspace", mcpServers: []})).rejects.toThrow();
+
+        expect(restart).not.toHaveBeenCalled();
+        expect(threadStartSpy).toHaveBeenCalledOnce();
+        expect(threadStartSpy).toHaveBeenCalledWith(expect.objectContaining({
+            modelProvider: null,
+            config: expect.not.objectContaining({
+                model_providers: expect.objectContaining({
+                    [CUSTOM_GATEWAY_PROVIDER_ID]: expect.anything(),
+                }),
+            }),
+        }));
+    });
+
+    it("restarts app-server and resumes all loaded sessions through the full provider lifecycle", async () => {
+        const firstGatewayReplacement = createCodexMockTestFixture().getCodexAcpClient();
+        const secondGatewayReplacement = createCodexMockTestFixture().getCodexAcpClient();
+        const nativeReplacement = createCodexMockTestFixture().getCodexAcpClient();
+        vi.spyOn(firstGatewayReplacement, "initialize").mockResolvedValue();
+        const firstGatewayResume = vi.spyOn(firstGatewayReplacement, "resumeSession").mockResolvedValue({} as never);
+        vi.spyOn(secondGatewayReplacement, "initialize").mockResolvedValue();
+        const secondGatewayResume = vi.spyOn(secondGatewayReplacement, "resumeSession").mockResolvedValue({} as never);
+        vi.spyOn(nativeReplacement, "initialize").mockResolvedValue();
+        const nativeResume = vi.spyOn(nativeReplacement, "resumeSession").mockResolvedValue({} as never);
+        const restart = vi.fn()
+            .mockResolvedValueOnce(firstGatewayReplacement)
+            .mockResolvedValueOnce(secondGatewayReplacement)
+            .mockResolvedValueOnce(nativeReplacement);
+        const fixture = createCodexMockTestFixture(restart);
+        const agent = fixture.getCodexAcpAgent();
+        await agent.initialize({protocolVersion: acp.PROTOCOL_VERSION});
+        const sessions = (agent as unknown as {sessions: Map<string, ReturnType<typeof createTestSessionState>>}).sessions;
+        sessions.set("thread-1", createTestSessionState({sessionId: "thread-1", cwd: "/one"}));
+        sessions.set("thread-2", createTestSessionState({sessionId: "thread-2", cwd: "/two"}));
+
+        await agent.setProvider({
+            providerId: OPENAI_PROVIDER_ID,
+            apiType: "openai",
+            baseUrl: "https://gateway.example/v1",
+            headers: {Authorization: "Bearer secret"},
+        });
+
+        expect(restart).toHaveBeenCalledTimes(1);
+        expect(firstGatewayReplacement.getModelProvider()).toBe(CUSTOM_GATEWAY_PROVIDER_ID);
+        expect(firstGatewayResume).toHaveBeenCalledTimes(2);
+        expect(firstGatewayResume).toHaveBeenCalledWith(expect.objectContaining({sessionId: "thread-1", cwd: "/one"}));
+        expect(firstGatewayResume).toHaveBeenCalledWith(expect.objectContaining({sessionId: "thread-2", cwd: "/two"}));
+
+        await agent.setProvider({
+            providerId: OPENAI_PROVIDER_ID,
+            apiType: "openai",
+            baseUrl: "https://second-gateway.example/v1",
+            headers: {Authorization: "Bearer replacement"},
+        });
+
+        expect(restart).toHaveBeenCalledTimes(2);
+        expect(secondGatewayReplacement.getModelProvider()).toBe(CUSTOM_GATEWAY_PROVIDER_ID);
+        expect(secondGatewayResume).toHaveBeenCalledTimes(2);
+        expect(agent.listProviders({}).providers[0]!.current).toEqual({
+            apiType: "openai",
+            baseUrl: "https://second-gateway.example/v1",
+        });
+
+        await agent.disableProvider({providerId: OPENAI_PROVIDER_ID});
+
+        expect(restart).toHaveBeenCalledTimes(3);
+        expect(nativeReplacement.getModelProvider()).toBeNull();
+        expect(nativeResume).toHaveBeenCalledTimes(2);
+        expect(agent.listProviders({}).providers[0]!.current).toEqual({
+            apiType: "openai",
+            baseUrl: "https://api.openai.com/v1",
+        });
+    });
+
+    it("attempts every session resume and allows a later provider update after one fails", async () => {
+        const failedReplacement = createCodexMockTestFixture().getCodexAcpClient();
+        const recoveredReplacement = createCodexMockTestFixture().getCodexAcpClient();
+        vi.spyOn(failedReplacement, "initialize").mockResolvedValue();
+        const failedResume = vi.spyOn(failedReplacement, "resumeSession")
+            .mockRejectedValueOnce(new Error("thread-1 failed"))
+            .mockResolvedValue({} as never);
+        vi.spyOn(recoveredReplacement, "initialize").mockResolvedValue();
+        const recoveredResume = vi.spyOn(recoveredReplacement, "resumeSession").mockResolvedValue({} as never);
+        const restart = vi.fn()
+            .mockResolvedValueOnce(failedReplacement)
+            .mockResolvedValueOnce(recoveredReplacement);
+        const fixture = createCodexMockTestFixture(restart);
+        const agent = fixture.getCodexAcpAgent();
+        await agent.initialize({protocolVersion: acp.PROTOCOL_VERSION});
+        const sessions = (agent as unknown as {sessions: Map<string, ReturnType<typeof createTestSessionState>>}).sessions;
+        sessions.set("thread-1", createTestSessionState({sessionId: "thread-1", cwd: "/one"}));
+        sessions.set("thread-2", createTestSessionState({sessionId: "thread-2", cwd: "/two"}));
+
+        await expect(agent.setProvider({
+            providerId: OPENAI_PROVIDER_ID,
+            apiType: "openai",
+            baseUrl: "https://broken-gateway.example/v1",
+        })).rejects.toThrow("Failed to resume 1 session(s)");
+
+        expect(failedResume).toHaveBeenCalledTimes(2);
+
+        await expect(agent.setProvider({
+            providerId: OPENAI_PROVIDER_ID,
+            apiType: "openai",
+            baseUrl: "https://recovered-gateway.example/v1",
+        })).resolves.toEqual({});
+
+        expect(restart).toHaveBeenCalledTimes(2);
+        expect(recoveredResume).toHaveBeenCalledTimes(2);
+        expect(agent.listProviders({}).providers[0]!.current).toEqual({
+            apiType: "openai",
+            baseUrl: "https://recovered-gateway.example/v1",
+        });
     });
 
     it("shares state with the legacy gateway auth method", async () => {

--- a/src/__tests__/acp-test-utils.ts
+++ b/src/__tests__/acp-test-utils.ts
@@ -85,7 +85,6 @@ export interface ConnectionConfig {
     connection: MessageConnection;
     getExitCode: () => number | null;
     acpConnection?: AcpConnectionConfig;
-    restartCodexClient?: (() => Promise<CodexAcpClient>) | undefined;
 }
 
 export function createBaseTestFixture(config: ConnectionConfig): TestFixture {
@@ -105,7 +104,6 @@ export function createBaseTestFixture(config: ConnectionConfig): TestFixture {
         undefined,
         config.getExitCode,
         undefined,
-        config.restartCodexClient,
     );
 
     const transportEvents: CodexConnectionEvent[] = [];
@@ -313,13 +311,16 @@ export function createCodexMockTestFixture(
     const baseFixture = createBaseTestFixture({
         connection: mockCodexConnection,
         getExitCode: () => null,
-        restartCodexClient,
         acpConnection: {
             connection: acpConnection,
             events: acpConnectionEvents,
             eventHandlers: acpEventHandlers,
         }
     });
+    if (restartCodexClient) {
+        vi.spyOn(baseFixture.getCodexAcpAgent() as any, "restartCodexClient")
+            .mockImplementation(restartCodexClient);
+    }
 
     return {
         ...baseFixture,

--- a/src/__tests__/acp-test-utils.ts
+++ b/src/__tests__/acp-test-utils.ts
@@ -85,6 +85,7 @@ export interface ConnectionConfig {
     connection: MessageConnection;
     getExitCode: () => number | null;
     acpConnection?: AcpConnectionConfig;
+    restartCodexClient?: (() => Promise<CodexAcpClient>) | undefined;
 }
 
 export function createBaseTestFixture(config: ConnectionConfig): TestFixture {
@@ -98,7 +99,14 @@ export function createBaseTestFixture(config: ConnectionConfig): TestFixture {
 
     const codexAppServerClient = new CodexAppServerClient(config.connection);
     const codexAcpClient = new CodexAcpClient(codexAppServerClient);
-    const codexAcpAgent = new CodexAcpServer(acpConnection, codexAcpClient, undefined, config.getExitCode);
+    const codexAcpAgent = new CodexAcpServer(
+        acpConnection,
+        codexAcpClient,
+        undefined,
+        config.getExitCode,
+        undefined,
+        config.restartCodexClient,
+    );
 
     const transportEvents: CodexConnectionEvent[] = [];
     const codexEventHandlers: ((event: CodexConnectionEvent) => void)[] = [];
@@ -255,7 +263,9 @@ export interface CodexMockTestFixture extends TestFixture {
  * Provides `sendServerRequest()` to simulate server-initiated requests (e.g., approval requests).
  * Provides `setPermissionResponse()` to control ACP permission dialog responses.
  */
-export function createCodexMockTestFixture(): CodexMockTestFixture {
+export function createCodexMockTestFixture(
+    restartCodexClient?: () => Promise<CodexAcpClient>,
+): CodexMockTestFixture {
     let unhandledNotificationHandler: ((notification: any) => void) | null = null;
     const requestHandlers = new Map<string, (params: unknown) => Promise<unknown>>();
 
@@ -303,6 +313,7 @@ export function createCodexMockTestFixture(): CodexMockTestFixture {
     const baseFixture = createBaseTestFixture({
         connection: mockCodexConnection,
         getExitCode: () => null,
+        restartCodexClient,
         acpConnection: {
             connection: acpConnection,
             events: acpConnectionEvents,

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {
     GOAL_CONTROL_METHOD, LEGACY_SET_SESSION_MODEL_METHOD,
     SESSION_STEERING_METHOD,
 } from "./AcpExtensions";
+import {once} from "node:events";
 
 const emptyExtensionParamsParser = z.preprocess(
     (params) => params ?? {},
@@ -88,13 +89,16 @@ function startAcpServer() {
         defaultAuthRequest: defaultAuthRequest ?? null,
     });
 
-    const codexConnection = startCodexConnection(codexPath);
+    let codexConnection = startCodexConnection(codexPath);
 
     const maxStderrTailChars = 2 * 1024;
     let stderr = "";
-    codexConnection.process.stderr.addListener("data", (data: Buffer) => {
-        stderr = (stderr + data.toString()).slice(-maxStderrTailChars);
-    });
+    const captureStderr = () => {
+        codexConnection.process.stderr.addListener("data", (data: Buffer) => {
+            stderr = (stderr + data.toString()).slice(-maxStderrTailChars);
+        });
+    };
+    captureStderr();
 
     process.stdin.on("close", () => {
         codexConnection.process.stdin.end();
@@ -109,10 +113,38 @@ function startAcpServer() {
 
     const acpJsonStream = createJsonStream(process.stdin, process.stdout);
 
+    async function restartCodexClient(): Promise<CodexAcpClient> {
+        const previous = codexConnection;
+        const exited = previous.process.exitCode === null
+            ? once(previous.process, "exit")
+            : Promise.resolve();
+        previous.process.stdin.end();
+        const forceKill = setTimeout(() => {
+            if (previous.process.exitCode === null) {
+                logger.log("Codex still running 2s after provider restart; terminating process");
+                previous.process.kill();
+            }
+        }, 2000);
+        await exited;
+        clearTimeout(forceKill);
+
+        stderr = "";
+        codexConnection = startCodexConnection(codexPath);
+        captureStderr();
+        return new CodexAcpClient(new CodexAppServerClient(codexConnection.connection), config, modelProvider);
+    }
+
     function createAgent(connection: acp.AgentContext): CodexAcpServer {
         const appServerClient = new CodexAppServerClient(codexConnection.connection);
         const codexClient = new CodexAcpClient(appServerClient, config, modelProvider);
-        return new CodexAcpServer(connection, codexClient, defaultAuthRequest, () => codexConnection.process.exitCode, () => stderr);
+        return new CodexAcpServer(
+            connection,
+            codexClient,
+            defaultAuthRequest,
+            () => codexConnection.process.exitCode,
+            () => stderr,
+            restartCodexClient,
+        );
     }
 
     let codexAcpServer: CodexAcpServer | null = null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
 import * as acp from "@agentclientprotocol/sdk";
 import {z} from "zod";
 import {startCodexConnection} from "./CodexJsonRpcConnection";
-import {CodexAcpServer} from "./CodexAcpServer";
+import {CodexAcpServer, type CodexProcessState} from "./CodexAcpServer";
 import {createJsonStream} from "./StdUtils";
 import {isCodexAuthRequest} from "./CodexAuthMethod";
 import {CodexAcpClient} from "./CodexAcpClient";
@@ -16,7 +16,6 @@ import {
     GOAL_CONTROL_METHOD, LEGACY_SET_SESSION_MODEL_METHOD,
     SESSION_STEERING_METHOD,
 } from "./AcpExtensions";
-import {once} from "node:events";
 
 const emptyExtensionParamsParser = z.preprocess(
     (params) => params ?? {},
@@ -89,61 +88,37 @@ function startAcpServer() {
         defaultAuthRequest: defaultAuthRequest ?? null,
     });
 
-    let codexConnection = startCodexConnection(codexPath);
-
-    const maxStderrTailChars = 2 * 1024;
-    let stderr = "";
-    const captureStderr = () => {
-        codexConnection.process.stderr.addListener("data", (data: Buffer) => {
-            stderr = (stderr + data.toString()).slice(-maxStderrTailChars);
-        });
+    const codexProcessState: CodexProcessState = {
+        connection: startCodexConnection(codexPath),
+        codexPath,
+        config,
+        modelProvider,
+        stderr: "",
     };
-    captureStderr();
 
     process.stdin.on("close", () => {
-        codexConnection.process.stdin.end();
+        codexProcessState.connection.process.stdin.end();
         // Kill the codex process if it doesn't exit naturally
         setTimeout(() => {
-            if (!codexConnection.process.killed) {
+            if (!codexProcessState.connection.process.killed) {
                 logger.log("Codex still running 2s after stdin closed; terminating process");
-                codexConnection.process.kill();
+                codexProcessState.connection.process.kill();
             }
         }, 2000);
     });
 
     const acpJsonStream = createJsonStream(process.stdin, process.stdout);
 
-    async function restartCodexClient(): Promise<CodexAcpClient> {
-        const previous = codexConnection;
-        const exited = previous.process.exitCode === null
-            ? once(previous.process, "exit")
-            : Promise.resolve();
-        previous.process.stdin.end();
-        const forceKill = setTimeout(() => {
-            if (previous.process.exitCode === null) {
-                logger.log("Codex still running 2s after provider restart; terminating process");
-                previous.process.kill();
-            }
-        }, 2000);
-        await exited;
-        clearTimeout(forceKill);
-
-        stderr = "";
-        codexConnection = startCodexConnection(codexPath);
-        captureStderr();
-        return new CodexAcpClient(new CodexAppServerClient(codexConnection.connection), config, modelProvider);
-    }
-
     function createAgent(connection: acp.AgentContext): CodexAcpServer {
-        const appServerClient = new CodexAppServerClient(codexConnection.connection);
+        const appServerClient = new CodexAppServerClient(codexProcessState.connection.connection);
         const codexClient = new CodexAcpClient(appServerClient, config, modelProvider);
         return new CodexAcpServer(
             connection,
             codexClient,
             defaultAuthRequest,
-            () => codexConnection.process.exitCode,
-            () => stderr,
-            restartCodexClient,
+            undefined,
+            undefined,
+            codexProcessState,
         );
     }
 


### PR DESCRIPTION
### Problem

Codex fixes `modelProvider` in the app-server thread runtime. Updating the adapter's Providers API state therefore affected newly created threads, while already loaded ACP sessions continued sending turns through the old backend.

The app-server does not currently expose an API that replaces a loaded thread's provider/config while preserving its ID.

### Solution

- Serialize provider updates and wait for active prompts to complete.
- Restart the adapter-owned Codex app-server between turns.
- Reinitialize the replacement client and resume every loaded thread with its existing session ID, cwd, additional directories, and MCP servers.
- Preserve startup/native provider state and restore it on `providers/disable`.
- Block session operations only while the coordinated restart is in progress.
- Attempt every thread resume even if one fails, report aggregate failures, and allow a later provider update to recover.
- Add PID and provider/restart routing details to opt-in app-server logs without exposing provider headers.

### Tests

Added coverage for:

- native behavior when Providers API is unused;
- gateway config passed to `thread/start`;
- multiple loaded sessions across native → proxy A → proxy B → native;
- all-session resume after app-server restart;
- partial resume failure and successful subsequent recovery;
- startup proxy restoration and legacy gateway auth interoperability.

Verification:

- provider suite: 14 passed
- `npm run typecheck`
- `npm run build`
- `git diff --check`

The repository's full suite still has the pre-existing approval/elicitation/session-close fixture mismatches; the provider suite and static/build checks are green.