### PR TITLE
fix: use executable model names for turns

### DIFF
--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -844,6 +844,7 @@ export class CodexAcpClient {
         request: acp.PromptRequest,
         agentMode: AgentMode,
         modelId: ModelId,
+        modelName: string,
         serviceTier: ServiceTier | null,
         disableSummary: boolean,
         cwd: string,
@@ -864,7 +865,7 @@ export class CodexAcpClient {
             sandboxPolicy: addAdditionalDirectoriesToSandboxPolicy(agentMode.sandboxPolicy, additionalDirectories),
             summary: disableSummary ? "none" : "auto",
             effort: effort,
-            model: modelId.model,
+            model: modelName,
             serviceTier: serviceTier,
         }, onTurnStarted);
     }

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -2417,6 +2417,8 @@ export class CodexAcpServer {
             }
 
             const modelId = ModelId.fromString(sessionState.currentModelId);
+            const modelName = this.findCurrentModel(sessionState.availableModels, sessionState.currentModelId)?.model
+                ?? modelId.model;
             const modelLacksReasoning = sessionState.supportedReasoningEfforts.length > 0
                 && sessionState.supportedReasoningEfforts.every(e => e.reasoningEffort === "none");
 
@@ -2442,6 +2444,7 @@ export class CodexAcpServer {
                     effectiveParams,
                     agentMode,
                     modelId,
+                    modelName,
                     serviceTier,
                     disableSummary,
                     sessionState.cwd,
@@ -2532,6 +2535,7 @@ export class CodexAcpServer {
                             implementationRequest,
                             agentMode,
                             modelId,
+                            modelName,
                             serviceTier,
                             disableSummary,
                             sessionState.cwd,

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -3580,6 +3580,27 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         expect(turnStartSpy).toHaveBeenCalledWith(expect.objectContaining({ summary: "auto" }));
     });
 
+    it('should pass the executable model name to turn/start', async () => {
+        const model = createTestModel({
+            id: "catalog-model-id",
+            model: "provider-model-name",
+        });
+        const {mockFixture, turnStartSpy} = setupPromptFixture({
+            currentModelId: "catalog-model-id[medium]",
+            availableModels: [model],
+        });
+
+        await mockFixture.getCodexAcpAgent().prompt({
+            sessionId: "session-id",
+            prompt: [{type: "text", text: "test"}],
+        });
+
+        expect(turnStartSpy).toHaveBeenCalledWith(expect.objectContaining({
+            model: "provider-model-name",
+            effort: "medium",
+        }));
+    });
+
     it ('should reject prompt with images when model does not support image input', async () => {
         const { mockFixture } = setupPromptFixture({
             supportedInputModalities: ["text"],


### PR DESCRIPTION
## Summary

- resolve ACP catalog IDs to their executable Codex model names before starting a turn
- preserve uncatalogued custom-provider model IDs as a fallback
- add regression coverage for catalogs where `Model.id` differs from `Model.model`

## Testing

- `npm test`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Fixes #198