### PR TITLE
feat: name Codex threads from ACP session metadata

### DIFF
--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -523,6 +523,8 @@ export class CodexAcpClient {
             cwd: request.cwd,
         });
 
+        const sessionTitle = await this.applySessionTitle(response.thread.id, request._meta);
+
         const codexModels = await this.fetchAvailableModels();
         if (codexModels.length === 0) {
             throw new Error("Codex did not return any models");
@@ -536,7 +538,31 @@ export class CodexAcpClient {
             modelProvider: response.modelProvider,
             currentServiceTier: response.serviceTier as ServiceTier ?? null,
             additionalDirectories,
+            sessionTitle,
         };
+    }
+
+    /**
+     * Name the thread from `_meta.sessionTitle`, supplied out of band by the
+     * client so the title never enters the prompt.
+     *
+     * Returns the applied title, or `null` when none was requested or the
+     * naming request failed. Naming is cosmetic: a failure must not fail
+     * session creation, so errors are logged and swallowed.
+     */
+    private async applySessionTitle(
+        threadId: string,
+        meta?: Record<string, unknown> | null,
+    ): Promise<string | null> {
+        const title = readMetaSessionTitle(meta);
+        if (!title) return null;
+        try {
+            await this.codexClient.threadSetName({threadId, name: title});
+            return title;
+        } catch (err) {
+            logger.error(`Failed to set thread name for ${threadId}`, err);
+            return null;
+        }
     }
 
     async closeSession(sessionId: string): Promise<void> {
@@ -1238,6 +1264,12 @@ export type SessionMetadata = {
     modelProvider?: string | null,
     currentServiceTier?: ServiceTier | null,
     additionalDirectories: string[],
+    /**
+     * Title applied to the thread from `_meta.sessionTitle`, or `null` when
+     * none was requested. Reported back so the caller can seed its title state
+     * synchronously and not let a fallback title overwrite an explicit one.
+     */
+    sessionTitle?: string | null,
 }
 
 export type SessionMetadataWithThread = SessionMetadata & {
@@ -1335,6 +1367,15 @@ function readMetaAdditionalRoots(meta?: Record<string, unknown> | null): string[
         .filter((value): value is string => typeof value === "string")
         .map(value => value.trim())
         .filter(value => value.length > 0));
+}
+
+function readMetaSessionTitle(meta?: Record<string, unknown> | null): string | null {
+    const rawTitle = meta?.["sessionTitle"];
+    if (typeof rawTitle !== "string") {
+        return null;
+    }
+    const title = rawTitle.replace(/\s+/g, " ").trim();
+    return title.length > 0 ? title : null;
 }
 
 function readAdditionalDirectories(cwd: string, additionalDirectories?: string[],  meta?: Record<string, unknown> | null): string[] {

--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -1369,12 +1369,38 @@ function readMetaAdditionalRoots(meta?: Record<string, unknown> | null): string[
         .filter(value => value.length > 0));
 }
 
+/** Upper bound on the length of a title requested through `_meta`. */
+const SESSION_TITLE_MAX_CHARS = 80;
+
+/**
+ * Read and sanitize the title requested in `_meta.sessionTitle`.
+ *
+ * Whitespace collapses to single spaces, control and format characters are
+ * dropped, and the result is capped at [`SESSION_TITLE_MAX_CHARS`] code points.
+ * Returns `null` when the value is absent, not a string, or has nothing
+ * printable left.
+ *
+ * This is the ACP boundary for arbitrary clients, and Codex's own thread-name
+ * normalization only trims: without a cap and a control-character filter an
+ * unbounded or invisible-character title would be persisted verbatim into the
+ * Codex thread store.
+ */
 function readMetaSessionTitle(meta?: Record<string, unknown> | null): string | null {
     const rawTitle = meta?.["sessionTitle"];
     if (typeof rawTitle !== "string") {
         return null;
     }
-    const title = rawTitle.replace(/\s+/g, " ").trim();
+    const collapsed = rawTitle
+        // Whitespace controls become spaces before the control filter runs, so
+        // a newline separates words instead of joining them.
+        .replace(/\s/gu, " ")
+        // Cc/Cf/Cs carry no printable meaning; Cf covers zero-width spaces and
+        // bidi overrides, Cs covers lone surrogates.
+        .replace(/[\p{Cc}\p{Cf}\p{Cs}]/gu, "")
+        .replace(/ +/g, " ")
+        .trim();
+    // Slice by code point, not by UTF-16 unit, so the cap can't split a pair.
+    const title = Array.from(collapsed).slice(0, SESSION_TITLE_MAX_CHARS).join("").trimEnd();
     return title.length > 0 ? title : null;
 }
 

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -624,8 +624,12 @@ export class CodexAcpServer {
             sessionMcpServers: sessionMcpServers,
             terminalOutputMode: this.terminalOutputMode,
             goalRevision: 0,
-            sessionTitle: null,
-            sessionTitleSource: "sessionId" in request ? "unknown" : "unset",
+            sessionTitle: sessionMetadata.sessionTitle ?? null,
+            // Seed from the title the client already applied, so a later
+            // fallback title cannot overwrite an explicit one.
+            sessionTitleSource: "sessionId" in request
+                ? "unknown"
+                : (sessionMetadata.sessionTitle ? "explicit" : "unset"),
         };
         this.sessions.set(sessionId, sessionState);
         resumeSubscribed = false;

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -634,6 +634,10 @@ export class CodexAcpServer {
         this.sessions.set(sessionId, sessionState);
         resumeSubscribed = false;
 
+        if (sessionState.sessionTitleSource === "explicit" && sessionState.sessionTitle) {
+            this.publishExplicitSessionTitleAsync(sessionId, sessionGeneration, sessionState.sessionTitle);
+        }
+
         if (requestedMcpServers.length > 0 && mcpServerStartupVersion !== null) {
             this.pendingMcpStartupSessions.set(sessionId, {
                 requestedServers: new Set(getRequestedMcpServerNames(requestedMcpServers)),
@@ -1981,6 +1985,48 @@ export class CodexAcpServer {
 
     private publishMcpStartupStatusAsync(sessionId: string): void {
         void this.doPublishMcpStartupStatus(sessionId);
+    }
+
+    /**
+     * Publish the title the client requested in `_meta`, once, after the
+     * `session/new` response has been written.
+     *
+     * The SDK's client installs its per-session update queue only when
+     * `session/new` resolves, and drops updates for sessions that have no queue
+     * attached, so an update emitted from inside the create path would be lost
+     * for a legitimate client. `setImmediate` puts the publish behind a
+     * macrotask boundary, which drains the microtasks that hand the response to
+     * the connection, and the connection serializes its writes — so the
+     * notification can only leave after the response.
+     */
+    private publishExplicitSessionTitleAsync(sessionId: string, generation: number, title: string): void {
+        setImmediate(() => {
+            void this.doPublishExplicitSessionTitle(sessionId, generation, title);
+        });
+    }
+
+    private async doPublishExplicitSessionTitle(
+        sessionId: string,
+        generation: number,
+        title: string,
+    ): Promise<void> {
+        const sessionState = this.sessions.get(sessionId);
+        // A session closed, reopened, or renamed during the gap must not be
+        // told about a title that is no longer its own.
+        if (!sessionState
+            || !this.sessionOpenCanInstall(sessionId, generation)
+            || sessionState.sessionTitleSource !== "explicit"
+            || sessionState.sessionTitle !== title) {
+            return;
+        }
+        try {
+            await new ACPSessionConnection(this.connection, sessionId).update({
+                sessionUpdate: "session_info_update",
+                title,
+            });
+        } catch (err) {
+            logger.error(`Failed to publish session title for session ${sessionId}`, err);
+        }
     }
 
     private async doPublishMcpStartupStatus(sessionId: string): Promise<void> {

--- a/src/CodexAppServerClient.ts
+++ b/src/CodexAppServerClient.ts
@@ -53,6 +53,8 @@ import type {
     ThreadReadResponse,
     ThreadResumeParams,
     ThreadResumeResponse,
+    ThreadSetNameParams,
+    ThreadSetNameResponse,
     ThreadSettings,
     ThreadStartParams,
     ThreadStartResponse,
@@ -534,6 +536,10 @@ export class CodexAppServerClient {
 
     async threadFork(params: ThreadForkParams): Promise<ThreadForkResponse> {
         return await this.sendRequest({ method: "thread/fork", params: params });
+    }
+
+    async threadSetName(params: ThreadSetNameParams): Promise<ThreadSetNameResponse> {
+        return await this.sendRequest({ method: "thread/name/set", params: params });
     }
 
     getThreadSettings(threadId: string): ThreadSettings | undefined {

--- a/src/__tests__/CodexACPAgent/data/session-new-sets-thread-name.json
+++ b/src/__tests__/CodexACPAgent/data/session-new-sets-thread-name.json
@@ -3,7 +3,7 @@
   "method": "thread/name/set",
   "params": {
     "threadId": "thread-id",
-    "name": "Fizz · #buzz-dev"
+    "name": "Nightly · #release-prep"
   }
 }
 {

--- a/src/__tests__/CodexACPAgent/data/session-new-sets-thread-name.json
+++ b/src/__tests__/CodexACPAgent/data/session-new-sets-thread-name.json
@@ -1,0 +1,23 @@
+{
+  "eventType": "request",
+  "method": "thread/name/set",
+  "params": {
+    "threadId": "thread-id",
+    "name": "Fizz · #buzz-dev"
+  }
+}
+{
+  "eventType": "response"
+}
+{
+  "eventType": "request",
+  "method": "skills/list",
+  "params": {
+    "cwds": [
+      ""
+    ]
+  }
+}
+{
+  "eventType": "response"
+}

--- a/src/__tests__/CodexACPAgent/data/session-new-without-thread-name.json
+++ b/src/__tests__/CodexACPAgent/data/session-new-without-thread-name.json
@@ -1,0 +1,12 @@
+{
+  "eventType": "request",
+  "method": "skills/list",
+  "params": {
+    "cwds": [
+      ""
+    ]
+  }
+}
+{
+  "eventType": "response"
+}

--- a/src/__tests__/CodexACPAgent/session-title-from-meta.test.ts
+++ b/src/__tests__/CodexACPAgent/session-title-from-meta.test.ts
@@ -3,7 +3,7 @@ import {createCodexMockTestFixture, createTestModel, type CodexMockTestFixture} 
 import type * as acp from "@agentclientprotocol/sdk";
 
 const threadId = "thread-id";
-const sessionTitle = "Fizz · #buzz-dev";
+const sessionTitle = "Nightly · #release-prep";
 
 describe("session title from _meta", () => {
     it("names the thread with the title supplied in _meta", async () => {
@@ -29,15 +29,52 @@ describe("session title from _meta", () => {
     it("collapses whitespace in the requested title before naming the thread", async () => {
         const fixture = createFixture();
 
-        await fixture.getCodexAcpAgent().newSession(newSessionRequest({sessionTitle: "  Fizz  ·\n\t#buzz-dev  "}));
+        await fixture.getCodexAcpAgent().newSession(
+            newSessionRequest({sessionTitle: "  Nightly  ·\n\t#release-prep  "}),
+        );
 
         expect(threadNamesSet(fixture)).toEqual([sessionTitle]);
+    });
+
+    it("strips control characters from the requested title", async () => {
+        const fixture = createFixture();
+
+        await fixture.getCodexAcpAgent().newSession(
+            newSessionRequest({sessionTitle: "Nightly\u0007 \u200b·\u202e #release-prep"}),
+        );
+
+        expect(threadNamesSet(fixture)).toEqual([sessionTitle]);
+    });
+
+    it("caps an over-long requested title", async () => {
+        const fixture = createFixture();
+        const requested = "a".repeat(500);
+
+        await fixture.getCodexAcpAgent().newSession(newSessionRequest({sessionTitle: requested}));
+
+        expect(threadNamesSet(fixture)).toEqual(["a".repeat(80)]);
+    });
+
+    it("caps an over-long requested title without splitting a surrogate pair", async () => {
+        const fixture = createFixture();
+
+        await fixture.getCodexAcpAgent().newSession(newSessionRequest({sessionTitle: "😀".repeat(200)}));
+
+        expect(threadNamesSet(fixture)).toEqual(["😀".repeat(80)]);
     });
 
     it("does not name the thread when the requested title is blank", async () => {
         const fixture = createFixture();
 
         await fixture.getCodexAcpAgent().newSession(newSessionRequest({sessionTitle: " \n\t "}));
+
+        expect(threadNamesSet(fixture)).toEqual([]);
+    });
+
+    it("does not name the thread when the requested title is only control characters", async () => {
+        const fixture = createFixture();
+
+        await fixture.getCodexAcpAgent().newSession(newSessionRequest({sessionTitle: "\u0007\u200b\u202e"}));
 
         expect(threadNamesSet(fixture)).toEqual([]);
     });
@@ -50,7 +87,7 @@ describe("session title from _meta", () => {
         expect(threadNamesSet(fixture)).toEqual([]);
     });
 
-    it("seeds the session title state so a prompt fallback cannot overwrite it", async () => {
+    it("records the applied title as the explicit title in the session state", async () => {
         const fixture = createFixture();
 
         const response = await fixture.getCodexAcpAgent().newSession(newSessionRequest({sessionTitle}));

--- a/src/__tests__/CodexACPAgent/session-title-from-meta.test.ts
+++ b/src/__tests__/CodexACPAgent/session-title-from-meta.test.ts
@@ -1,0 +1,126 @@
+import {describe, expect, it, vi} from "vitest";
+import {createCodexMockTestFixture, createTestModel, type CodexMockTestFixture} from "../acp-test-utils";
+import type * as acp from "@agentclientprotocol/sdk";
+
+const threadId = "thread-id";
+const sessionTitle = "Fizz · #buzz-dev";
+
+describe("session title from _meta", () => {
+    it("names the thread with the title supplied in _meta", async () => {
+        const fixture = createFixture();
+
+        await fixture.getCodexAcpAgent().newSession(newSessionRequest({sessionTitle}));
+
+        await expect(fixture.getCodexConnectionDump([])).toMatchFileSnapshot(
+            "data/session-new-sets-thread-name.json"
+        );
+    });
+
+    it("does not name the thread when _meta carries no title", async () => {
+        const fixture = createFixture();
+
+        await fixture.getCodexAcpAgent().newSession(newSessionRequest());
+
+        await expect(fixture.getCodexConnectionDump([])).toMatchFileSnapshot(
+            "data/session-new-without-thread-name.json"
+        );
+    });
+
+    it("collapses whitespace in the requested title before naming the thread", async () => {
+        const fixture = createFixture();
+
+        await fixture.getCodexAcpAgent().newSession(newSessionRequest({sessionTitle: "  Fizz  ·\n\t#buzz-dev  "}));
+
+        expect(threadNamesSet(fixture)).toEqual([sessionTitle]);
+    });
+
+    it("does not name the thread when the requested title is blank", async () => {
+        const fixture = createFixture();
+
+        await fixture.getCodexAcpAgent().newSession(newSessionRequest({sessionTitle: " \n\t "}));
+
+        expect(threadNamesSet(fixture)).toEqual([]);
+    });
+
+    it("does not name the thread when the requested title is not a string", async () => {
+        const fixture = createFixture();
+
+        await fixture.getCodexAcpAgent().newSession(newSessionRequest({sessionTitle: 42}));
+
+        expect(threadNamesSet(fixture)).toEqual([]);
+    });
+
+    it("seeds the session title state so a prompt fallback cannot overwrite it", async () => {
+        const fixture = createFixture();
+
+        const response = await fixture.getCodexAcpAgent().newSession(newSessionRequest({sessionTitle}));
+
+        expect(fixture.getCodexAcpAgent().getSessionState(response.sessionId)).toMatchObject({
+            sessionTitle,
+            sessionTitleSource: "explicit",
+        });
+    });
+
+    it("leaves the title unset when none was requested", async () => {
+        const fixture = createFixture();
+
+        const response = await fixture.getCodexAcpAgent().newSession(newSessionRequest());
+
+        expect(fixture.getCodexAcpAgent().getSessionState(response.sessionId)).toMatchObject({
+            sessionTitle: null,
+            sessionTitleSource: "unset",
+        });
+    });
+
+    it("creates the session successfully when naming the thread fails", async () => {
+        const fixture = createFixture();
+        vi.spyOn(fixture.getCodexAppServerClient(), "threadSetName")
+            .mockRejectedValue(new Error("thread/name/set is not supported"));
+
+        const response = await fixture.getCodexAcpAgent().newSession(newSessionRequest({sessionTitle}));
+
+        expect(response.sessionId).toBe(threadId);
+        // A rejected naming request must not be recorded as an applied title,
+        // so a later fallback title is still free to fill the gap.
+        expect(fixture.getCodexAcpAgent().getSessionState(threadId)).toMatchObject({
+            sessionTitle: null,
+            sessionTitleSource: "unset",
+        });
+    });
+});
+
+function newSessionRequest(meta?: Record<string, unknown>): acp.NewSessionRequest {
+    // cwd is empty so skill discovery is skipped and the recorded frames hold
+    // only what these tests are about.
+    return {cwd: "", mcpServers: [], ...(meta ? {_meta: meta} : {})};
+}
+
+/** Names carried by the `thread/name/set` frames sent to Codex, in order. */
+function threadNamesSet(fixture: CodexMockTestFixture): unknown[] {
+    return fixture.getCodexConnectionEvents([])
+        .filter(event => event.eventType === "request" && event.method === "thread/name/set")
+        .map(event => (event as {params: {name: unknown}}).params.name);
+}
+
+/**
+ * Fixture whose `thread/start` and `model/list` calls are stubbed at the
+ * wrapper level, so they leave no transport frames and the connection dump
+ * shows only whether `thread/name/set` was sent.
+ */
+function createFixture(): CodexMockTestFixture {
+    const fixture = createCodexMockTestFixture();
+    const codexAcpClient = fixture.getCodexAcpClient();
+    const codexAppServerClient = fixture.getCodexAppServerClient();
+
+    vi.spyOn(codexAcpClient, "authRequired").mockResolvedValue(false);
+    vi.spyOn(codexAcpClient, "getAccount").mockResolvedValue({account: null, requiresOpenaiAuth: false});
+    vi.spyOn(codexAppServerClient, "threadStart").mockResolvedValue({
+        thread: {id: threadId} as any,
+        model: "model-id",
+        reasoningEffort: "medium",
+        modelProvider: "openai",
+    } as any);
+    vi.spyOn(codexAcpClient, "fetchAvailableModels").mockResolvedValue([createTestModel()]);
+
+    return fixture;
+}

--- a/src/__tests__/CodexACPAgent/session-title-ordering.test.ts
+++ b/src/__tests__/CodexACPAgent/session-title-ordering.test.ts
@@ -1,0 +1,130 @@
+import {describe, expect, it, vi} from "vitest";
+import * as acp from "@agentclientprotocol/sdk";
+import {CodexAcpClient} from "../../CodexAcpClient";
+import {CodexAcpServer} from "../../CodexAcpServer";
+import {CodexAppServerClient} from "../../CodexAppServerClient";
+import {createMockCodexConnection, createTestModel} from "../acp-test-utils";
+
+const threadId = "thread-id";
+const sessionTitle = "Nightly · #release-prep";
+const promptText = "Fix the flaky test";
+
+/**
+ * These tests drive a real in-process SDK client/agent pair rather than the
+ * smart mock, because what is under test is ordering: the SDK client installs
+ * its per-session update queue only once `session/new` resolves, and silently
+ * drops updates for sessions with no queue attached. An update published from
+ * inside the create path is therefore unobservable, and a mock that records
+ * every notification it is handed cannot tell the two cases apart.
+ */
+describe("explicit session title over a real ACP connection", () => {
+    it("delivers the requested title to the client after session/new returns", async () => {
+        await withConnectedClient(async (ctx) => {
+            const session = await startSession(ctx, {sessionTitle});
+
+            await expect(nextSessionTitle(session)).resolves.toBe(sessionTitle);
+        });
+    });
+
+    it("leaves the first title to the prompt fallback when none was requested", async () => {
+        await withConnectedClient(async (ctx) => {
+            const session = await startSession(ctx);
+            void session.prompt(promptText);
+
+            await expect(nextSessionTitle(session)).resolves.toBe(promptText);
+        });
+    });
+
+    it("does not follow the requested title with a prompt-derived one", async () => {
+        await withConnectedClient(async (ctx) => {
+            const session = await startSession(ctx, {sessionTitle});
+            await expect(nextSessionTitle(session)).resolves.toBe(sessionTitle);
+
+            expect(await sessionTitlesDuringPrompt(session)).toEqual([]);
+        });
+    });
+});
+
+/** Starts a session, optionally requesting a title through `_meta`. */
+async function startSession(ctx: acp.ClientContext, meta?: Record<string, unknown>): Promise<acp.ActiveSession> {
+    // cwd is empty so skill discovery is skipped.
+    return await ctx.buildSession({cwd: "", mcpServers: [], ...(meta ? {_meta: meta} : {})}).start();
+}
+
+/** Title carried by the next `session_info_update` the client observes. */
+async function nextSessionTitle(session: acp.ActiveSession): Promise<unknown> {
+    while (true) {
+        const message = await session.nextUpdate();
+        if (message.kind === "stop") {
+            throw new Error("prompt turn stopped before a session title arrived");
+        }
+        if (message.update.sessionUpdate === "session_info_update") {
+            return message.update.title;
+        }
+    }
+}
+
+/** Titles carried by `session_info_update`s seen during one prompt turn. */
+async function sessionTitlesDuringPrompt(session: acp.ActiveSession): Promise<unknown[]> {
+    void session.prompt(promptText);
+    const titles: unknown[] = [];
+    while (true) {
+        const message = await session.nextUpdate();
+        if (message.kind === "stop") return titles;
+        if (message.update.sessionUpdate === "session_info_update") {
+            titles.push(message.update.title);
+        }
+    }
+}
+
+/**
+ * Runs `op` against a real ACP connection to a `CodexAcpServer` whose Codex
+ * side is stubbed at the wrapper level.
+ */
+async function withConnectedClient(op: (ctx: acp.ClientContext) => Promise<void>): Promise<void> {
+    const codexConnection = createMockCodexConnection();
+    const appServerClient = new CodexAppServerClient(codexConnection.connection);
+    const codexAcpClient = new CodexAcpClient(appServerClient);
+
+    vi.spyOn(codexAcpClient, "authRequired").mockResolvedValue(false);
+    vi.spyOn(codexAcpClient, "getAccount").mockResolvedValue({account: null, requiresOpenaiAuth: false});
+    vi.spyOn(codexAcpClient, "fetchAvailableModels").mockResolvedValue([createTestModel()]);
+    vi.spyOn(appServerClient, "threadStart").mockResolvedValue({
+        thread: {id: threadId} as any,
+        model: "model-id",
+        reasoningEffort: "medium",
+        modelProvider: "openai",
+    } as any);
+    vi.spyOn(appServerClient, "threadSetName").mockResolvedValue({} as any);
+    vi.spyOn(codexAcpClient, "sendPrompt").mockResolvedValue({
+        threadId,
+        turn: {
+            id: "turn-id",
+            items: [],
+            itemsView: "notLoaded",
+            status: "completed",
+            error: null,
+            startedAt: null,
+            completedAt: null,
+            durationMs: null,
+        },
+    } as any);
+
+    let server: CodexAcpServer | null = null;
+    const getServer = (): CodexAcpServer => {
+        if (!server) throw new Error("agent is not connected");
+        return server;
+    };
+    const agentApp = acp.agent({name: "codex-acp-ordering-test"})
+        .onConnect((connection) => {
+            server = new CodexAcpServer(connection.client, codexAcpClient, undefined, () => null);
+        })
+        .onRequest(acp.methods.agent.initialize, (c) => getServer().initialize(c.params))
+        .onRequest(acp.methods.agent.session.new, (c) => getServer().newSession(c.params))
+        .onRequest(acp.methods.agent.session.prompt, (c) => getServer().prompt(c.params, c.signal));
+
+    await acp.client({name: "ordering-test-client"}).connectWith(agentApp, async (ctx) => {
+        await ctx.request(acp.methods.agent.initialize, {protocolVersion: acp.PROTOCOL_VERSION});
+        await op(ctx);
+    });
+}

--- a/src/__tests__/acp-test-utils.ts
+++ b/src/__tests__/acp-test-utils.ts
@@ -254,28 +254,22 @@ export interface CodexMockTestFixture extends TestFixture {
     setElicitationResponse(response: CreateElicitationResponse | Promise<CreateElicitationResponse>): void,
 }
 
+export interface MockCodexConnection {
+    connection: MessageConnection,
+    sendServerNotification(notification: ServerNotification | Record<string, unknown>): void,
+    sendServerRequest<T>(method: string, params: unknown): Promise<T>,
+}
+
 /**
- * Creates a test fixture with a mock Codex connection.
- * Use for unit tests that don't need a real Codex binary.
- * Provides `sendServerNotification()` to simulate server notifications.
- * Provides `sendServerRequest()` to simulate server-initiated requests (e.g., approval requests).
- * Provides `setPermissionResponse()` to control ACP permission dialog responses.
+ * Creates a mock Codex `MessageConnection` that records nothing and answers
+ * every request with `undefined`, so callers spy on the wrapper methods they
+ * care about.
  */
-export function createCodexMockTestFixture(
-    restartCodexClient?: () => Promise<CodexAcpClient>,
-): CodexMockTestFixture {
+export function createMockCodexConnection(): MockCodexConnection {
     let unhandledNotificationHandler: ((notification: any) => void) | null = null;
     const requestHandlers = new Map<string, (params: unknown) => Promise<unknown>>();
 
-    // State for controlling permission responses
-    const permissionState: { response: RequestPermissionResponse | Promise<RequestPermissionResponse> } = {
-        response: { outcome: { outcome: 'cancelled' } }
-    };
-    const elicitationState: { response: CreateElicitationResponse | Promise<CreateElicitationResponse> } = {
-        response: { action: 'cancel' }
-    };
-
-    const mockCodexConnection = {
+    const connection = {
         sendRequest: () => Promise.resolve(undefined),
         onUnhandledNotification: (handler: (notification: any) => void) => {
             unhandledNotificationHandler = handler;
@@ -286,6 +280,41 @@ export function createCodexMockTestFixture(
         },
         end: () => {},
     } as unknown as MessageConnection;
+
+    return {
+        connection,
+        sendServerNotification(notification: ServerNotification | Record<string, unknown>): void {
+            unhandledNotificationHandler?.(notification);
+        },
+        async sendServerRequest<T>(method: string, params: unknown): Promise<T> {
+            const handler = requestHandlers.get(method);
+            if (!handler) {
+                throw new Error(`No handler registered for ${method}`);
+            }
+            return await handler(params) as T;
+        },
+    };
+}
+
+/**
+ * Creates a test fixture with a mock Codex connection.
+ * Use for unit tests that don't need a real Codex binary.
+ * Provides `sendServerNotification()` to simulate server notifications.
+ * Provides `sendServerRequest()` to simulate server-initiated requests (e.g., approval requests).
+ * Provides `setPermissionResponse()` to control ACP permission dialog responses.
+ */
+export function createCodexMockTestFixture(
+    restartCodexClient?: () => Promise<CodexAcpClient>,
+): CodexMockTestFixture {
+    const mockCodexConnection = createMockCodexConnection();
+
+    // State for controlling permission responses
+    const permissionState: { response: RequestPermissionResponse | Promise<RequestPermissionResponse> } = {
+        response: { outcome: { outcome: 'cancelled' } }
+    };
+    const elicitationState: { response: CreateElicitationResponse | Promise<CreateElicitationResponse> } = {
+        response: { action: 'cancel' }
+    };
 
     // Create ACP connection with configurable permission response
     const acpConnectionEvents: MethodCallEvent[] = [];
@@ -309,7 +338,7 @@ export function createCodexMockTestFixture(
     }, { returnValues });
 
     const baseFixture = createBaseTestFixture({
-        connection: mockCodexConnection,
+        connection: mockCodexConnection.connection,
         getExitCode: () => null,
         acpConnection: {
             connection: acpConnection,
@@ -324,18 +353,8 @@ export function createCodexMockTestFixture(
 
     return {
         ...baseFixture,
-        sendServerNotification(notification: ServerNotification | Record<string, unknown>): void {
-            if (unhandledNotificationHandler) {
-                unhandledNotificationHandler(notification);
-            }
-        },
-        async sendServerRequest<T>(method: string, params: unknown): Promise<T> {
-            const handler = requestHandlers.get(method);
-            if (!handler) {
-                throw new Error(`No handler registered for ${method}`);
-            }
-            return await handler(params) as T;
-        },
+        sendServerNotification: mockCodexConnection.sendServerNotification,
+        sendServerRequest: mockCodexConnection.sendServerRequest,
         setPermissionResponse(response: RequestPermissionResponse | Promise<RequestPermissionResponse>): void {
             permissionState.response = response;
         },


### PR DESCRIPTION
## Summary

- Read `sessionTitle` from `session/new` `_meta` and apply it with Codex `thread/name/set`.
- Seed the adapter's explicit-title state and publish the title through `session_info_update` after the `session/new` response.
- Sanitize untrusted titles by collapsing whitespace, removing Unicode control/format/surrogate characters, and capping them at 80 code points.
- Keep title application cosmetic: failures are logged without failing session creation.

## Motivation

Buzz already sends a bounded, out-of-band session title in [block/buzz#3028](https://github.com/block/buzz/pull/3028). Without the adapter half, Codex still derives the thread title from the first prompt, which can turn a complete orchestrator prompt into the task title. Using ACP metadata keeps the label out of the prompt and avoids spending tokens on title plumbing.

This rebases and supersedes #338 on current `main`. It preserves the original commits, authorship, and DCO sign-offs from @wpfleger96 while resolving the intervening thread-fork and test-fixture API changes.

## Testing

- `npx vitest run --no-file-parallelism src/__tests__/CodexACPAgent/session-title-from-meta.test.ts src/__tests__/CodexACPAgent/session-title-ordering.test.ts` (15 passed)
- `npm run typecheck`
- `npm test` (454 passed, 28 skipped)
- `npm run build`
- `npm run codex-test -- -p "Reply with exactly: title-ok" -o summary`
- Live Codex app-server smoke test: created a session with `_meta.sessionTitle`, read the persisted thread name back, and archived the test thread

## Related

- block/buzz#2334
- block/buzz#3028
- #338
