### PR TITLE
feat: forward account rate limits to clients as session metadata

### DIFF
--- a/src/CodexEventHandler.ts
+++ b/src/CodexEventHandler.ts
@@ -470,7 +470,9 @@ export class CodexEventHandler {
                 return this.createMcpToolProgressEvent(notification.params);
             case "account/rateLimits/updated":
                 this.handleRateLimitsUpdated(notification.params);
-                return null;
+                return this.createCodexSessionInfoUpdate({
+                    rateLimits: notification.params.rateLimits,
+                });
             case "configWarning":
                 return await this.createConfigWarningEvent(notification.params);
             case "warning":

--- a/src/__tests__/CodexACPAgent/data/account-rate-limits-updated.json
+++ b/src/__tests__/CodexACPAgent/data/account-rate-limits-updated.json
@@ -1,0 +1,34 @@
+{
+  "method": "sessionUpdate",
+  "args": [
+    {
+      "sessionId": "test-session-id",
+      "update": {
+        "sessionUpdate": "session_info_update",
+        "_meta": {
+          "codex": {
+            "rateLimits": {
+              "limitId": "codex",
+              "limitName": null,
+              "primary": {
+                "usedPercent": 42,
+                "windowDurationMins": 300,
+                "resetsAt": 1710000000
+              },
+              "secondary": {
+                "usedPercent": 7,
+                "windowDurationMins": 10080,
+                "resetsAt": 1710600000
+              },
+              "credits": null,
+              "individualLimit": null,
+              "spendControlReached": false,
+              "planType": "plus",
+              "rateLimitReachedType": null
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/__tests__/CodexACPAgent/rate-limit-events.test.ts
+++ b/src/__tests__/CodexACPAgent/rate-limit-events.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { SessionState } from "../../CodexAcpServer";
+import type { ServerNotification } from "../../app-server";
+import { AgentMode } from "../../AgentMode";
+import {
+    createCodexMockTestFixture,
+    createTestSessionState,
+    setupPromptAndSendNotifications,
+    type CodexMockTestFixture,
+} from "../acp-test-utils";
+
+describe("CodexEventHandler - account rate limit events", () => {
+    let mockFixture: CodexMockTestFixture;
+    const sessionId = "test-session-id";
+
+    beforeEach(() => {
+        mockFixture = createCodexMockTestFixture();
+        vi.clearAllMocks();
+    });
+
+    const rateLimitsUpdatedNotification: ServerNotification = {
+        method: "account/rateLimits/updated",
+        params: {
+            rateLimits: {
+                limitId: "codex",
+                limitName: null,
+                primary: { usedPercent: 42, windowDurationMins: 300, resetsAt: 1710000000 },
+                secondary: { usedPercent: 7, windowDurationMins: 10080, resetsAt: 1710600000 },
+                credits: null,
+                individualLimit: null,
+                spendControlReached: false,
+                planType: "plus",
+                rateLimitReachedType: null,
+            },
+        },
+    };
+
+    it("should send account rate limits as session metadata", async () => {
+        await setupPromptAndSendNotifications(mockFixture, sessionId, createSessionState(), [
+            rateLimitsUpdatedNotification,
+        ]);
+
+        await expect(mockFixture.getAcpConnectionDump([])).toMatchFileSnapshot(
+            "data/account-rate-limits-updated.json"
+        );
+    });
+
+    function createSessionState(): SessionState {
+        return createTestSessionState({
+            sessionId,
+            currentModelId: "model-id[effort]",
+            agentMode: AgentMode.DEFAULT_AGENT_MODE,
+        });
+    }
+});


### PR DESCRIPTION
## What

`account/rateLimits/updated` is already handled: the snapshot is stored in
`sessionState.rateLimits` and rendered by `/status` via `formatRateLimitLines`.
But the handler returns `null`, so nothing reaches the client — the numbers are
only visible if the user types a command.

This forwards them as session metadata too, using the existing
`createCodexSessionInfoUpdate` helper.

## Why

It makes usage indicators free to build. A client that wants to show how much of
the plan is left has no way to learn it from the stream today, so it has to spawn
its own `codex app-server` and poll `account/rateLimits/read` — a second Codex
process and a duplicate request per refresh, for data the adapter already
receives, parses and keeps.

Forwarding it removes both: no extra process, no extra requests, no polling
machinery, and the figures update exactly when Codex says they changed.

Nothing is removed. `/status` keeps working, since the state is still recorded.

## Change

One case in `src/CodexEventHandler.ts`:

```diff
             case "account/rateLimits/updated":
                 this.handleRateLimitsUpdated(notification.params);
-                return null;
+                return this.createCodexSessionInfoUpdate({
+                    rateLimits: notification.params.rateLimits,
+                });
```

Clients see the snapshot under `_meta.codex.rateLimits`, the same `_meta.codex`
convention as the other codex-specific session metadata.

## Tests

`src/__tests__/CodexACPAgent/rate-limit-events.test.ts` — one snapshot of what
the client receives, so the wire format is visible in review.

- `npm run typecheck` — clean
- `npx vitest run` — 440 passed, 28 skipped, nothing else affected
