### PR TITLE
fix: report complete status usage and limits

### DIFF
--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -32,6 +32,7 @@ import {sanitizeMcpServerName} from "./McpServerName";
 import type {
     AccountLoginCompletedNotification,
     AccountUpdatedNotification,
+    GetAccountRateLimitsResponse,
     GetAccountResponse,
     ListMcpServerStatusResponse,
     McpServerOauthLoginCompletedNotification,
@@ -471,6 +472,10 @@ export class CodexAcpClient {
 
     async getAccount(): Promise<GetAccountResponse> {
         return this.codexClient.accountRead({refreshToken: false});
+    }
+
+    async getRateLimits(): Promise<GetAccountRateLimitsResponse> {
+        return this.codexClient.accountRateLimitsRead();
     }
 
     async resumeSession(request: acp.ResumeSessionRequest, onSubscribed?: () => void): Promise<SessionMetadata> {

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -2494,7 +2494,6 @@ export class CodexAcpServer {
         let promptWasCancelled = false;
         let recoverableSessionFailure = sessionState.sessionFailure;
         sessionState.currentTurnId = null;
-        sessionState.lastTokenUsage = null;
         const activePrompt = this.trackActivePrompt(params.sessionId);
         let pendingTurnStart: PendingTurnStart | null = null;
         const ensurePendingTurnStart = (): PendingTurnStart => {
@@ -2580,6 +2579,7 @@ export class CodexAcpServer {
 
             const commandPromise = this.availableCommands.tryHandleCommand(params.prompt, sessionState, {
                 onTurnStartPending: () => {
+                    sessionState.lastTokenUsage = null;
                     ensurePendingTurnStart();
                 },
                 onTurnStarted: (turnId, threadId) => {
@@ -2685,6 +2685,7 @@ export class CodexAcpServer {
                 sessionState.fastModeEnabled,
                 sessionState.currentModelSupportsFast,
             );
+            sessionState.lastTokenUsage = null;
             ensurePendingTurnStart();
             const sendPromptPromise = this.runWithProcessCheck(
                 () => this.codexAcpClient.sendPrompt(

--- a/src/CodexAppServerClient.ts
+++ b/src/CodexAppServerClient.ts
@@ -11,6 +11,7 @@ import type {
     ConfigReadParams,
     ConfigReadResponse,
     GetAccountParams,
+    GetAccountRateLimitsResponse,
     GetAccountResponse,
     ListMcpServerStatusParams,
     ListMcpServerStatusResponse,
@@ -661,6 +662,10 @@ export class CodexAppServerClient {
 
     async accountRead(params: GetAccountParams): Promise<GetAccountResponse> {
         return await this.sendRequest({ method: "account/read", params: params });
+    }
+
+    async accountRateLimitsRead(): Promise<GetAccountRateLimitsResponse> {
+        return await this.sendRequest({ method: "account/rateLimits/read", params: undefined });
     }
 
     //TODO create type-safe helper

--- a/src/CodexCommands.ts
+++ b/src/CodexCommands.ts
@@ -534,15 +534,31 @@ export class CodexCommands {
 
         if (rateLimits.individualLimit) {
             const limit = rateLimits.individualLimit;
-            const percentLeft = Math.round(limit.remainingPercent);
-            const resetDate = new Date(limit.resetsAt * 1000)
-                .toLocaleDateString("en-US", {month: "short", day: "numeric"});
-            lines.push(
-                `**${prefix}individual spend limit:** ${percentLeft}% left (${limit.used} used / ${limit.limit}; resets ${resetDate})`,
-            );
+            const used = this.formatCreditAmount(limit.used);
+            const total = this.formatCreditAmount(limit.limit);
+            if (used !== null && total !== null) {
+                const percentLeft = Math.round(Math.min(100, Math.max(0, limit.remainingPercent)));
+                const resetDate = new Date(limit.resetsAt * 1000)
+                    .toLocaleDateString("en-US", {month: "short", day: "numeric"});
+                lines.push(
+                    `**${prefix}individual spend limit:** ${percentLeft}% left (${used} of ${total} credits used; resets ${resetDate})`,
+                );
+            }
         }
 
         return lines;
+    }
+
+    private formatCreditAmount(raw: string): string | null {
+        const trimmed = raw.trim();
+        if (trimmed.length === 0) {
+            return null;
+        }
+        const value = Number(trimmed);
+        if (!Number.isFinite(value) || value < 0) {
+            return null;
+        }
+        return Math.round(value).toLocaleString("en-US");
     }
 
     private formatWindowLabel(windowDurationMins: number | null): string {

--- a/src/CodexCommands.ts
+++ b/src/CodexCommands.ts
@@ -4,7 +4,7 @@ import {ACPSessionConnection, type AcpClientConnection} from "./ACPSessionConnec
 import type {CodexAcpClient} from "./CodexAcpClient";
 import type {RateLimitSnapshot, ReviewTarget, SkillsListEntry, SkillsListParams, TurnCompletedNotification} from "./app-server/v2";
 import type {SessionState} from "./CodexAcpServer";
-import type {RateLimitsMap} from "./RateLimitsMap";
+import {createRateLimitsMap, type RateLimitsMap} from "./RateLimitsMap";
 import type {TokenCount} from "./TokenCount";
 import {logger} from "./Logger";
 import {createAgentTextMessageChunk} from "./ContentChunks";
@@ -261,6 +261,7 @@ export class CodexCommands {
                 return { handled: true, turnCompleted };
             }
             case "status": {
+                await this.refreshRateLimits(sessionState);
                 const session = new ACPSessionConnection(this.connection, sessionId);
                 const message = this.buildStatusMessage(sessionState);
                 await session.update(createAgentTextMessageChunk(message));
@@ -442,6 +443,17 @@ export class CodexCommands {
         return lines.join("  \n");
     }
 
+    private async refreshRateLimits(sessionState: SessionState): Promise<void> {
+        try {
+            const response = await this.runWithProcessCheck(() => this.codexAcpClient.getRateLimits());
+            if (response) {
+                sessionState.rateLimits = createRateLimitsMap(response);
+            }
+        } catch (err) {
+            logger.error(`Failed to refresh rate limits for session ${sessionState.sessionId}`, err);
+        }
+    }
+
     private formatAccountInfo(account: SessionState["account"]): string {
         if (!account) {
             return "not logged in";
@@ -474,10 +486,10 @@ export class CodexCommands {
             return "data not available yet";
         }
         const used = usage.totalTokens;
-        const percentLeft = Math.round(((contextWindow - used) / contextWindow) * 100);
+        const percentUsed = Math.round((used / contextWindow) * 100);
         const usedFormatted = this.formatTokenCount(used);
         const totalFormatted = this.formatTokenCount(contextWindow);
-        return `${percentLeft}% left (${usedFormatted} used / ${totalFormatted})`;
+        return `${percentUsed}% used (${usedFormatted} used / ${totalFormatted})`;
     }
 
     private formatRateLimitLines(rateLimits: RateLimitsMap | null): string[] {
@@ -518,6 +530,16 @@ export class CodexCommands {
             } else if (rateLimits.credits.balance) {
                 lines.push(`**${prefix}Credits:** ${rateLimits.credits.balance}`);
             }
+        }
+
+        if (rateLimits.individualLimit) {
+            const limit = rateLimits.individualLimit;
+            const percentLeft = Math.round(limit.remainingPercent);
+            const resetDate = new Date(limit.resetsAt * 1000)
+                .toLocaleDateString("en-US", {month: "short", day: "numeric"});
+            lines.push(
+                `**${prefix}individual spend limit:** ${percentLeft}% left (${limit.used} used / ${limit.limit}; resets ${resetDate})`,
+            );
         }
 
         return lines;

--- a/src/CodexEventHandler.ts
+++ b/src/CodexEventHandler.ts
@@ -1283,16 +1283,11 @@ export class CodexEventHandler {
         if (!this.sessionState.rateLimits) {
             this.sessionState.rateLimits = new Map();
         }
-        const explicitLimitId = params.rateLimits.limitId ?? params.rateLimits.limitName;
-        const existingEntry = explicitLimitId === null
-            ? (this.sessionState.rateLimits.size === 1
-                ? this.sessionState.rateLimits.values().next().value
-                : undefined)
-            : this.sessionState.rateLimits.get(explicitLimitId);
-        const limitId = explicitLimitId ?? existingEntry?.limitId ?? "unknown";
+        const limitId = params.rateLimits.limitId ?? "codex";
+        const existingEntry = this.sessionState.rateLimits.get(limitId);
         const snapshot = existingEntry
             ? mergeRateLimitSnapshot(existingEntry.snapshot, params.rateLimits)
-            : params.rateLimits;
+            : {...params.rateLimits, limitId};
         this.sessionState.rateLimits.set(limitId, {
             limitId: limitId,
             limitName: snapshot.limitName ?? existingEntry?.limitName ?? limitId,

--- a/src/CodexEventHandler.ts
+++ b/src/CodexEventHandler.ts
@@ -80,6 +80,7 @@ import {
 } from "./AirExtension";
 import {CodexSubagentEventRouter} from "./subagents/CodexSubagentEventRouter";
 import type {SubagentState} from "./subagents/AcpSubagents";
+import {mergeRateLimitSnapshot} from "./RateLimitsMap";
 
 export { stripShellPrefix };
 
@@ -1282,11 +1283,20 @@ export class CodexEventHandler {
         if (!this.sessionState.rateLimits) {
             this.sessionState.rateLimits = new Map();
         }
-        const limitId = params.rateLimits.limitId ?? params.rateLimits.limitName ?? "unknown";
+        const explicitLimitId = params.rateLimits.limitId ?? params.rateLimits.limitName;
+        const existingEntry = explicitLimitId === null
+            ? (this.sessionState.rateLimits.size === 1
+                ? this.sessionState.rateLimits.values().next().value
+                : undefined)
+            : this.sessionState.rateLimits.get(explicitLimitId);
+        const limitId = explicitLimitId ?? existingEntry?.limitId ?? "unknown";
+        const snapshot = existingEntry
+            ? mergeRateLimitSnapshot(existingEntry.snapshot, params.rateLimits)
+            : params.rateLimits;
         this.sessionState.rateLimits.set(limitId, {
             limitId: limitId,
-            limitName: params.rateLimits.limitName ?? limitId,
-            snapshot: params.rateLimits,
+            limitName: snapshot.limitName ?? existingEntry?.limitName ?? limitId,
+            snapshot,
         });
     }
 

--- a/src/RateLimitsMap.ts
+++ b/src/RateLimitsMap.ts
@@ -8,8 +8,8 @@ export type RateLimitEntry = {
 
 export type RateLimitsMap = Map<string, RateLimitEntry>;
 
-function rateLimitId(snapshot: RateLimitSnapshot, fallback = "unknown"): string {
-    return snapshot.limitId ?? snapshot.limitName ?? fallback;
+function rateLimitId(snapshot: RateLimitSnapshot, fallback = "codex"): string {
+    return snapshot.limitId ?? fallback;
 }
 
 export function createRateLimitsMap(response: GetAccountRateLimitsResponse): RateLimitsMap {
@@ -37,14 +37,11 @@ export function mergeRateLimitSnapshot(
     update: RateLimitSnapshot,
 ): RateLimitSnapshot {
     return {
-        limitId: update.limitId ?? previous.limitId,
-        limitName: update.limitName ?? previous.limitName,
-        primary: update.primary ?? previous.primary,
-        secondary: update.secondary ?? previous.secondary,
+        ...update,
+        limitId: update.limitId ?? "codex",
         credits: update.credits ?? previous.credits,
         individualLimit: update.individualLimit ?? previous.individualLimit,
         spendControlReached: update.spendControlReached ?? previous.spendControlReached,
         planType: update.planType ?? previous.planType,
-        rateLimitReachedType: update.rateLimitReachedType ?? previous.rateLimitReachedType,
     };
 }

--- a/src/RateLimitsMap.ts
+++ b/src/RateLimitsMap.ts
@@ -1,4 +1,4 @@
-import type {RateLimitSnapshot} from "./app-server/v2";
+import type {GetAccountRateLimitsResponse, RateLimitSnapshot} from "./app-server/v2";
 
 export type RateLimitEntry = {
     limitId: string;
@@ -7,3 +7,44 @@ export type RateLimitEntry = {
 };
 
 export type RateLimitsMap = Map<string, RateLimitEntry>;
+
+function rateLimitId(snapshot: RateLimitSnapshot, fallback = "unknown"): string {
+    return snapshot.limitId ?? snapshot.limitName ?? fallback;
+}
+
+export function createRateLimitsMap(response: GetAccountRateLimitsResponse): RateLimitsMap {
+    const result: RateLimitsMap = new Map();
+    const snapshots = Object.entries(response.rateLimitsByLimitId ?? {})
+        .filter((entry): entry is [string, RateLimitSnapshot] => entry[1] !== undefined);
+
+    if (snapshots.length === 0) {
+        snapshots.push([rateLimitId(response.rateLimits), response.rateLimits]);
+    }
+
+    for (const [fallbackId, snapshot] of snapshots) {
+        const limitId = rateLimitId(snapshot, fallbackId);
+        result.set(limitId, {
+            limitId,
+            limitName: snapshot.limitName ?? limitId,
+            snapshot,
+        });
+    }
+    return result;
+}
+
+export function mergeRateLimitSnapshot(
+    previous: RateLimitSnapshot,
+    update: RateLimitSnapshot,
+): RateLimitSnapshot {
+    return {
+        limitId: update.limitId ?? previous.limitId,
+        limitName: update.limitName ?? previous.limitName,
+        primary: update.primary ?? previous.primary,
+        secondary: update.secondary ?? previous.secondary,
+        credits: update.credits ?? previous.credits,
+        individualLimit: update.individualLimit ?? previous.individualLimit,
+        spendControlReached: update.spendControlReached ?? previous.spendControlReached,
+        planType: update.planType ?? previous.planType,
+        rateLimitReachedType: update.rateLimitReachedType ?? previous.rateLimitReachedType,
+    };
+}

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -1607,6 +1607,48 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         await expect(mockFixture.getAcpConnectionDump([])).toMatchFileSnapshot("data/command-status.json");
     });
 
+    it('preserves the latest context usage while handling /status locally', async () => {
+        const {mockFixture, sessionState} = setupPromptFixture({
+            lastTokenUsage: {
+                totalTokens: 41_500,
+                inputTokens: 40_000,
+                cachedInputTokens: 1_000,
+                outputTokens: 500,
+                reasoningOutputTokens: 100,
+            },
+            modelContextWindow: 258_400,
+        });
+
+        await mockFixture.getCodexAcpAgent().prompt({
+            sessionId: sessionState.sessionId,
+            prompt: [{type: "text", text: "/status"}],
+        });
+
+        expect(sessionState.lastTokenUsage?.totalTokens).toBe(41_500);
+        expect(mockFixture.getAcpConnectionDump([])).toContain(
+            "**Context window:** 16% used (41.5K used / 258.4K)",
+        );
+    });
+
+    it('resets the previous context usage before a model turn', async () => {
+        const {mockFixture, sessionState} = setupPromptFixture({
+            lastTokenUsage: {
+                totalTokens: 41_500,
+                inputTokens: 40_000,
+                cachedInputTokens: 1_000,
+                outputTokens: 500,
+                reasoningOutputTokens: 100,
+            },
+        });
+
+        await mockFixture.getCodexAcpAgent().prompt({
+            sessionId: sessionState.sessionId,
+            prompt: [{type: "text", text: "start a model turn"}],
+        });
+
+        expect(sessionState.lastTokenUsage).toBeNull();
+    });
+
     it('passes skill slash commands through to Codex', async () => {
         const { mockFixture, turnStartSpy } = setupPromptFixture();
 
@@ -3845,6 +3887,45 @@ describe('ACP server test', { timeout: 40_000 }, () => {
 
         await mockFixture.getCodexAcpAgent().prompt({ sessionId: "session-id", prompt: [{ type: "text", text: "/status" }] });
         await expect(mockFixture.getAcpConnectionDump([])).toMatchFileSnapshot("data/command-status-with-rate-limits.json");
+    });
+
+    it ('should refresh the complete rate-limit snapshot for status', async () => {
+        const {mockFixture, sessionState} = setupPromptFixture();
+        vi.spyOn(mockFixture.getCodexAcpClient(), "getRateLimits").mockResolvedValue({
+            rateLimits: {
+                limitId: "codex",
+                limitName: "Codex",
+                primary: {usedPercent: 15, resetsAt: null, windowDurationMins: 300},
+                secondary: {usedPercent: 25, resetsAt: null, windowDurationMins: 10080},
+                credits: {hasCredits: false, unlimited: false, balance: "0"},
+                individualLimit: {
+                    limit: "$50",
+                    used: "$14",
+                    remainingPercent: 72,
+                    resetsAt: Date.UTC(2026, 8, 30, 12) / 1000,
+                },
+                spendControlReached: null,
+                planType: null,
+                rateLimitReachedType: null,
+            },
+            rateLimitsByLimitId: null,
+            rateLimitResetCredits: null,
+            accountId: null,
+            rateLimitUpsell: null,
+        });
+
+        await mockFixture.getCodexAcpAgent().prompt({
+            sessionId: sessionState.sessionId,
+            prompt: [{type: "text", text: "/status"}],
+        });
+
+        const dump = mockFixture.getAcpConnectionDump([]);
+        expect(dump).toContain("**Codex 5h limit:** 85% left");
+        expect(dump).toContain("**Codex Weekly limit:** 75% left");
+        expect(dump).toContain("**Codex Credits:** 0");
+        expect(dump).toContain(
+            "**Codex individual spend limit:** 72% left ($14 used / $50; resets Sep 30)",
+        );
     });
 
     it ('should surface thread/compacted as user-visible message', async () => {

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -3899,8 +3899,8 @@ describe('ACP server test', { timeout: 40_000 }, () => {
                 secondary: {usedPercent: 25, resetsAt: null, windowDurationMins: 10080},
                 credits: {hasCredits: false, unlimited: false, balance: "0"},
                 individualLimit: {
-                    limit: "$50",
-                    used: "$14",
+                    limit: "25000",
+                    used: "8000",
                     remainingPercent: 72,
                     resetsAt: Date.UTC(2026, 8, 30, 12) / 1000,
                 },
@@ -3924,7 +3924,7 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         expect(dump).toContain("**Codex Weekly limit:** 75% left");
         expect(dump).toContain("**Codex Credits:** 0");
         expect(dump).toContain(
-            "**Codex individual spend limit:** 72% left ($14 used / $50; resets Sep 30)",
+            "**Codex individual spend limit:** 72% left (8,000 of 25,000 credits used; resets Sep 30)",
         );
     });
 
@@ -4095,6 +4095,73 @@ describe('ACP server test', { timeout: 40_000 }, () => {
                 planType: null,
                 rateLimitReachedType: null,
             }
+        });
+    });
+
+    it ('should apply a missing-id rate-limit update to the codex bucket', async () => {
+        const sessionId = "test-session-id";
+        const rateLimits: RateLimitsMap = new Map([
+            ["codex", {
+                limitId: "codex",
+                limitName: "Codex",
+                snapshot: {
+                    limitId: "codex",
+                    limitName: "Codex",
+                    primary: {usedPercent: 10, resetsAt: null, windowDurationMins: 300},
+                    secondary: {usedPercent: 20, resetsAt: null, windowDurationMins: 10080},
+                    credits: {hasCredits: true, unlimited: false, balance: "25"},
+                    individualLimit: null,
+                    spendControlReached: null,
+                    planType: null,
+                    rateLimitReachedType: null,
+                },
+            }],
+            ["codex_other", {
+                limitId: "codex_other",
+                limitName: "Other",
+                snapshot: {
+                    limitId: "codex_other",
+                    limitName: "Other",
+                    primary: {usedPercent: 30, resetsAt: null, windowDurationMins: 60},
+                    secondary: null,
+                    credits: null,
+                    individualLimit: null,
+                    spendControlReached: null,
+                    planType: null,
+                    rateLimitReachedType: null,
+                },
+            }],
+        ]);
+        const {mockFixture, sessionState} = setupPromptFixture({sessionId, rateLimits});
+
+        await mockFixture.getCodexAcpAgent().prompt({
+            sessionId,
+            prompt: [{type: "text", text: "test"}],
+        });
+        mockFixture.sendServerNotification({
+            method: "account/rateLimits/updated",
+            params: {
+                rateLimits: {
+                    limitId: null,
+                    limitName: null,
+                    primary: null,
+                    secondary: {usedPercent: 40, resetsAt: null, windowDurationMins: 10080},
+                    credits: null,
+                    individualLimit: null,
+                    spendControlReached: null,
+                    planType: null,
+                    rateLimitReachedType: null,
+                },
+            },
+        });
+        await mockFixture.getCodexAcpClient().waitForSessionNotifications(sessionId);
+
+        expect([...sessionState.rateLimits!.keys()]).toEqual(["codex", "codex_other"]);
+        expect(sessionState.rateLimits!.get("codex")!.snapshot).toMatchObject({
+            limitId: "codex",
+            primary: null,
+            secondary: {usedPercent: 40, resetsAt: null, windowDurationMins: 10080},
+            credits: {hasCredits: true, unlimited: false, balance: "25"},
         });
     });
 });

--- a/src/__tests__/RateLimitsMap.test.ts
+++ b/src/__tests__/RateLimitsMap.test.ts
@@ -1,0 +1,52 @@
+import {describe, expect, it} from "vitest";
+import type {RateLimitSnapshot} from "../app-server/v2";
+import {createRateLimitsMap, mergeRateLimitSnapshot} from "../RateLimitsMap";
+
+function snapshot(overrides: Partial<RateLimitSnapshot> = {}): RateLimitSnapshot {
+    return {
+        limitId: "codex",
+        limitName: "Codex",
+        primary: null,
+        secondary: null,
+        credits: null,
+        individualLimit: null,
+        spendControlReached: null,
+        planType: null,
+        rateLimitReachedType: null,
+        ...overrides,
+    };
+}
+
+describe("RateLimitsMap", () => {
+    it("uses every bucket from the complete rate-limit response", () => {
+        const codex = snapshot({limitId: "codex"});
+        const fast = snapshot({limitId: "fast", limitName: "Fast"});
+
+        const result = createRateLimitsMap({
+            rateLimits: codex,
+            rateLimitsByLimitId: {codex, fast},
+            rateLimitResetCredits: null,
+            accountId: null,
+            rateLimitUpsell: null,
+        });
+
+        expect([...result.keys()]).toEqual(["codex", "fast"]);
+    });
+
+    it("does not erase known fields when applying a sparse update", () => {
+        const previous = snapshot({
+            primary: {usedPercent: 15, resetsAt: 100, windowDurationMins: 300},
+            credits: {hasCredits: true, unlimited: false, balance: "10"},
+        });
+        const update = snapshot({
+            limitName: null,
+            primary: null,
+            secondary: {usedPercent: 25, resetsAt: 200, windowDurationMins: 10080},
+        });
+
+        expect(mergeRateLimitSnapshot(previous, update)).toEqual({
+            ...previous,
+            secondary: update.secondary,
+        });
+    });
+});

--- a/src/__tests__/RateLimitsMap.test.ts
+++ b/src/__tests__/RateLimitsMap.test.ts
@@ -33,19 +33,25 @@ describe("RateLimitsMap", () => {
         expect([...result.keys()]).toEqual(["codex", "fast"]);
     });
 
-    it("does not erase known fields when applying a sparse update", () => {
+    it("preserves account metadata but replaces usage windows from a sparse update", () => {
         const previous = snapshot({
             primary: {usedPercent: 15, resetsAt: 100, windowDurationMins: 300},
+            secondary: {usedPercent: 20, resetsAt: 150, windowDurationMins: 10080},
             credits: {hasCredits: true, unlimited: false, balance: "10"},
+            rateLimitReachedType: "rate_limit_reached",
         });
         const update = snapshot({
+            limitId: null,
             limitName: null,
             primary: null,
             secondary: {usedPercent: 25, resetsAt: 200, windowDurationMins: 10080},
+            rateLimitReachedType: null,
         });
 
         expect(mergeRateLimitSnapshot(previous, update)).toEqual({
-            ...previous,
+            ...update,
+            limitId: "codex",
+            credits: previous.credits,
             secondary: update.secondary,
         });
     });


### PR DESCRIPTION
## Summary

- preserve the latest context usage for local commands and reset it only before model turns
- report context consumption as percent used
- refresh the complete account rate-limit snapshot for /status and merge sparse updates
- show individual spend limits while leaving spend-control state internal

## Testing

- npm run typecheck
- npm test
- npm run build