### PR TITLE
fix: expose web search results as resource links

### DIFF
--- a/src/CodexToolCallMapper.ts
+++ b/src/CodexToolCallMapper.ts
@@ -395,13 +395,60 @@ export function createWebSearchStartUpdate(
 export function createWebSearchCompleteUpdate(
     item: WebSearchItem
 ): UpdateSessionEvent {
+    const content = createWebSearchContent(item.results);
     return {
         sessionUpdate: "tool_call_update",
         toolCallId: item.id,
         title: formatWebSearchTitle(item),
         status: "completed",
         rawInput: createWebSearchRawInput(item),
+        ...(content.length > 0 ? {content} : {}),
     };
+}
+
+function createWebSearchContent(results: WebSearchItem["results"]): ToolCallContent[] {
+    const sources = new Map<string, {uri: string; canonicalUri: string; title?: string}>();
+    const conflicts = new Set<string>();
+
+    for (const result of results ?? []) {
+        if (typeof result !== "object" || result === null || Array.isArray(result)) continue;
+        if (result["type"] !== "text_result") continue;
+
+        const name = typeof result["ref_id"] === "string" ? result["ref_id"] : "";
+        const uri = typeof result["url"] === "string" ? result["url"] : "";
+        if (name.trim().length === 0 || uri.trim().length === 0 || conflicts.has(name)) continue;
+
+        let canonicalUri: string;
+        try {
+            const parsed = new URL(uri);
+            if (parsed.protocol !== "http:" && parsed.protocol !== "https:") continue;
+            canonicalUri = parsed.href;
+        } catch {
+            continue;
+        }
+
+        const title = typeof result["title"] === "string" && result["title"].trim().length > 0
+            ? result["title"]
+            : undefined;
+        const previous = sources.get(name);
+        if (previous && previous.canonicalUri !== canonicalUri) {
+            sources.delete(name);
+            conflicts.add(name);
+            continue;
+        }
+        if (previous) {
+            if (!previous.title && title) sources.set(name, {...previous, title});
+            continue;
+        }
+        sources.set(name, {uri, canonicalUri, ...(title ? {title} : {})});
+    }
+
+    return Array.from(sources, ([name, source]) => createContent({
+        type: "resource_link",
+        name,
+        uri: source.uri,
+        ...(source.title ? {title: source.title} : {}),
+    }));
 }
 
 function createWebSearchRawInput(item: WebSearchItem): Record<string, JsonValue> {

--- a/src/__tests__/CodexACPAgent/data/web-search-start-and-complete.json
+++ b/src/__tests__/CodexACPAgent/data/web-search-start-and-complete.json
@@ -42,7 +42,26 @@
             "query": "agent client protocol",
             "queries": null
           }
-        }
+        },
+        "content": [
+          {
+            "type": "content",
+            "content": {
+              "type": "resource_link",
+              "name": "turn0search0",
+              "uri": "https://agentclientprotocol.com/",
+              "title": "Agent Client Protocol"
+            }
+          },
+          {
+            "type": "content",
+            "content": {
+              "type": "resource_link",
+              "name": "turn0search1",
+              "uri": "https://example.com/source"
+            }
+          }
+        ]
       }
     }
   ]

--- a/src/__tests__/CodexACPAgent/web-search-events.test.ts
+++ b/src/__tests__/CodexACPAgent/web-search-events.test.ts
@@ -24,7 +24,7 @@ describe("CodexEventHandler - web search events", () => {
         agentMode: AgentMode.DEFAULT_AGENT_MODE
     });
 
-    it("maps web search start and completion to a search tool call", async () => {
+    it("maps web search results to resource links", async () => {
         const notifications: ServerNotification[] = [
             {
                 method: "item/started",
@@ -55,7 +55,44 @@ describe("CodexEventHandler - web search events", () => {
                         type: "webSearch",
                         id: "web-search-1",
                         query: "agent client protocol",
-                        results: null,
+                        results: [
+                            {
+                                type: "text_result",
+                                ref_id: "turn0search0",
+                                url: "https://agentclientprotocol.com/",
+                                title: "Agent Client Protocol",
+                            },
+                            {
+                                type: "text_result",
+                                ref_id: "turn0search1",
+                                url: "https://example.com/source",
+                            },
+                            {
+                                type: "image_result",
+                                ref_id: "turn0image0",
+                                url: "https://example.com/image.png",
+                            },
+                            {
+                                type: "text_result",
+                                ref_id: "",
+                                url: "https://example.com/missing-ref",
+                            },
+                            {
+                                type: "text_result",
+                                ref_id: "turn0search2",
+                                url: "javascript:alert(1)",
+                            },
+                            {
+                                type: "text_result",
+                                ref_id: "turn0search3",
+                                url: "https://example.com/first",
+                            },
+                            {
+                                type: "text_result",
+                                ref_id: "turn0search3",
+                                url: "https://example.com/conflict",
+                            },
+                        ],
                         action: {
                             type: "search",
                             query: "agent client protocol",
@@ -68,7 +105,7 @@ describe("CodexEventHandler - web search events", () => {
 
         await setupPromptAndSendNotifications(mockFixture, sessionId, sessionState, notifications);
 
-        await expect(mockFixture.getAcpConnectionDump([])).toMatchFileSnapshot(
+        await expect(`${mockFixture.getAcpConnectionDump([])}\n`).toMatchFileSnapshot(
             "data/web-search-start-and-complete.json"
         );
     });


### PR DESCRIPTION
## Summary

- project valid Codex `WebSearchItem.results` text results as ACP `resource_link` tool content
- preserve reference IDs for inline citation resolution while omitting opaque and invalid results
- reject conflicting URLs for the same reference ID

## Testing

- `npm test -- src/__tests__/CodexACPAgent/web-search-events.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run build`

