### PR TITLE
fix: treat omitted autoResolutionMs as no auto-resolution

### DIFF
--- a/src/CodexElicitationHandler.ts
+++ b/src/CodexElicitationHandler.ts
@@ -390,7 +390,7 @@ export class CodexElicitationHandler implements ElicitationHandler {
         params: ToolRequestUserInputParams
     ): Promise<acp.CreateElicitationResponse | null> {
         const request = this.buildUserInputRequest(params);
-        if (params.autoResolutionMs === null) {
+        if (params.autoResolutionMs == null) {
             return await this.connection.request(
                 acp.methods.client.elicitation.create,
                 request,

--- a/src/__tests__/CodexACPAgent/elicitation-events.test.ts
+++ b/src/__tests__/CodexACPAgent/elicitation-events.test.ts
@@ -871,5 +871,44 @@ describe('Elicitation Events', () => {
             completeTurn();
             await promptPromise;
         });
+
+        it('should wait for the client when autoResolutionMs is omitted instead of aborting immediately', async () => {
+            const { promptPromise, completeTurn } = await setupSessionWithPendingPromptAndCapabilities({
+                elicitation: { form: {} },
+            });
+            fixture.setElicitationResponse(new Promise((resolve) => {
+                setTimeout(() => resolve({
+                    action: 'accept',
+                    content: { next_step: 'Go ahead' },
+                }), 200);
+            }));
+
+            const params = {
+                threadId: sessionId,
+                turnId: 'turn-1',
+                itemId: 'request-user-input-1',
+                isBlocking: true,
+                questions: [{
+                    id: 'next_step',
+                    header: 'Next step',
+                    question: 'Continue?',
+                    isOther: false,
+                    isSecret: false,
+                    options: null,
+                }],
+            } as unknown as ToolRequestUserInputParams;
+
+            const startedAt = Date.now();
+            const response = await fixture.sendServerRequest('item/tool/requestUserInput', params);
+            const elapsedMs = Date.now() - startedAt;
+
+            expect(response).toEqual({
+                answers: { next_step: { answers: ['Go ahead'] } },
+            });
+            expect(elapsedMs).toBeGreaterThanOrEqual(150);
+
+            completeTurn();
+            await promptPromise;
+        });
     });
 });


### PR DESCRIPTION
## Summary

Fixes #344.

- `request_user_input` was aborted immediately with `{answers:{}}` when `autoResolutionMs` is omitted, before the client could render the form.
- Root cause in `requestUserInputElicitation`: the blocking path was gated on `params.autoResolutionMs === null`. When Codex omits the field it arrives as `undefined`, so the code fell through to the timeout path where `undefined ?? 0` schedules an immediate `resolveWithoutInput`; the abort wins `Promise.race` on the next tick.
- Change: treat both `null` and `undefined` as "no auto-resolution" via `== null`. Explicit numeric `autoResolutionMs` timeout behavior is unchanged.

## Tests

- Added a regression test in `src/__tests__/CodexACPAgent/elicitation-events.test.ts`: with `autoResolutionMs` omitted and a client answer arriving after 200ms, the handler must wait for the client instead of aborting. On the current code it returns `{answers:{}}` in ~11ms; with the fix it waits ~200ms and returns the client's answers.
- `npm test` (435 passed, 28 skipped)
- `npm run typecheck`

## Note on e2e coverage

This is not covered by an e2e test. `request_user_input` is emitted by a real Codex session during interactive flows, so deterministically reproducing the omitted-field case requires injecting the protocol message rather than driving a live model (which would also need `OPENAI_API_KEY`). The mock-fixture unit test above does exactly that, matching the runtime shape Codex actually sends.