### PR TITLE
fix: report AIR file changes from audit turns

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Use [OpenAI Codex](https://github.com/openai/codex) from [Agent Client Protocol]
 - Shell command, file change, [permission request](docs/permission-extension.md), MCP tool call, terminal output, reasoning, plan, web search, image generation, image view, token usage, and review events.
 - Subagent launches as standard ACP tool calls, with Codex thread identity and activity details in namespaced `_meta.codex.subagent` metadata.
 - Session-scoped long-running goals through the provider-neutral [goal extension](docs/goal-extension.md).
+- A per-turn [agent file-change report](docs/agent-file-change-report.md) after capability negotiation.
 - Client-provided MCP servers over command-based stdio config and HTTP transport.
 - Slash commands: `/status`, `/mcp`, `/skills`, `/goal`, `/review`, `/review-branch`, `/review-commit`, `/compact`, and `/logout`, as well as configured skills.
 

--- a/docs/agent-file-change-report.md
+++ b/docs/agent-file-change-report.md
@@ -1,0 +1,60 @@
+# Agent file-change report
+
+Standard ACP can describe a change from one tool call. It has no complete file list for one prompt turn.
+
+This adapter supports the version-1 `agentFileChangeReport` extension. The client and adapter must both advertise it in `_meta.jetbrains.air.capabilities` during `initialize`.
+
+The client adds this object to `session/prompt`:
+
+```json
+{
+  "_meta": {
+    "jetbrains": {
+      "air": {
+        "agentFileChangeReportRequest": {
+          "version": 1,
+          "requestId": "a-unique-request-id"
+        }
+      }
+    }
+  }
+}
+```
+
+The request identifier has 1 to 128 characters. It can contain ASCII letters, digits, `.`, `_`, `:`, and `-`.
+
+The adapter runs a hidden, read-only Codex fork after the main turn. The fork reports files that the main turn changed. Its output does not enter the visible transcript.
+
+The adapter sends one `session_info_update` before the `PromptResponse`:
+
+```json
+{
+  "sessionUpdate": "session_info_update",
+  "_meta": {
+    "jetbrains": {
+      "air": {
+        "version": 1,
+        "agentFileChangeReport": {
+          "version": 1,
+          "requestId": "a-unique-request-id",
+          "status": "reported",
+          "paths": ["/workspace/src/App.ts"],
+          "declaredComplete": true,
+          "truncated": false,
+          "uncertainty": "Optional short explanation"
+        }
+      }
+    }
+  }
+}
+```
+
+Each path is an absolute normalized path in the working directory or an additional workspace directory. The report contains no file content, diff, line count, or path order guarantee.
+
+The adapter sends at most 1,024 paths. Each path has at most 4,096 characters. The serialized report has at most 256 KiB. The optional uncertainty has at most 2,000 characters.
+
+The adapter marks the result unavailable after 30 seconds. It can also use `cancelled`, `invalidOutput`, `notReported`, or `providerError` as the reason. The main prompt still completes.
+
+The client must match the request identifier. It must ignore a duplicate, stale, malformed, or unavailable report.
+
+Rollback is outside this extension. This adapter does not advertise an `undo` or `rollback` command.

--- a/src/AgentFileChangeReport.ts
+++ b/src/AgentFileChangeReport.ts
@@ -60,7 +60,7 @@ export type AgentFileChangeReport = ReportedAgentFileChangeReport | UnavailableA
 export const AGENT_FILE_CHANGE_REPORT_OUTPUT_SCHEMA: JsonValue = {
     type: "object",
     additionalProperties: false,
-    required: ["paths", "complete"],
+    required: ["paths", "complete", "uncertainty"],
     properties: {
         paths: {
             type: "array",
@@ -68,8 +68,12 @@ export const AGENT_FILE_CHANGE_REPORT_OUTPUT_SCHEMA: JsonValue = {
         },
         complete: {type: "boolean"},
         uncertainty: {
-            type: "string",
-            maxLength: AGENT_FILE_CHANGE_REPORT_MAX_UNCERTAINTY_LENGTH,
+            anyOf: [{
+                type: "string",
+                maxLength: AGENT_FILE_CHANGE_REPORT_MAX_UNCERTAINTY_LENGTH,
+            }, {
+                type: "null",
+            }],
         },
     },
 };
@@ -148,7 +152,10 @@ function parseModelFileChangeReport(turn: Turn): ModelFileChangeReport {
         case "interrupted":
             throw new AgentFileChangeReportError("cancelled", "The audit turn was interrupted");
         case "failed":
-            throw new AgentFileChangeReportError("providerError", "The audit turn failed");
+            throw new AgentFileChangeReportError(
+                "providerError",
+                `The audit turn failed${turn.error?.message ? `: ${turn.error.message}` : ""}`,
+            );
         case "inProgress":
             throw new AgentFileChangeReportError("notReported", "The audit turn did not complete");
         case "completed":
@@ -183,10 +190,10 @@ function parseModelFileChangeReport(turn: Turn): ModelFileChangeReport {
     if (!Array.isArray(paths)
         || !paths.every((item): item is string => typeof item === "string")
         || typeof complete !== "boolean"
-        || (uncertainty !== undefined && typeof uncertainty !== "string")) {
+        || (uncertainty !== undefined && uncertainty !== null && typeof uncertainty !== "string")) {
         throw new AgentFileChangeReportError("invalidOutput", "The audit turn returned invalid fields");
     }
-    const normalizedUncertainty = uncertainty?.trim();
+    const normalizedUncertainty = typeof uncertainty === "string" ? uncertainty.trim() : undefined;
     if (normalizedUncertainty !== undefined
         && normalizedUncertainty.length > AGENT_FILE_CHANGE_REPORT_MAX_UNCERTAINTY_LENGTH) {
         throw new AgentFileChangeReportError("invalidOutput", "The audit turn returned oversized uncertainty");

--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -924,22 +924,9 @@ export class CodexAcpClient {
             });
             const outcome = await budget.wait(turnPromise);
             auditTurnCompleted = true;
-            const thread = await budget.wait(this.codexClient.threadRead({
-                threadId: forkThreadId,
-                includeTurns: true,
-            }));
-            const completedTurn = thread.thread.turns.find(
-                turn => turn.id === outcome.turn.id,
-            );
-            if (completedTurn === undefined) {
-                throw new AgentFileChangeReportError(
-                    "notReported",
-                    "The completed audit turn was not present in thread history",
-                );
-            }
             return createReportedAgentFileChangeReport(
                 params.requestId,
-                completedTurn,
+                outcome.turn,
                 params.workspace,
             );
         } catch (error) {
@@ -956,7 +943,7 @@ export class CodexAcpClient {
                 return createUnavailableAgentFileChangeReport(params.requestId, error.reason);
             }
             if (error instanceof AgentFileChangeReportError) {
-                logger.log("Agent file-change report unavailable", {reason: error.reason});
+                logger.error("Agent file-change report unavailable", error);
                 return createUnavailableAgentFileChangeReport(params.requestId, error.reason);
             }
             logger.error("Agent file-change report failed", error);

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -26,7 +26,12 @@ class Logger {
     }
 
     error(message: string, err: unknown) {
-        this.log(`[SYSTEM_ERROR] ${message}`, {exception: this.formatError(err)});
+        const formattedError = this.formatError(err);
+        if (!this.logFilePath) {
+            console.error(`[SYSTEM_ERROR] ${message}: ${formattedError}`);
+            return;
+        }
+        this.log(`[SYSTEM_ERROR] ${message}`, {exception: formattedError});
     }
 
     log(message: string, context?: LogContext) {

--- a/src/__tests__/AgentFileChangeReport.test.ts
+++ b/src/__tests__/AgentFileChangeReport.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import {describe, expect, it} from "vitest";
 import {
+    AGENT_FILE_CHANGE_REPORT_OUTPUT_SCHEMA,
     AGENT_FILE_CHANGE_REPORT_MAX_PATH_LENGTH,
     AGENT_FILE_CHANGE_REPORT_MAX_TOTAL_BYTES,
     AgentFileChangeReportError,
@@ -31,6 +32,17 @@ function completedReport(value: unknown): Turn {
 }
 
 describe("agent file-change report", () => {
+    it("uses a strict output schema with nullable uncertainty", () => {
+        expect(AGENT_FILE_CHANGE_REPORT_OUTPUT_SCHEMA).toMatchObject({
+            required: ["paths", "complete", "uncertainty"],
+            properties: {
+                uncertainty: {
+                    anyOf: [{type: "string"}, {type: "null"}],
+                },
+            },
+        });
+    });
+
     it("accepts only a versioned request with a bounded opaque id", () => {
         expect(parseAgentFileChangeReportRequest({
             jetbrains: {air: {agentFileChangeReportRequest: {version: 1, requestId: "turn.42:audit-1"}}},
@@ -78,6 +90,39 @@ describe("agent file-change report", () => {
             truncated: true,
             uncertainty: "generator output may be incomplete",
         });
+    });
+
+    it("treats null uncertainty as absent and reports an empty file list", () => {
+        const report = createReportedAgentFileChangeReport(
+            "request-empty",
+            completedReport({paths: [], complete: true, uncertainty: null}),
+            {cwd: "/repo", additionalDirectories: []},
+        );
+
+        expect(report).toEqual({
+            version: 1,
+            requestId: "request-empty",
+            status: "reported",
+            paths: [],
+            declaredComplete: true,
+            truncated: false,
+        });
+    });
+
+    it("preserves the provider error from a failed audit turn", () => {
+        const turn = completedReport({});
+        turn.status = "failed";
+        turn.error = {
+            message: "invalid_json_schema: missing uncertainty",
+            codexErrorInfo: null,
+            additionalDetails: null,
+        };
+
+        expect(() => createReportedAgentFileChangeReport(
+            "request-failed",
+            turn,
+            {cwd: "/repo", additionalDirectories: []},
+        )).toThrow("The audit turn failed: invalid_json_schema: missing uncertainty");
     });
 
     it("deduplicates Windows paths case-insensitively on a non-Windows host", () => {

--- a/src/__tests__/CodexACPAgent/agent-file-change-report.test.ts
+++ b/src/__tests__/CodexACPAgent/agent-file-change-report.test.ts
@@ -11,9 +11,9 @@ import {
     AGENT_FILE_CHANGE_REPORT_TIMEOUT_MS,
 } from "../../AgentFileChangeReport";
 import {CodexCommands} from "../../CodexCommands";
+import {logger} from "../../Logger";
 import type {
     ThreadForkResponse,
-    ThreadReadResponse,
     Turn,
     TurnCompletedNotification,
 } from "../../app-server/v2";
@@ -38,10 +38,6 @@ function createTurn(
 
 function createForkResponse(threadId: string): ThreadForkResponse {
     return {thread: {id: threadId}} as ThreadForkResponse;
-}
-
-function createThreadReadResponse(threadId: string, turns: Turn[]): ThreadReadResponse {
-    return {thread: {id: threadId, turns}} as ThreadReadResponse;
 }
 
 function promptWithFileChangeReport(
@@ -150,21 +146,20 @@ describe("agent file-change report lifecycle", () => {
             });
             return {
                 threadId: "audit-thread",
-                turn: createTurn("audit-turn", "completed"),
+                turn: createTurn("audit-turn", "completed", [{
+                    type: "agentMessage",
+                    id: "audit-message",
+                    text: JSON.stringify({
+                        paths: ["src/Main.kt", "/generated/output.txt"],
+                        complete: true,
+                        uncertainty: null,
+                    }),
+                    phase: "final_answer",
+                    memoryCitation: null,
+                }], "full"),
             };
         });
-        vi.spyOn(appServer, "threadRead").mockResolvedValue(createThreadReadResponse("audit-thread", [
-            createTurn("audit-turn", "completed", [{
-                type: "agentMessage",
-                id: "audit-message",
-                text: JSON.stringify({
-                    paths: ["src/Main.kt", "/generated/output.txt"],
-                    complete: true,
-                }),
-                phase: "final_answer",
-                memoryCitation: null,
-            }], "full"),
-        ]));
+        const threadRead = vi.spyOn(appServer, "threadRead");
         const unsubscribe = vi.spyOn(appServer, "threadUnsubscribe")
             .mockResolvedValue({status: "unsubscribed"});
 
@@ -198,10 +193,7 @@ describe("agent file-change report lifecycle", () => {
             summary: "none",
             outputSchema: AGENT_FILE_CHANGE_REPORT_OUTPUT_SCHEMA,
         });
-        expect(appServer.threadRead).toHaveBeenCalledWith({
-            threadId: "audit-thread",
-            includeTurns: true,
-        });
+        expect(threadRead).not.toHaveBeenCalled();
         expect(unsubscribe).toHaveBeenCalledWith({threadId: "audit-thread"});
 
         const acpEvents = fixture.getAcpConnectionEvents([]);
@@ -466,33 +458,42 @@ describe("agent file-change report lifecycle", () => {
         });
     });
 
-    it("bounds a stuck thread read with the same audit deadline", async () => {
-        vi.useFakeTimers();
+    it("reports a failed audit turn with the provider error without failing the main prompt", async () => {
         const {fixture, sessionState, turnStart, awaitTurnCompleted} = await setupMainPrompt();
         const appServer = fixture.getCodexAppServerClient();
         vi.spyOn(appServer, "threadFork").mockResolvedValue(createForkResponse("audit-thread"));
         turnStart.mockResolvedValueOnce({turn: createTurn("audit-turn", "inProgress")});
+        const failedTurn = createTurn("audit-turn", "failed");
+        failedTurn.error = {
+            message: "invalid_json_schema: missing uncertainty",
+            codexErrorInfo: null,
+            additionalDetails: null,
+        };
         awaitTurnCompleted.mockResolvedValueOnce({
             threadId: "audit-thread",
-            turn: createTurn("audit-turn", "completed"),
+            turn: failedTurn,
         });
-        const read = vi.spyOn(appServer, "threadRead").mockReturnValue(new Promise(() => {}));
-        vi.spyOn(appServer, "threadUnsubscribe").mockReturnValue(new Promise(() => {}));
+        const read = vi.spyOn(appServer, "threadRead");
+        vi.spyOn(appServer, "threadUnsubscribe").mockResolvedValue({status: "unsubscribed"});
+        const logError = vi.spyOn(logger, "error").mockImplementation(() => {});
 
-        const prompt = fixture.getCodexAcpAgent().prompt(
+        await expect(fixture.getCodexAcpAgent().prompt(
             promptWithFileChangeReport(sessionState.sessionId, "request-read-timeout"),
+        )).resolves.toMatchObject({stopReason: "end_turn"});
+        expect(read).not.toHaveBeenCalled();
+        expect(logError).toHaveBeenCalledWith(
+            "Agent file-change report unavailable",
+            expect.objectContaining({
+                reason: "providerError",
+                message: "The audit turn failed: invalid_json_schema: missing uncertainty",
+            }),
         );
-        await vi.advanceTimersByTimeAsync(0);
-        expect(read).toHaveBeenCalledOnce();
-        await vi.advanceTimersByTimeAsync(AGENT_FILE_CHANGE_REPORT_TIMEOUT_MS);
-
-        await expect(prompt).resolves.toMatchObject({stopReason: "end_turn"});
         expect(reportedUpdates(fixture)).toHaveLength(1);
         expect(reportedUpdates(fixture)[0]).toMatchObject({
             _meta: {jetbrains: {air: {agentFileChangeReport: {
                 requestId: "request-read-timeout",
                 status: "unavailable",
-                reason: "timeout",
+                reason: "providerError",
             }}}},
         });
     });
@@ -504,17 +505,15 @@ describe("agent file-change report lifecycle", () => {
         turnStart.mockResolvedValueOnce({turn: createTurn("audit-turn", "inProgress")});
         awaitTurnCompleted.mockResolvedValueOnce({
             threadId: "audit-thread",
-            turn: createTurn("audit-turn", "completed"),
-        });
-        vi.spyOn(appServer, "threadRead").mockResolvedValue(createThreadReadResponse("audit-thread", [
-            createTurn("audit-turn", "completed", [{
+            turn: createTurn("audit-turn", "completed", [{
                 type: "agentMessage",
                 id: "audit-message",
                 text: "not JSON",
                 phase: "final_answer",
                 memoryCitation: null,
             }], "full"),
-        ]));
+        });
+        const threadRead = vi.spyOn(appServer, "threadRead");
         vi.spyOn(appServer, "threadUnsubscribe").mockResolvedValue({status: "unsubscribed"});
 
         await expect(fixture.getCodexAcpAgent().prompt({
@@ -528,6 +527,8 @@ describe("agent file-change report lifecycle", () => {
                 },
             },
         })).resolves.toMatchObject({stopReason: "end_turn"});
+
+        expect(threadRead).not.toHaveBeenCalled();
 
         expect(fixture.getAcpConnectionEvents([])).toEqual([{
             method: "sessionUpdate",


### PR DESCRIPTION
## Summary

- make the AIR file-change audit output schema valid for strict structured output
- consume the completed audit turn directly instead of reading ephemeral thread history
- preserve provider error details in diagnostics while keeping the safe ACP response
- cover nullable uncertainty, empty reports, failed audits, request correlation, and no thread/read calls
- document the AIR file-change report extension

## Verification

- `npm run typecheck`
- `npm test` — 459 passed, 28 skipped
- live Codex app-server check returned `status: reported`, `paths: []`, and the original request ID