### PR TITLE
fix: wait for MCP server startup before starting an agent turn

### DIFF
--- a/readme-dev.md
+++ b/readme-dev.md
@@ -12,6 +12,7 @@ Set `CODEX_PATH` to run a different Codex binary; versions other than the one sp
 - `INITIAL_AGENT_MODE` - initial mode id: `read-only`, `agent`, or `agent-full-access`.
 - `NO_BROWSER` - hide browser-based ChatGPT auth when set.
 - `APP_SERVER_LOGS` - directory for adapter logs.
+- `MCP_STARTUP_PROMPT_TIMEOUT_MS` - how long a prompt waits for the session's MCP servers to finish starting before the turn is started without them (default `30000`).
 
 ### Quick start
 

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -184,6 +184,8 @@ export interface SessionFailure {
 
 const CODEX_PROCESS_EXITED_ERROR_CODE = 1001;
 
+const DEFAULT_MCP_STARTUP_PROMPT_TIMEOUT_MS = 30_000;
+
 function clientSupportsTypedSessionFailures(capabilities: acp.ClientCapabilities | null): boolean {
     return clientSupportsAirCapability(capabilities, AIR_SESSION_FAILURE_KEY);
 }
@@ -200,6 +202,8 @@ interface ActiveAuthState {
 interface PendingMcpStartupSession {
     requestedServers: Set<string>;
     afterVersion: number;
+    settled: Promise<void>;
+    gateExpired: boolean;
 }
 
 interface PendingTurnStart {
@@ -213,6 +217,7 @@ interface ActivePrompt {
     cancelSignal: Promise<null>;
     signal: AbortSignal;
     currentTurn: { threadId: string, turnId: string } | null;
+    awaitingMcpStartup: boolean;
     requestCancel: () => void;
     requestClose: () => void;
     complete: () => void;
@@ -658,11 +663,7 @@ export class CodexAcpServer {
 
         const canPublishSessionUpdates = operation !== "fork";
         if (canPublishSessionUpdates && requestedMcpServers.length > 0 && mcpServerStartupVersion !== null) {
-            this.pendingMcpStartupSessions.set(sessionId, {
-                requestedServers: new Set(getRequestedMcpServerNames(requestedMcpServers)),
-                afterVersion: mcpServerStartupVersion,
-            });
-            this.publishMcpStartupStatusAsync(sessionId);
+            this.trackMcpServerStartup(sessionId, requestedMcpServers, mcpServerStartupVersion);
         }
 
         if (canPublishSessionUpdates) {
@@ -1708,11 +1709,7 @@ export class CodexAcpServer {
         subscribed = false;
 
         if (requestedMcpServers.length > 0 && mcpServerStartupVersion !== null) {
-            this.pendingMcpStartupSessions.set(sessionId, {
-                requestedServers: new Set(getRequestedMcpServerNames(requestedMcpServers)),
-                afterVersion: mcpServerStartupVersion,
-            });
-            this.publishMcpStartupStatusAsync(sessionId);
+            this.trackMcpServerStartup(sessionId, requestedMcpServers, mcpServerStartupVersion);
         }
 
         await this.publishAvailableCommands(sessionState, requestedSessionGeneration);
@@ -2152,16 +2149,73 @@ export class CodexAcpServer {
         return [];
     }
 
-    private publishMcpStartupStatusAsync(sessionId: string): void {
-        void this.doPublishMcpStartupStatus(sessionId);
+    private trackMcpServerStartup(
+        sessionId: string,
+        requestedMcpServers: Array<acp.McpServer>,
+        afterVersion: number,
+    ): void {
+        const pendingStartup: PendingMcpStartupSession = {
+            requestedServers: new Set(getRequestedMcpServerNames(requestedMcpServers)),
+            afterVersion: afterVersion,
+            settled: Promise.resolve(),
+            gateExpired: false,
+        };
+        this.pendingMcpStartupSessions.set(sessionId, pendingStartup);
+        pendingStartup.settled = this.doPublishMcpStartupStatus(sessionId, pendingStartup);
     }
 
-    private async doPublishMcpStartupStatus(sessionId: string): Promise<void> {
+    /**
+     * Waits until the session's MCP servers finished starting, so a turn never runs with tools
+     * Codex has not registered yet. Returns false when the prompt was cancelled while waiting.
+     */
+    private async awaitSessionMcpStartup(sessionId: string, activePrompt: ActivePrompt): Promise<boolean> {
         const pendingStartup = this.pendingMcpStartupSessions.get(sessionId);
-        if (!pendingStartup) {
-            return;
+        if (!pendingStartup || pendingStartup.gateExpired) {
+            return true;
         }
 
+        const requestedServers = Array.from(pendingStartup.requestedServers);
+        logger.log("Waiting for MCP server startup before starting a turn", {sessionId, servers: requestedServers});
+        const timeoutMs = getMcpStartupPromptTimeoutMs();
+        let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+        const expired = new Promise<"expired">((resolve) => {
+            timeoutHandle = setTimeout(() => resolve("expired"), timeoutMs);
+            timeoutHandle.unref?.();
+        });
+        activePrompt.awaitingMcpStartup = true;
+        try {
+            const outcome = await Promise.race([
+                pendingStartup.settled.then(() => "started" as const),
+                activePrompt.cancelSignal.then(() => "cancelled" as const),
+                expired,
+            ]);
+            if (outcome === "cancelled") {
+                logger.log("Prompt cancelled while waiting for MCP server startup", {sessionId});
+                return false;
+            }
+            if (outcome === "expired") {
+                // Codex may never report a post-startup status for a server. Do not block prompts
+                // forever on it: run the turn without those tools and stop waiting on later prompts.
+                pendingStartup.gateExpired = true;
+                logger.log("MCP server startup timed out, starting the turn without those tools", {
+                    sessionId,
+                    timeoutMs,
+                    servers: requestedServers,
+                });
+                return true;
+            }
+            logger.log("MCP server startup completed, starting the turn", {sessionId});
+            return true;
+        } finally {
+            activePrompt.awaitingMcpStartup = false;
+            clearTimeout(timeoutHandle);
+        }
+    }
+
+    private async doPublishMcpStartupStatus(
+        sessionId: string,
+        pendingStartup: PendingMcpStartupSession,
+    ): Promise<void> {
         try {
             const mcpStartup = await this.runWithProcessCheck(() =>
                 this.codexAcpClient.awaitMcpServerStartup(
@@ -2228,6 +2282,7 @@ export class CodexAcpServer {
             cancelSignal,
             signal: abortController.signal,
             currentTurn: null,
+            awaitingMcpStartup: false,
             requestCancel: () => {
                 if (abortController.signal.aborted) {
                     return;
@@ -2521,6 +2576,15 @@ export class CodexAcpServer {
 
             if (activePrompt.signal.aborted) {
                 return cancelledPromptResponse();
+            }
+
+            if (this.availableCommands.startsAgentTurn(params.prompt)) {
+                if (!await this.awaitSessionMcpStartup(params.sessionId, activePrompt)) {
+                    return cancelledPromptResponse();
+                }
+                if (this.sessionIsClosing(params.sessionId)) {
+                    return cancelledPromptResponse();
+                }
             }
 
             const commandPromise = this.availableCommands.tryHandleCommand(params.prompt, sessionState, {
@@ -3007,6 +3071,14 @@ export class CodexAcpServer {
             return;
         }
 
+        // No turn exists yet while the prompt waits for MCP startup, so there is nothing to interrupt.
+        const activePrompt = this.activePrompts.get(params.sessionId);
+        if (activePrompt?.awaitingMcpStartup) {
+            logger.log("Cancel requested while waiting for MCP server startup", {sessionId: params.sessionId});
+            activePrompt.requestCancel();
+            return;
+        }
+
         // After turnInterrupt(), Codex will send turn/completed, which naturally completes awaitTurnCompleted().
         await this.interruptSessionTurn(sessionState, "Cancel", false);
     }
@@ -3097,4 +3169,16 @@ function historyUpdateContentKey(update: UpdateSessionEvent): string | null {
 
 function getRequestedMcpServerNames(mcpServers: Array<acp.McpServer>): Array<string> {
     return Array.from(new Set(mcpServers.map(server => sanitizeMcpServerName(server.name))));
+}
+
+function getMcpStartupPromptTimeoutMs(): number {
+    const value = process.env["MCP_STARTUP_PROMPT_TIMEOUT_MS"]?.trim();
+    if (!value) {
+        return DEFAULT_MCP_STARTUP_PROMPT_TIMEOUT_MS;
+    }
+    const configured = Number(value);
+    if (!Number.isFinite(configured) || configured < 0) {
+        return DEFAULT_MCP_STARTUP_PROMPT_TIMEOUT_MS;
+    }
+    return configured;
 }

--- a/src/CodexCommands.ts
+++ b/src/CodexCommands.ts
@@ -202,6 +202,36 @@ export class CodexCommands {
         };
     }
 
+    /**
+     * Whether this prompt makes Codex run an agent turn that can call MCP tools.
+     * Keep the switch in sync with {@link tryHandleCommand}.
+     */
+    startsAgentTurn(prompt: acp.ContentBlock[]): boolean {
+        const command = this.parseCommand(prompt);
+        if (command === null) return true;
+        if (command.name.startsWith("$")) return true;
+
+        switch (command.name) {
+            case "plan":
+            case "status":
+            case "skills":
+            case "mcp":
+            case "rename":
+            case "logout":
+            case "compact":
+                return false;
+            case "review":
+            case "review-branch":
+            case "review-commit":
+            // "/goal pause" and "/goal clear" do not start a turn, but the other forms do.
+            case "goal":
+                return true;
+            default:
+                // Unrecognized commands are forwarded to Codex as raw prompts.
+                return true;
+        }
+    }
+
     async tryHandleCommand(
         prompt: acp.ContentBlock[],
         sessionState: SessionState,

--- a/src/CodexCommands.ts
+++ b/src/CodexCommands.ts
@@ -223,9 +223,12 @@ export class CodexCommands {
             case "review":
             case "review-branch":
             case "review-commit":
-            // "/goal pause" and "/goal clear" do not start a turn, but the other forms do.
-            case "goal":
                 return true;
+            // "/goal pause", "/goal clear", and "/goal" (usage) do not start a turn, but the other forms do.
+            case "goal": {
+                const arg = command.rest.trim().toLowerCase();
+                return !(arg.length === 0 || arg === "pause" || arg === "clear" || arg.length > 4000);
+            }
             default:
                 // Unrecognized commands are forwarded to Codex as raw prompts.
                 return true;

--- a/src/__tests__/CodexACPAgent/mcp-startup-gate.test.ts
+++ b/src/__tests__/CodexACPAgent/mcp-startup-gate.test.ts
@@ -1,0 +1,255 @@
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {
+    createCodexMockTestFixture,
+    createTestModel,
+    mockPromptTurn,
+    type CodexMockTestFixture,
+} from "../acp-test-utils";
+import type {CodexAcpServer} from "../../CodexAcpServer";
+import type {CodexAcpClient} from "../../CodexAcpClient";
+import type {McpStartupResult} from "../../CodexAppServerClient";
+import type {McpServer} from "@agentclientprotocol/sdk";
+
+const sessionId = "session-id";
+
+const mcpServer: McpServer = {
+    name: "test-mcp",
+    command: "npx",
+    args: ["test-mcp"],
+    env: [],
+};
+
+describe("MCP startup prompt gate", () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it("does not start a turn before the session MCP servers are ready", async () => {
+        const mcpStartup = deferred<McpStartupResult>();
+        const {fixture, codexAcpAgent, codexAcpClient} = await createSession({
+            mcpServers: [mcpServer],
+            configure: ({codexAcpClient}) => {
+                vi.spyOn(codexAcpClient, "awaitMcpServerStartup").mockReturnValue(mcpStartup.promise);
+            },
+        });
+        await vi.waitFor(() => {
+            expect(codexAcpClient.awaitMcpServerStartup).toHaveBeenCalledWith(["test-mcp"], expect.any(Number));
+        });
+
+        const turnStart = mockPromptTurn(fixture, sessionId);
+        const promptPromise = codexAcpAgent.prompt({
+            sessionId,
+            prompt: [{type: "text", text: "use the mcp tool"}],
+        });
+        await waitForMicrotasks();
+
+        expect(turnStart).not.toHaveBeenCalled();
+
+        mcpStartup.resolve({ready: ["test-mcp"], failed: [], cancelled: []});
+
+        await expect(promptPromise).resolves.toMatchObject({stopReason: "end_turn"});
+        expect(turnStart).toHaveBeenCalledTimes(1);
+    });
+
+    it("starts the turn immediately when the session has no MCP servers", async () => {
+        const {fixture, codexAcpAgent} = await createSession();
+
+        const turnStart = mockPromptTurn(fixture, sessionId);
+        const promptPromise = codexAcpAgent.prompt({
+            sessionId,
+            prompt: [{type: "text", text: "no mcp needed"}],
+        });
+        await waitForMicrotasks();
+
+        expect(turnStart).toHaveBeenCalledTimes(1);
+        await expect(promptPromise).resolves.toMatchObject({stopReason: "end_turn"});
+    });
+
+    it("waits only for the first prompt once startup completed", async () => {
+        const mcpStartup = deferred<McpStartupResult>();
+        const {fixture, codexAcpAgent, codexAcpClient} = await createSession({
+            mcpServers: [mcpServer],
+            configure: ({codexAcpClient}) => {
+                vi.spyOn(codexAcpClient, "awaitMcpServerStartup").mockReturnValue(mcpStartup.promise);
+            },
+        });
+        await vi.waitFor(() => {
+            expect(codexAcpClient.awaitMcpServerStartup).toHaveBeenCalledTimes(1);
+        });
+        mcpStartup.resolve({ready: ["test-mcp"], failed: [], cancelled: []});
+
+        const turnStart = mockPromptTurn(fixture, sessionId);
+        await codexAcpAgent.prompt({sessionId, prompt: [{type: "text", text: "first"}]});
+
+        const secondPrompt = codexAcpAgent.prompt({sessionId, prompt: [{type: "text", text: "second"}]});
+        await waitForMicrotasks();
+
+        expect(turnStart).toHaveBeenCalledTimes(2);
+        await expect(secondPrompt).resolves.toMatchObject({stopReason: "end_turn"});
+    });
+
+    it("does not delay commands the adapter answers itself", async () => {
+        const mcpStartup = deferred<McpStartupResult>();
+        const {fixture, codexAcpAgent, codexAcpClient} = await createSession({
+            mcpServers: [mcpServer],
+            configure: ({codexAcpClient}) => {
+                vi.spyOn(codexAcpClient, "awaitMcpServerStartup").mockReturnValue(mcpStartup.promise);
+            },
+        });
+        await vi.waitFor(() => {
+            expect(codexAcpClient.awaitMcpServerStartup).toHaveBeenCalledTimes(1);
+        });
+
+        // Startup is still pending: a local command must answer without waiting for it.
+        await expect(codexAcpAgent.prompt({
+            sessionId,
+            prompt: [{type: "text", text: "/status"}],
+        })).resolves.toMatchObject({stopReason: "end_turn"});
+        expect(fixture.getAcpConnectionDump([])).toContain("Model:");
+
+        mcpStartup.resolve({ready: ["test-mcp"], failed: [], cancelled: []});
+    });
+
+    it("waits for MCP server startup before a command starts a turn", async () => {
+        const mcpStartup = deferred<McpStartupResult>();
+        const {codexAcpAgent, codexAcpClient} = await createSession({
+            mcpServers: [mcpServer],
+            configure: ({codexAcpClient}) => {
+                vi.spyOn(codexAcpClient, "awaitMcpServerStartup").mockReturnValue(mcpStartup.promise);
+            },
+        });
+        await vi.waitFor(() => {
+            expect(codexAcpClient.awaitMcpServerStartup).toHaveBeenCalledTimes(1);
+        });
+
+        const runReview = vi.spyOn(codexAcpClient, "runReview").mockResolvedValue({
+            threadId: sessionId,
+            turn: {
+                id: "review-turn",
+                items: [],
+                itemsView: "notLoaded",
+                status: "completed",
+                error: null,
+                startedAt: null,
+                completedAt: null,
+                durationMs: null,
+            },
+        });
+        const promptPromise = codexAcpAgent.prompt({
+            sessionId,
+            prompt: [{type: "text", text: "/review"}],
+        });
+        await waitForMicrotasks();
+
+        expect(runReview).not.toHaveBeenCalled();
+
+        mcpStartup.resolve({ready: ["test-mcp"], failed: [], cancelled: []});
+
+        await expect(promptPromise).resolves.toMatchObject({stopReason: "end_turn"});
+        expect(runReview).toHaveBeenCalledTimes(1);
+    });
+
+    it("cancels a prompt that is waiting for MCP server startup", async () => {
+        const mcpStartup = deferred<McpStartupResult>();
+        const {fixture, codexAcpAgent, codexAcpClient} = await createSession({
+            mcpServers: [mcpServer],
+            configure: ({codexAcpClient}) => {
+                vi.spyOn(codexAcpClient, "awaitMcpServerStartup").mockReturnValue(mcpStartup.promise);
+            },
+        });
+        await vi.waitFor(() => {
+            expect(codexAcpClient.awaitMcpServerStartup).toHaveBeenCalledTimes(1);
+        });
+
+        const turnStart = mockPromptTurn(fixture, sessionId);
+        const promptPromise = codexAcpAgent.prompt({
+            sessionId,
+            prompt: [{type: "text", text: "cancel me"}],
+        });
+        await waitForMicrotasks();
+
+        await codexAcpAgent.cancel({sessionId});
+
+        await expect(promptPromise).resolves.toMatchObject({stopReason: "cancelled"});
+        expect(turnStart).not.toHaveBeenCalled();
+
+        mcpStartup.resolve({ready: ["test-mcp"], failed: [], cancelled: []});
+    });
+
+    it("starts the turn when MCP startup never reports back", async () => {
+        vi.stubEnv("MCP_STARTUP_PROMPT_TIMEOUT_MS", "10");
+        const neverSettles = new Promise<McpStartupResult>(() => {});
+        const {fixture, codexAcpAgent, codexAcpClient} = await createSession({
+            mcpServers: [mcpServer],
+            configure: ({codexAcpClient}) => {
+                vi.spyOn(codexAcpClient, "awaitMcpServerStartup").mockReturnValue(neverSettles);
+            },
+        });
+        await vi.waitFor(() => {
+            expect(codexAcpClient.awaitMcpServerStartup).toHaveBeenCalledTimes(1);
+        });
+
+        const turnStart = mockPromptTurn(fixture, sessionId);
+        await expect(codexAcpAgent.prompt({
+            sessionId,
+            prompt: [{type: "text", text: "first"}],
+        })).resolves.toMatchObject({stopReason: "end_turn"});
+
+        // The expired gate must not delay any later prompt again.
+        vi.stubEnv("MCP_STARTUP_PROMPT_TIMEOUT_MS", "100000");
+        const secondPrompt = codexAcpAgent.prompt({sessionId, prompt: [{type: "text", text: "second"}]});
+        await waitForMicrotasks();
+
+        expect(turnStart).toHaveBeenCalledTimes(2);
+        await expect(secondPrompt).resolves.toMatchObject({stopReason: "end_turn"});
+    });
+});
+
+async function createSession(options: {
+    mcpServers?: McpServer[],
+    configure?: (params: {
+        fixture: CodexMockTestFixture,
+        codexAcpAgent: CodexAcpServer,
+        codexAcpClient: CodexAcpClient,
+    }) => void,
+} = {}): Promise<{
+    fixture: CodexMockTestFixture,
+    codexAcpAgent: CodexAcpServer,
+    codexAcpClient: CodexAcpClient,
+}> {
+    const fixture = createCodexMockTestFixture();
+    const codexAcpAgent = fixture.getCodexAcpAgent();
+    const codexAcpClient = fixture.getCodexAcpClient();
+
+    vi.spyOn(codexAcpClient, "authRequired").mockResolvedValue(false);
+    vi.spyOn(codexAcpClient, "getAccount").mockResolvedValue({account: null, requiresOpenaiAuth: false});
+    vi.spyOn(codexAcpClient, "listSkills").mockResolvedValue({data: []});
+    vi.spyOn(codexAcpClient, "newSession").mockResolvedValue({
+        sessionId,
+        currentModelId: "model-id[medium]",
+        models: [createTestModel()],
+        collaborationMode: "default",
+        currentServiceTier: null,
+        additionalDirectories: [],
+    });
+
+    options.configure?.({fixture, codexAcpAgent, codexAcpClient});
+
+    await codexAcpAgent.newSession({cwd: "/test/cwd", mcpServers: options.mcpServers ?? []});
+    fixture.clearCodexConnectionDump();
+    fixture.clearAcpConnectionDump();
+
+    return {fixture, codexAcpAgent, codexAcpClient};
+}
+
+function deferred<T>(): {promise: Promise<T>, resolve: (value: T) => void} {
+    let resolve: (value: T) => void = () => {};
+    const promise = new Promise<T>((innerResolve) => {
+        resolve = innerResolve;
+    });
+    return {promise, resolve};
+}
+
+async function waitForMicrotasks(): Promise<void> {
+    await new Promise(resolve => setTimeout(resolve, 10));
+}


### PR DESCRIPTION
## Summary

- wait for the session's MCP servers to reach a terminal startup state before dispatching a turn
- only gate prompts that actually run an agent turn; commands the adapter answers itself dispatch immediately
- bound the wait with `MCP_STARTUP_PROMPT_TIMEOUT_MS` (default 30s) and skip it on later prompts once it expires
- handle cancellation during the wait, where no turn exists yet to interrupt
- add regression coverage for the gate, the local-command bypass, cancellation, and the timeout fallback

## Root cause

`session/new` registers the session's pending MCP startup and publishes its status fire-and-forget, then returns. Nothing orders `turn/start` against that startup, so a prompt sent immediately after runs without the server's tools.

Measured against a stdio MCP server that delays `initialize` by 6s: `turn/start` goes out ~0.2s after session creation, about six seconds before the server reports `ready`, and the model has no access to the tool. Codex does not await MCP startup on the app-server path, so the adapter has to order it.

Earlier versions awaited MCP startup during session creation. That await was removed in #83 and #112 when the startup tracking was reworked, presumably for unrelated reasons.

The wait is bounded because it only settles once every requested server reports a status newer than the version snapshot taken at session start. If Codex ever reuses an already-running server without re-announcing it, no such status arrives. On timeout the turn starts without those tools rather than hanging.

## Upstream

Codex's CLI path does await MCP startup before listing tools, tracked upstream as a first-turn stall (openai/codex#19556). The app-server path we drive does not, so this change adds the ordering. openai/codex#21318 and openai/codex#29321 propose building turns from only-ready MCP tools in the CLI as well, so this gate stays necessary rather than becoming redundant if they land.

## Testing

- `npm run typecheck`
- `npm test`: 492 passed, 26 skipped
- `npm run bundle:all`: all six targets compile, and `codex-acp-x64-linux --version` runs
- verified the new tests fail without the gate (turn starts early, cancel returns `end_turn`) and that the local-command test fails if `/status` is misclassified as turn-starting

### End-to-end against a real MCP server

Setup: an ACP session configured with one stdio MCP server that sleeps 6s before answering `initialize`, and exposes a single tool returning a fixed magic string. The prompt instructs the model to call that tool and echo the string back, or to answer `NO_TOOL` if no such tool is available to it. Three runs per case, and all timings are relative to session creation.

| Branch | Prompt sent | `turn/start` | MCP `ready` | Model could use the tool |
|---|---|---:|---:|---|
| pre-fix | immediately | 0.19s | 6.2s | no (0/3) |
| pre-fix | after 20s | 20.2s | 6.2s | yes (3/3) |
| pre-fix, MCP delay removed | immediately | 0.19s | 0.19s | yes (3/3) |
| with fix | immediately | 6.21s | 6.19s | yes (3/3) |

Row 1 is the bug: the turn starts six seconds before the server is ready and the model cannot see the tool. Rows 2 and 3 are controls showing the same setup works whenever the turn happens to start after readiness. Row 4 is the fix, with the turn now starting 15ms after readiness instead of six seconds before it.