### PR TITLE
fix: complete prompts on newly forked sessions

### DIFF
--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -159,6 +159,9 @@ export interface SessionState {
     sessionFailure?: SessionFailure;
     titleGen?: TitleGenerator;
     subagents: CodexSubagentEventRouter;
+    // Fork creation releases the app-server writer so another ACP process can load it.
+    // A direct prompt must reacquire that subscription first.
+    resumeBeforePrompt: boolean;
 }
 
 export type SessionFailureCategory =
@@ -646,6 +649,7 @@ export class CodexAcpServer {
                 clientSupportsSubagents(this.clientCapabilities),
                 new ACPSessionConnection(this.connection, sessionId),
             ),
+            resumeBeforePrompt: operation === "fork",
         };
         sessionState.titleGen = new TitleGenerator(
             this.codexAcpClient.appServerClient,
@@ -1697,6 +1701,7 @@ export class CodexAcpServer {
                 clientSupportsSubagents(this.clientCapabilities),
                 new ACPSessionConnection(this.connection, sessionId),
             ),
+            resumeBeforePrompt: false,
         };
         sessionState.titleGen = new TitleGenerator(
             this.codexAcpClient.appServerClient,
@@ -2486,6 +2491,15 @@ export class CodexAcpServer {
             prompt: params.prompt,
         });
         const sessionState = this.getSessionState(params.sessionId);
+        if (sessionState.resumeBeforePrompt) {
+            await this.runWithProcessCheck(() => this.codexAcpClient.resumeSession({
+                sessionId: sessionState.sessionId,
+                cwd: sessionState.cwd,
+                additionalDirectories: sessionState.additionalDirectories,
+                mcpServers: sessionState.mcpServers ?? [],
+            }));
+            sessionState.resumeBeforePrompt = false;
+        }
         const agentFileChangeReportRequest = clientSupportsAgentFileChangeReports(this.clientCapabilities)
             ? parseAgentFileChangeReportRequest(params._meta)
             : null;

--- a/src/__tests__/CodexACPAgent/session-fork.test.ts
+++ b/src/__tests__/CodexACPAgent/session-fork.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, it, vi} from "vitest";
 import {createCodexMockTestFixture, createTestModel} from "../acp-test-utils";
+import type {ServerNotification} from "../../app-server";
 
 describe("ACP session fork", () => {
     it("creates and installs a forked session", async () => {
@@ -34,6 +35,119 @@ describe("ACP session fork", () => {
             sessionId: "source-id",
             cwd: "/workspace",
             mcpServers: [],
+        });
+    });
+
+    it("streams and completes a prompt sent directly to a newly forked session", async () => {
+        const fixture = createCodexMockTestFixture();
+        const agent = fixture.getCodexAcpAgent();
+        const client = fixture.getCodexAcpClient();
+        const appServer = fixture.getCodexAppServerClient();
+        const model = createTestModel({id: "gpt-5"});
+        const metadata = {
+            sessionId: "fork-id",
+            currentModelId: "gpt-5[medium]",
+            models: [model],
+            collaborationMode: "default" as const,
+            modelProvider: "openai",
+            currentServiceTier: null,
+            additionalDirectories: [],
+        };
+
+        vi.spyOn(client, "authRequired").mockResolvedValue(false);
+        vi.spyOn(client, "getAccount").mockResolvedValue({account: null, requiresOpenaiAuth: false});
+        vi.spyOn(client, "listSkills").mockResolvedValue({data: []});
+        vi.spyOn(client, "forkSession").mockResolvedValue(metadata);
+        const resumeSpy = vi.spyOn(client, "resumeSession").mockResolvedValue(metadata);
+        vi.spyOn(appServer, "turnStart").mockImplementation(async () => {
+            queueMicrotask(() => {
+                const notifications: ServerNotification[] = [
+                    {
+                        method: "item/started",
+                        params: {
+                            threadId: "fork-id",
+                            turnId: "turn-id",
+                            startedAtMs: 0,
+                            item: {
+                                type: "agentMessage",
+                                id: "message-id",
+                                text: "",
+                                phase: "final_answer",
+                                memoryCitation: null,
+                                delivery: null,
+                            },
+                        },
+                    },
+                    {
+                        method: "item/agentMessage/delta",
+                        params: {
+                            threadId: "fork-id",
+                            turnId: "turn-id",
+                            itemId: "message-id",
+                            delta: "Fork answer",
+                        },
+                    },
+                    {
+                        method: "turn/completed",
+                        params: {
+                            threadId: "fork-id",
+                            turn: {
+                                id: "turn-id",
+                                items: [],
+                                itemsView: "notLoaded",
+                                status: "completed",
+                                error: null,
+                                startedAt: null,
+                                completedAt: null,
+                                durationMs: null,
+                            },
+                        },
+                    },
+                ];
+                notifications.forEach(notification => fixture.sendServerNotification(notification));
+            });
+            return {
+                turn: {
+                    id: "turn-id",
+                    items: [],
+                    itemsView: "notLoaded",
+                    status: "inProgress",
+                    error: null,
+                    startedAt: null,
+                    completedAt: null,
+                    durationMs: null,
+                },
+            };
+        });
+
+        const fork = await agent.forkSession({sessionId: "source-id", cwd: "/workspace", mcpServers: []});
+        const prompt = agent.prompt({
+            sessionId: fork.sessionId,
+            prompt: [{type: "text", text: "Answer from the fork"}],
+        });
+        const response = await Promise.race([
+            prompt,
+            new Promise<never>((_, reject) => setTimeout(() => reject(new Error("fork prompt timed out")), 1_000)),
+        ]);
+
+        expect(response.stopReason).toBe("end_turn");
+        expect(resumeSpy).toHaveBeenCalledWith({
+            sessionId: "fork-id",
+            cwd: "/workspace",
+            additionalDirectories: [],
+            mcpServers: [],
+        });
+        expect(fixture.getAcpConnectionEvents([])).toContainEqual({
+            method: "sessionUpdate",
+            args: [{
+                sessionId: "fork-id",
+                update: {
+                    sessionUpdate: "agent_message_chunk",
+                    content: {type: "text", text: "Fork answer"},
+                    messageId: "message-id",
+                    _meta: {codex: {phase: "final_answer"}},
+                },
+            }],
         });
     });
 });

--- a/src/__tests__/acp-test-utils.ts
+++ b/src/__tests__/acp-test-utils.ts
@@ -409,6 +409,7 @@ export function createTestSessionState(overrides?: Partial<SessionState>): Sessi
         goalRevision: 0,
         sessionTitle: null,
         sessionTitleSource: "unknown",
+        resumeBeforePrompt: false,
         subagents: new CodexSubagentEventRouter(
             sessionId,
             false,


### PR DESCRIPTION
## Summary

- reactivate the Codex app-server subscription before the first direct prompt on a newly forked ACP session
- preserve the intentional post-fork `thread/unsubscribe`, so another ACP process can still load the persisted fork
- add a bounded event-driven regression test that requires both streamed fork output and a resolved prompt response

## ACP lifecycle

The [ACP session/fork RFD](https://github.com/agentclientprotocol/agent-client-protocol/blob/main/docs/rfds/session-fork.mdx) motivates the method with a client flow that forks, issues additional messages, and closes the fork. It also specifies a response shaped like `session/new`. The [draft schema](https://github.com/agentclientprotocol/agent-client-protocol/blob/main/schema/v1/schema.unstable.json) describes the returned ID as the newly created forked session and does not require an intervening `session/load` or `session/resume`.

Therefore a successful `session/fork` response must produce a session that accepts `session/prompt` directly. Explicit `session/load` remains valid for a persisted/inactive fork, but it is not a required activation step after a successful fork on the same ACP connection.

## Observed behavior

With codex-acp 1.8.0 and Codex 0.152.1:

1. `session/fork(parentSessionId, cwd, mcpServers)` returned a fork session ID.
2. `session/prompt(forkSessionId, prompt)` was accepted.
3. Codex completed and persisted the answer internally.
4. The ACP client received no answer `session/update` notifications.
5. The `session/prompt` request remained pending indefinitely.

A real-Codex reproduction using the repository `/run-codex` harness timed out the direct sequence after 30 seconds with zero updates. The control sequence `fork -> load -> prompt` completed in 2.7 seconds.

### Client impact: Tandem

This does more than lose streamed output. Tandem records the aside as started and changes the parent agent to working, but receives neither the answer updates nor the prompt response. The UI leaves the aside card permanently at “Asking in existing context…”, while the completed answer exists only in Codex internal history.

Tandem serializes ordinary prompts and isolated asides through one queue. The unresolved aside therefore blocks every later prompt behind it, and its cleanup path never reaches `session/close`. The parent conversation remains correctly unmodified; the failure is delivery and lifecycle completion, not isolation.

## Root cause

The fork implementation intentionally calls app-server `thread/unsubscribe` after `thread/fork` to release the writer for clients such as AIR that may load the fork through another ACP process. codex-acp nevertheless installs the returned fork in its local ACP session map as if it were immediately promptable.

Before this change, a direct prompt started a turn on that unsubscribed thread. Codex executed it, but app-server delivered no thread notifications to this connection. `CodexAppServerClient.runTurn` consequently never observed `turn/completed`, so codex-acp emitted no answer updates and never resolved the ACP prompt.

This PR keeps the unsubscribe behavior. The ACP session state records that a new fork needs resubscription, and the first direct prompt resumes the thread before registering prompt handlers and starting the turn. An explicit `session/load` creates an already-subscribed session state and does not take the lazy-resume path.

## Regression test

The new test:

- creates a fork and immediately prompts its returned session ID;
- simulates app-server message and completion notifications;
- requires the ACP `agent_message_chunk` for the fork;
- requires the prompt response to resolve with `end_turn`;
- uses a one-second timeout so the original indefinite wait fails deterministically.

## Verification

- `npm run typecheck`
- `npm test` — 487 passed, 26 skipped
- real Codex: `fork -> prompt` — completed in 3.3 seconds after the fix
- real Codex: `fork -> load -> prompt` — completed in 3.8 seconds after the fix