### PR TITLE
feat: report the agent's auth identity over ACP (authStatus extension)

### DIFF
--- a/src/AcpExtensions.ts
+++ b/src/AcpExtensions.ts
@@ -13,6 +13,17 @@ import {
 } from "./GoalExtension";
 
 export {
+    AUTH_STATUS_META_KEY,
+    AUTH_STATUS_UPDATE_METHOD,
+    authStatusCapability,
+    sameAuthStatus,
+    type AuthStatus,
+    type AuthStatusCapability,
+    type AuthStatusKind,
+    type AuthStatusUpdateNotification,
+} from "./AuthStatusMeta";
+
+export {
     GOAL_CONTROL_ACTIONS,
     GOAL_CONTROL_METHOD,
     GOAL_EXTENSION_VERSION,
@@ -73,6 +84,12 @@ export function isExtMethodRequest(request: { method: string, params: Record<str
         || request.method === SESSION_STEERING_METHOD;
 }
 
+/**
+ * @deprecated Legacy pull method; it drops the ChatGPT `planType` and predates
+ * the standard `logout` method. Listen to the `authStatus` extension instead:
+ * the agent pushes `_auth/status_update` (see `AuthStatusMeta.ts`), which
+ * follows the upstream auth-identity RFD.
+ */
 export type AuthenticationStatusRequest = { method: "authentication/status", params: {} }
 export type AuthenticationStatusResponse = { type: "api-key" } | { type: "chat-gpt", email: string } | { type: "gateway", name: string } | { type: "unauthenticated" }
 

--- a/src/AuthStatusMeta.ts
+++ b/src/AuthStatusMeta.ts
@@ -1,0 +1,251 @@
+import type {Account, AccountUpdatedNotification} from "./app-server/v2";
+import type {AuthMode} from "./app-server/AuthMode";
+import type {PlanType} from "./app-server/PlanType";
+
+/**
+ * `authStatus` — interim `_meta`-based ACP extension that reports the auth
+ * identity of the connection (the agent process serving this ACP connection).
+ *
+ * Push only. There is one carrier, connection-scoped and never per session: the
+ * notification `_auth/status_update` with `{authStatus}`. The client sends
+ * nothing; there is no request method to pull the value.
+ *
+ * The agent pushes:
+ * - once after `initialize`, as soon as it knows its identity, including
+ *   `none`. That first push is unconditional and is sent after the `initialize`
+ *   response;
+ * - on every change it observes afterwards, and only on change
+ *   ({@link sameAuthStatus}): a completed `authenticate` or `logout`, each
+ *   session create/fork/load (a refused session reports too — the client must
+ *   know which account was refused), and the app-server `account/updated` push,
+ *   which the agent maps straight onto a status ({@link fromAccountUpdated}).
+ *
+ * `account/updated` is the free freshness channel for a login or a logout made
+ * in another terminal, so there are no timers here and no re-read at a turn
+ * boundary.
+ *
+ * An agent that cannot learn its identity pushes nothing, and the client shows
+ * "not reported". `kind: "none"` is not that case: it is a known logged-out
+ * state, and it is reported.
+ *
+ * The payload moves to first-class protocol fields once the upstream
+ * auth-identity RFD lands; this extension is retired then.
+ */
+export const AUTH_STATUS_UPDATE_METHOD = "_auth/status_update";
+export const AUTH_STATUS_META_KEY = "authStatus";
+
+/** Category of the credential the agent uses. Clients tolerate unknown values. */
+export type AuthStatusKind = "account" | "api_key" | "gateway" | "external" | "none";
+
+export interface AuthStatusAccount {
+    email?: string;
+    organization?: string;
+    /** Vendor plan/license string, not normalized. */
+    plan?: string;
+}
+
+export interface AuthStatus {
+    kind: AuthStatusKind;
+    /** Human-readable, agent-defined; usable as a UI string on its own. */
+    label: string;
+    /**
+     * Optional secondary line (gateway provider, key source, ...). Clients
+     * render `label` first and fall back to `account.email` when there is no
+     * detail.
+     */
+    detail?: string;
+    account?: AuthStatusAccount;
+    /** Vendor-namespaced extras. */
+    vendor?: Record<string, unknown>;
+}
+
+/** Params of the `_auth/status_update` notification. */
+export type AuthStatusUpdateNotification = {
+    authStatus: AuthStatus;
+}
+
+/**
+ * Capability advertised in the `initialize` response under
+ * `agentCapabilities._meta.authStatus`: an empty object whose presence means
+ * "this agent pushes its identity". It is never a status payload, and it gates
+ * nothing the client sends — the client only listens.
+ */
+export type AuthStatusCapability = {}
+
+export function authStatusCapability(): AuthStatusCapability {
+    return {};
+}
+
+const NOT_LOGGED_IN_LABEL = "Not logged in";
+const DEFAULT_GATEWAY_LABEL = "Custom model gateway";
+
+const PLAN_DISPLAY_NAMES: Record<string, string> = {
+    free: "Free",
+    go: "Go",
+    plus: "Plus",
+    pro: "Pro",
+    team: "Team",
+    business: "Business",
+    enterprise: "Enterprise",
+    edu: "Edu",
+};
+
+/**
+ * Display name for a Codex plan; unknown raw values are capitalized so the
+ * label stays truthful when the enum grows.
+ */
+export function planTypePresentable(planType: PlanType | string | null | undefined): string | null {
+    if (!planType || planType === "unknown") {
+        return null;
+    }
+    return PLAN_DISPLAY_NAMES[planType] ?? capitalize(planType);
+}
+
+function capitalize(value: string): string {
+    return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function chatGptLabel(planType: PlanType | null | undefined): string {
+    const plan = planTypePresentable(planType);
+    return plan === null ? "ChatGPT" : `ChatGPT ${plan}`;
+}
+
+/**
+ * Agent-owned gateway routing: the `gateway` auth method, or Codex's own config.
+ * `label` is the type line and stays constant; the provider name is the
+ * specifics, so it rides in `detail` (line 2) the way every other kind does.
+ */
+export function gatewayStatus(providerName?: string | null): AuthStatus {
+    const detail = typeof providerName === "string" && providerName.trim().length > 0
+        ? providerName.trim()
+        : undefined;
+    return {
+        kind: "gateway",
+        label: DEFAULT_GATEWAY_LABEL,
+        ...(detail === undefined ? {} : {detail}),
+    };
+}
+
+export function unauthenticatedStatus(): AuthStatus {
+    return {
+        kind: "none",
+        label: NOT_LOGGED_IN_LABEL,
+    };
+}
+
+/** Maps the app-server `account/read` result. */
+export function fromAccount(account: Account | null): AuthStatus {
+    if (account === null) {
+        return unauthenticatedStatus();
+    }
+    switch (account.type) {
+        case "chatgpt": {
+            const accountInfo: AuthStatusAccount = {};
+            if (account.email) {
+                accountInfo.email = account.email;
+            }
+            if (account.planType) {
+                accountInfo.plan = account.planType;
+            }
+            return {
+                kind: "account",
+                label: chatGptLabel(account.planType),
+                ...(Object.keys(accountInfo).length > 0 ? {account: accountInfo} : {}),
+            };
+        }
+        case "apiKey":
+            return {
+                kind: "api_key",
+                label: "OpenAI API key",
+            };
+        case "amazonBedrock":
+            return {
+                kind: "external",
+                label: "AWS Bedrock",
+            };
+    }
+}
+
+/**
+ * Maps the coarser `account/updated` push, which carries no email. The last
+ * known email is kept only when the account kind did not change; otherwise it
+ * is dropped until the next full `account/read`.
+ */
+export function fromAccountUpdated(
+    notification: AccountUpdatedNotification,
+    previous?: AuthStatus | null,
+): AuthStatus {
+    const authMode: AuthMode | null = notification.authMode;
+    if (authMode === null) {
+        return unauthenticatedStatus();
+    }
+    switch (authMode) {
+        case "chatgpt":
+        case "chatgptAuthTokens": {
+            const status: AuthStatus = {
+                kind: "account",
+                label: chatGptLabel(notification.planType),
+            };
+            const accountInfo: AuthStatusAccount = {};
+            const previousEmail = previous?.kind === "account" ? previous.account?.email : undefined;
+            if (previousEmail) {
+                accountInfo.email = previousEmail;
+            }
+            if (notification.planType) {
+                accountInfo.plan = notification.planType;
+            }
+            if (Object.keys(accountInfo).length > 0) {
+                status.account = accountInfo;
+            }
+            return status;
+        }
+        case "apikey":
+            return {
+                kind: "api_key",
+                label: "OpenAI API key",
+            };
+        case "personalAccessToken":
+            return {
+                kind: "api_key",
+                label: "OpenAI personal access token",
+            };
+        case "bedrockApiKey":
+        case "bedrockAccessKeys":
+            return {
+                kind: "external",
+                label: "AWS Bedrock",
+            };
+        case "agentIdentity":
+            return {
+                kind: "external",
+                label: "Agent identity",
+            };
+        case "headers":
+            return gatewayStatus();
+    }
+}
+
+/**
+ * Do two payloads carry the same information? Compares every rendered field,
+ * so a richer read of the same login is NOT the same. Callers use it to drop a
+ * push that would tell the client nothing new: the identity is read on many
+ * occasions (`initialize`, each session create, each `account/updated`) and
+ * almost all of them see the login that is already reported.
+ *
+ * A missing `previous` means "nothing reported yet", which never equals a payload.
+ */
+export function sameAuthStatus(previous: AuthStatus | null | undefined, next: AuthStatus): boolean {
+    if (!previous) {
+        return false;
+    }
+    return previous.kind === next.kind
+        && previous.label === next.label
+        && previous.detail === next.detail
+        && previous.account?.email === next.account?.email
+        && previous.account?.organization === next.account?.organization
+        && previous.account?.plan === next.account?.plan
+        // Vendor extras are an open bag, so compare them structurally. Both
+        // sides are built here from the same key order, so a string compare is
+        // enough and costs nothing on the usual `undefined`/`undefined` pair.
+        && JSON.stringify(previous.vendor) === JSON.stringify(next.vendor);
+}

--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -114,6 +114,12 @@ export class CodexAcpClient {
     private readonly config: JsonObject;
     private readonly modelProvider: string | null;
     private gatewayConfig: GatewayConfig | null;
+    /**
+     * Where the stored gateway routing came from: the `gateway` auth method
+     * (agent-owned authentication) or the ACP `providers/*` API (client-driven
+     * routing). `authStatus` reports only the agent-owned one.
+     */
+    private gatewayConfigSource: GatewayConfigSource | null;
     private pendingLoginCompleted: Promise<AccountLoginCompletedNotification> | null = null;
     private pendingAccountUpdated: Promise<AccountUpdatedNotification> | null = null;
     private readonly sessionNotificationQueues = new Map<string, Promise<void>>();
@@ -127,6 +133,7 @@ export class CodexAcpClient {
         this.config = codexConfig ?? {};
         this.modelProvider = modelProvider ?? null;
         this.gatewayConfig = null;
+        this.gatewayConfigSource = null;
         this.subagents = new CodexSubagentSubscriptions(codexClient);
     }
 
@@ -165,6 +172,7 @@ export class CodexAcpClient {
             throw RequestError.invalidRequest();
         }
         this.gatewayConfig = null;
+        this.gatewayConfigSource = null;
         switch (authRequest.methodId) {
             case "api-key":
                 return await this.authenticateWithApiKey(authRequest);
@@ -257,7 +265,7 @@ export class CodexAcpClient {
             apiType: GatewayAuthMethod._meta.gateway.protocol,
             headers: gatewaySettings.headers,
             providerName: gatewaySettings.providerName,
-        });
+        }, "authentication");
 
         return true;
     }
@@ -308,6 +316,11 @@ export class CodexAcpClient {
         }
     }
 
+    /**
+     * The provider that actually serves requests, ACP-configured gateway
+     * routing included. Use {@link getAgentConfiguredModelProvider} instead
+     * when asking what the agent itself is configured with (`authStatus`).
+     */
     async getCurrentModelProvider(): Promise<string | null> {
         const sessionModelProvider = this.getModelProvider();
         if (sessionModelProvider !== null) {
@@ -346,7 +359,7 @@ export class CodexAcpClient {
         headers?: Record<string, string> | undefined;
         providerName?: string | undefined;
         apiType: acp.LlmProtocol;
-    }): void {
+    }, source: GatewayConfigSource): void {
         const apiType = params.apiType;
         const wireApi = SUPPORTED_GATEWAY_PROTOCOLS[apiType];
         if (!wireApi) {
@@ -366,6 +379,7 @@ export class CodexAcpClient {
             ...params.headers,
         };
 
+        this.gatewayConfigSource = source;
         this.gatewayConfig = {
             modelProvider: CUSTOM_GATEWAY_PROVIDER_ID,
             config: {
@@ -436,7 +450,7 @@ export class CodexAcpClient {
             apiType: request.apiType,
             baseUrl: request.baseUrl,
             headers: request.headers,
-        });
+        }, "acpProviders");
         logger.log("providers/set applied", {
             providerId: request.providerId,
             apiType: request.apiType,
@@ -453,6 +467,7 @@ export class CodexAcpClient {
         const overrideWasActive = this.gatewayConfig !== null;
         if (request.providerId === OPENAI_PROVIDER_ID) {
             this.gatewayConfig = null;
+            this.gatewayConfigSource = null;
         }
         const current = this.gatewayConfig
             ? {
@@ -476,6 +491,40 @@ export class CodexAcpClient {
 
     async getRateLimits(): Promise<GetAccountRateLimitsResponse> {
         return this.codexClient.accountRateLimitsRead();
+    }
+
+    /**
+     * Presentable name of the gateway the agent itself authenticated against
+     * (the `gateway` auth method), or `null`. Routing that the client
+     * configured through `providers/set` is deliberately not reported here:
+     * `authStatus` describes the agent-owned login only.
+     */
+    getAuthGatewayProviderName(): string | null {
+        return this.gatewayConfigSource === "authentication"
+            ? this.gatewayConfig?.config.name ?? null
+            : null;
+    }
+
+    /** Whether this provider id is client-driven routing set through `providers/set`. */
+    isClientConfiguredProvider(providerId: string | null): boolean {
+        return providerId === CUSTOM_GATEWAY_PROVIDER_ID && this.gatewayConfigSource === "acpProviders";
+    }
+
+    /**
+     * The model provider the agent itself is configured with (launch option or
+     * Codex config), ignoring any ACP-configured gateway routing. The
+     * routing-aware counterpart is {@link getCurrentModelProvider}.
+     */
+    async getAgentConfiguredModelProvider(): Promise<string | null> {
+        const provider = this.getModelProvider();
+        // Routing set through `providers/set` is the client's, not the agent's:
+        // look past it to what the agent itself was started/configured with.
+        const agentProvider = this.isClientConfiguredProvider(provider) ? this.modelProvider : provider;
+        if (agentProvider !== null) {
+            return agentProvider;
+        }
+        const settingsModelProvider = await this.codexClient.configRead({includeLayers: false});
+        return settingsModelProvider?.config?.model_provider ?? null;
     }
 
     async resumeSession(request: acp.ResumeSessionRequest, onSubscribed?: () => void): Promise<SessionMetadata> {
@@ -1340,6 +1389,8 @@ function shouldDeduplicateMcpConflicts(): boolean {
 }
 
 type WireApi = "responses";
+
+type GatewayConfigSource = "authentication" | "acpProviders";
 
 interface GatewayConfig {
     modelProvider: string;

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -23,7 +23,16 @@ import {CodexAppServerClient, type McpStartupResult} from "./CodexAppServerClien
 import {type CodexConnection, startCodexConnection} from "./CodexJsonRpcConnection";
 import {type AcpClientConnection, ACPSessionConnection, type UpdateSessionEvent} from "./ACPSessionConnection";
 import type {InputModality, ReasoningEffort, ServerNotification} from "./app-server";
-import type {Account, Model, ReasoningEffortOption, Thread, ThreadGoal, ThreadItem, UserInput} from "./app-server/v2";
+import type {
+    Account,
+    AccountUpdatedNotification,
+    Model,
+    ReasoningEffortOption,
+    Thread,
+    ThreadGoal,
+    ThreadItem,
+    UserInput
+} from "./app-server/v2";
 import type {RateLimitsMap} from "./RateLimitsMap";
 import {ModelId} from "./ModelId";
 import {AgentMode, MODE_CONFIG_ID} from "./AgentMode";
@@ -51,6 +60,10 @@ import {logger} from "./Logger";
 import {sanitizeMcpServerName} from "./McpServerName";
 import {createResponseItemHistoryFallbackUpdates} from "./ResponseItemHistoryFallback";
 import {
+    AUTH_STATUS_META_KEY,
+    AUTH_STATUS_UPDATE_METHOD,
+    authStatusCapability,
+    type AuthStatus,
     GOAL_CONTROL_ACTIONS,
     GOAL_CONTROL_METHOD,
     GOAL_EXTENSION_VERSION,
@@ -106,6 +119,12 @@ import {
 } from "./subagents/AcpSubagents";
 import {CodexSubagentEventRouter} from "./subagents/CodexSubagentEventRouter";
 import {nameFromAgentPath} from "./subagents/CodexAgentPath";
+import {
+    fromAccount,
+    fromAccountUpdated,
+    gatewayStatus,
+    sameAuthStatus,
+} from "./AuthStatusMeta";
 import {randomUUID} from "node:crypto";
 import {TitleGenerator} from "./TitleGenerator";
 import {once} from "node:events";
@@ -245,6 +264,8 @@ export class CodexAcpServer {
     private clientCapabilities: acp.ClientCapabilities | null;
     private terminalOutputMode: TerminalOutputMode;
     private booleanConfigOptionsSupported: boolean;
+    /** Last `authStatus` pushed to the client; used to suppress duplicates. */
+    private currentAuthStatus: AuthStatus | null;
 
     private readonly sessions: Map<string, SessionState>;
     private readonly pendingMcpStartupSessions: Map<string, PendingMcpStartupSession>;
@@ -290,6 +311,7 @@ export class CodexAcpServer {
         this.clientCapabilities = null;
         this.terminalOutputMode = "terminal_output_delta";
         this.booleanConfigOptionsSupported = false;
+        this.currentAuthStatus = null;
         this.availableCommands = this.createAvailableCommands(codexAcpClient);
     }
 
@@ -298,7 +320,7 @@ export class CodexAcpServer {
             this.connection,
             client,
             (operation) => this.runWithProcessCheck(operation),
-            () => this.refreshSessionsAuthState(null)
+            () => this.refreshAuthState(null)
         );
     }
 
@@ -312,6 +334,7 @@ export class CodexAcpServer {
         this.terminalOutputMode = resolveTerminalOutputMode(_params.clientCapabilities);
         this.booleanConfigOptionsSupported = clientSupportsBooleanConfigOptions(_params.clientCapabilities);
         await this.runWithProcessCheck(() => this.codexAcpClient.initialize(_params));
+        this.publishFirstAuthStatusAfterResponse();
         const sessionCapabilities: SubagentAwareSessionCapabilities = {
             resume: { },
             list: { },
@@ -343,7 +366,12 @@ export class CodexAcpServer {
                     acp: false,
                     http: true,
                     sse: false
-                }
+                },
+                _meta: {
+                    // Presence means "this agent pushes `_auth/status_update`". It
+                    // never carries a payload, and the client never asks for one.
+                    [AUTH_STATUS_META_KEY]: authStatusCapability(),
+                },
             },
             authMethods: getCodexAuthMethods(_params.clientCapabilities),
             _meta: {
@@ -478,7 +506,7 @@ export class CodexAcpServer {
     async handleError(e: Error){
         if (e.message.includes("log out") || e.message.includes("cloud requirements")) {
             await this.runWithProcessCheck(() => this.codexAcpClient.logout());
-            await this.refreshSessionsAuthState(null);
+            await this.refreshAuthState(null);
             throw RequestError.internalError(`${(e.message)}\n\nYou have been logged out. Please try again.`);
         }
         const configPath = this.codexAcpClient.getHomePath() ?? "global";
@@ -679,12 +707,14 @@ export class CodexAcpServer {
 
     private async getAuthStateForProvider(authProvider: string | null): Promise<ActiveAuthState> {
         if (!this.authProviderUsesOpenAiAccount(authProvider)) {
+            await this.publishAuthStatus(authProvider, null);
             return {
                 account: null,
                 authConfigured: true,
             };
         }
         const accountResponse = await this.runWithProcessCheck(() => this.codexAcpClient.getAccount());
+        await this.publishAuthStatus(authProvider, accountResponse.account);
         return {
             account: accountResponse.account,
             authConfigured: accountResponse.account !== null || !accountResponse.requiresOpenaiAuth,
@@ -898,7 +928,7 @@ export class CodexAcpServer {
             logger.log("Authenticate request failed");
             throw RequestError.invalidParams();
         }
-        await this.refreshSessionsAuthState(this.getAuthProviderForAuthenticateRequest(_params));
+        await this.refreshAuthState(this.getAuthProviderForAuthenticateRequest(_params));
         logger.log("Authenticate request completed");
         return { };
     }
@@ -931,7 +961,7 @@ export class CodexAcpServer {
     async logout(_params: acp.LogoutRequest): Promise<void> {
         logger.log("Logout request received");
         await this.runWithProcessCheck(() => this.codexAcpClient.logout());
-        await this.refreshSessionsAuthState(null);
+        await this.refreshAuthState(null);
         logger.log("Logout request completed");
     }
 
@@ -1048,17 +1078,175 @@ export class CodexAcpServer {
         );
     }
 
-    private async refreshSessionsAuthState(authProvider: string | null): Promise<void> {
-        if (this.sessions.size === 0) return;
+    /** Returns whether the auth state was read (and thus the auth status pushed). */
+    private async refreshSessionsAuthState(authProvider: string | null): Promise<boolean> {
+        if (this.sessions.size === 0) return false;
 
         const sessionsToRefresh = [...this.sessions.values()]
             .filter(sessionState => this.authProvidersMatch(sessionState.authProvider, authProvider));
-        if (sessionsToRefresh.length === 0) return;
+        if (sessionsToRefresh.length === 0) return false;
 
         const authState = await this.getAuthStateForProvider(authProvider);
         for (const sessionState of sessionsToRefresh) {
             sessionState.account = authState.account;
             sessionState.authConfigured = authState.authConfigured;
+        }
+        return true;
+    }
+
+    /**
+     * Refreshes the sessions of a provider and makes sure the connection-level
+     * `authStatus` is pushed even when no session matched (the empty-screen
+     * login case). Reuses the session refresh read; never adds a second one.
+     */
+    private async refreshAuthState(authProvider: string | null): Promise<void> {
+        const refreshed = await this.refreshSessionsAuthState(authProvider);
+        if (refreshed) return;
+        try {
+            // Only the push matters here: there is no session for the auth state to land in.
+            await this.getAuthStateForProvider(authProvider ?? this.codexAcpClient.getModelProvider());
+        } catch (error) {
+            logger.log("Failed to refresh auth status", {error: String(error)});
+        }
+    }
+
+    /**
+     * Schedules the connection's first `_auth/status_update`: one account read,
+     * pushed whatever it says, including `none`.
+     *
+     * The push must not overtake the `initialize` response. The JSON-RPC layer
+     * writes that response in the microtask that resolves {@link initialize}, so
+     * the read starts from a check-phase callback, which always runs after it.
+     * `initialize` itself never waits for the read.
+     *
+     * "Unconditional" costs nothing extra here: nothing has been pushed yet on
+     * this connection, so {@link setAuthStatus} cannot suppress this one.
+     */
+    private publishFirstAuthStatusAfterResponse(): void {
+        setImmediate(() => void this.publishAuthStatusRead());
+    }
+
+    /**
+     * Reads the agent-owned identity and pushes it.
+     *
+     * Never rejects: an unreadable source means "nothing to report", not an
+     * error. The client then keeps showing the last pushed value, or "not
+     * reported" when there was none.
+     */
+    private async publishAuthStatusRead(): Promise<void> {
+        let authStatus: AuthStatus;
+        try {
+            authStatus = await this.readAgentAuthIdentity();
+        } catch (error) {
+            logger.log("Cannot determine auth status", {error: String(error)});
+            return;
+        }
+        await this.setAuthStatus(authStatus);
+    }
+
+    /**
+     * Builds the agent-owned auth identity. Routing the client configured
+     * through the ACP `providers/*` API is invisible here: the reported state
+     * is what the agent itself is logged in with. `gateway` stays reserved for
+     * agent-owned gateway state — the `gateway` auth method, or a provider the
+     * user configured in Codex's own config.
+     */
+    private async readAgentAuthIdentity(): Promise<AuthStatus> {
+        const authGatewayName = this.codexAcpClient.getAuthGatewayProviderName();
+        if (authGatewayName !== null) {
+            return gatewayStatus(authGatewayName);
+        }
+        const modelProvider = await this.runWithProcessCheck(() => this.codexAcpClient.getAgentConfiguredModelProvider());
+        if (!this.authProviderUsesOpenAiAccount(modelProvider)) {
+            return gatewayStatus(modelProvider);
+        }
+        const accountResponse = await this.runWithProcessCheck(() => this.codexAcpClient.getAccount());
+        return fromAccount(accountResponse.account);
+    }
+
+    /**
+     * Pushes `_auth/status_update` for the freshly read account of a provider.
+     * Agent-owned gateway authentication wins; a client-driven provider
+     * override is ignored and the agent-owned login is reported instead.
+     */
+    private async publishAuthStatus(
+        authProvider: string | null,
+        account: Account | null,
+    ): Promise<void> {
+        const authGatewayName = this.codexAcpClient.getAuthGatewayProviderName();
+        if (authGatewayName !== null) {
+            await this.setAuthStatus(gatewayStatus(authGatewayName));
+            return;
+        }
+        if (this.authProviderUsesOpenAiAccount(authProvider)) {
+            await this.setAuthStatus(fromAccount(account));
+            return;
+        }
+        if (this.codexAcpClient.isClientConfiguredProvider(authProvider)) {
+            // The session routes through client-configured providers; the agent-owned
+            // login is a separate question, so read it instead of reporting the
+            // override. A failed read means "nothing to report" — it must never
+            // take the session create down with it.
+            await this.publishAuthStatusRead();
+            return;
+        }
+        await this.setAuthStatus(gatewayStatus(authProvider));
+    }
+
+    /**
+     * Handles the app-server `account/updated` push: the free freshness channel
+     * for logins and logouts happening outside this connection.
+     */
+    handleAccountUpdated(notification: AccountUpdatedNotification): void {
+        void this.applyAccountUpdated(notification);
+    }
+
+    /**
+     * `account/updated` describes the Codex account only. It must never
+     * overwrite an agent-owned gateway status, which no account event can
+     * invalidate; only a gateway logout or a provider change does.
+     */
+    private async applyAccountUpdated(notification: AccountUpdatedNotification): Promise<void> {
+        try {
+            if (this.codexAcpClient.getAuthGatewayProviderName() !== null) {
+                return;
+            }
+            if (this.currentAuthStatus === null) {
+                // Nothing pushed yet, so the account event alone cannot tell whether
+                // the agent routes through its own gateway config: read the full state.
+                await this.publishAuthStatusRead();
+                return;
+            }
+            if (this.currentAuthStatus.kind === "gateway") {
+                return;
+            }
+            await this.setAuthStatus(fromAccountUpdated(notification, this.currentAuthStatus));
+        } catch (error) {
+            logger.log("Failed to apply account update to auth status", {error: String(error)});
+        }
+    }
+
+    /**
+     * Stores `next` and pushes `_auth/status_update`.
+     *
+     * A push goes out only when the payload changed. The identity is read on
+     * many occasions — `initialize`, each session create, each `account/updated`
+     * — and almost all of them see the login already reported.
+     * Clients replace their whole state on each update and tolerate duplicates,
+     * so a repeat is harmless, but it is pure noise all the same.
+     *
+     * The first push of a connection always goes out: nothing was reported yet,
+     * so no payload can equal it.
+     */
+    private async setAuthStatus(next: AuthStatus): Promise<void> {
+        if (sameAuthStatus(this.currentAuthStatus, next)) {
+            return;
+        }
+        this.currentAuthStatus = next;
+        try {
+            await this.connection.notify(AUTH_STATUS_UPDATE_METHOD, {authStatus: next});
+        } catch (error) {
+            logger.log("Failed to send auth status update", {error: String(error)});
         }
     }
 
@@ -2531,6 +2719,7 @@ export class CodexAcpServer {
                 clientSupportsTypedSessionFailures(this.clientCapabilities),
                 this.sessionFailureEpoch,
                 sessionState.subagents,
+                (accountUpdated) => this.handleAccountUpdated(accountUpdated),
             );
             eventHandler = promptEventHandler;
             const permissionLifecycle = this.permissionLifecycleContext(sessionState);

--- a/src/CodexEventHandler.ts
+++ b/src/CodexEventHandler.ts
@@ -13,6 +13,7 @@ import {type PlanEntry, RequestError} from "@agentclientprotocol/sdk";
 import {ACPSessionConnection, type AcpClientConnection, type UpdateSessionEvent} from "./ACPSessionConnection";
 import type {
     AccountRateLimitsUpdatedNotification,
+    AccountUpdatedNotification,
     AgentMessageDeltaNotification,
     CodexErrorInfo,
     CommandExecutionOutputDeltaNotification,
@@ -226,6 +227,8 @@ export class CodexEventHandler {
     private readonly terminalCommandOutputIds = new Set<string>();
     private readonly agentMessagePhases = new Map<string, string | null>();
     private readonly subagents: CodexSubagentEventRouter;
+    /** Connection-level `authStatus` sink; the app-server account push feeds it. */
+    private readonly onAccountUpdated: ((notification: AccountUpdatedNotification) => void) | undefined;
 
     constructor(
         connection: AcpClientConnection,
@@ -238,7 +241,9 @@ export class CodexEventHandler {
             false,
             new ACPSessionConnection(connection, sessionState.sessionId),
         ),
+        onAccountUpdated?: (notification: AccountUpdatedNotification) => void,
     ) {
+        this.onAccountUpdated = onAccountUpdated;
         this.sessionState = sessionState;
         this.supportsPlanUpdates = supportsPlanUpdates;
         this.supportsTypedSessionFailures = supportsTypedSessionFailures;
@@ -501,6 +506,9 @@ export class CodexEventHandler {
             case "account/rateLimits/updated":
                 this.handleRateLimitsUpdated(notification.params);
                 return null;
+            case "account/updated":
+                this.onAccountUpdated?.(notification.params);
+                return null;
             case "configWarning":
                 return await this.createConfigWarningEvent(notification.params);
             case "warning":
@@ -551,7 +559,6 @@ export class CodexEventHandler {
             case "turn/moderationMetadata":
             case "item/fileChange/outputDelta":
             case "item/fileChange/patchUpdated":
-            case "account/updated":
             case "fs/changed":
             case "mcpServer/startupStatus/updated":
             case "mcpServer/event/stream/notification":

--- a/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
+++ b/src/__tests__/CodexACPAgent/CodexAcpClient.test.ts
@@ -4,6 +4,7 @@ import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {CODEX_API_KEY_ENV_VAR, OPENAI_API_KEY_ENV_VAR, type CodexAuthRequest} from "../../CodexAuthMethod";
 import type * as acp from "@agentclientprotocol/sdk";
 import {
+    awaitFirstAuthStatusPush,
     createCodexMockTestFixture,
     createTestFixture,
     createTestModel,
@@ -38,6 +39,10 @@ describe('ACP server test', { timeout: 40_000 }, () => {
 
         await codexAcpAgent.initialize({protocolVersion: 1});
         await authFixture.getCodexAcpClient().logout();
+        // `initialize` reads the auth identity without waiting for it, and pushes
+        // it. Let that read land before the dump is cleared, so it cannot appear
+        // in the snapshot of the failing `newSession`.
+        await awaitFirstAuthStatusPush(authFixture);
         authFixture.clearCodexConnectionDump();
 
         await expect(
@@ -59,6 +64,7 @@ describe('ACP server test', { timeout: 40_000 }, () => {
         const unauthenticatedResponse = await keyFixture.getCodexAcpAgent().extMethod("authentication/status", {});
         expect(unauthenticatedResponse).toEqual({type: "unauthenticated"});
 
+        await awaitFirstAuthStatusPush(keyFixture);
         keyFixture.clearCodexConnectionDump();
 
         const authRequest: CodexAuthRequest = { methodId: "api-key", _meta: { "api-key": { apiKey: "TOKEN" }}};
@@ -87,6 +93,9 @@ describe('ACP server test', { timeout: 40_000 }, () => {
             "account/login/start",
             "account/read",
             "account/updated",
+            // Reads the connection auth identity for the `auth/status_update` push
+            // when no session is open yet.
+            "account/read",
             "thread/start",
             "model/list",
             "thread/started",

--- a/src/__tests__/CodexACPAgent/auth-status.test.ts
+++ b/src/__tests__/CodexACPAgent/auth-status.test.ts
@@ -1,0 +1,438 @@
+import {describe, expect, it, vi} from "vitest";
+import {
+    createCodexMockTestFixture,
+    createTestModel,
+    createTestSessionState,
+    mockPromptTurn,
+    type CodexMockTestFixture,
+    type MethodCallEvent,
+} from "../acp-test-utils";
+import {
+    AUTH_STATUS_META_KEY,
+    AUTH_STATUS_UPDATE_METHOD,
+    type AuthStatus,
+} from "../../AuthStatusMeta";
+import {ModelId} from "../../ModelId";
+import {PROTOCOL_VERSION} from "@agentclientprotocol/sdk";
+import {CodexEventHandler} from "../../CodexEventHandler";
+import type {AcpClientConnection} from "../../ACPSessionConnection";
+import type {Account, AccountUpdatedNotification} from "../../app-server/v2";
+
+const CHAT_GPT_PLUS: AuthStatus = {
+    kind: "account",
+    label: "ChatGPT Plus",
+    account: {email: "user@example.com", plan: "plus"},
+};
+
+function authStatusUpdates(fixture: CodexMockTestFixture): AuthStatus[] {
+    return fixture.getAcpConnectionEvents([])
+        .filter((event: MethodCallEvent) => event.method === "notify" && event.args[0] === AUTH_STATUS_UPDATE_METHOD)
+        .map((event: MethodCallEvent) => (event.args[1] as {authStatus: AuthStatus}).authStatus);
+}
+
+function mockAccount(fixture: CodexMockTestFixture, account: Account | null) {
+    return vi.spyOn(fixture.getCodexAcpClient(), "getAccount").mockResolvedValue({
+        account,
+        requiresOpenaiAuth: account === null,
+    });
+}
+
+/** Waits for the fire-and-forget publishes of `initialize` and `account/updated`. */
+async function awaitAuthStatusUpdates(fixture: CodexMockTestFixture, count: number): Promise<AuthStatus[]> {
+    await vi.waitFor(() => expect(authStatusUpdates(fixture)).toHaveLength(count));
+    return authStatusUpdates(fixture);
+}
+
+/**
+ * Lets every already-scheduled callback run, so that "nothing was pushed" is a
+ * verdict and not a race. Once its source is mocked, the identity read is a
+ * fixed, short chain of scheduled work.
+ */
+async function drainScheduledWork(): Promise<void> {
+    for (let round = 0; round < 5; round += 1) {
+        await new Promise<void>(resolve => setImmediate(resolve));
+    }
+}
+
+/** `initialize`, plus the first push it starts. */
+async function initializeAndAwaitFirstPush(fixture: CodexMockTestFixture): Promise<AuthStatus> {
+    await fixture.getCodexAcpAgent().initialize({protocolVersion: PROTOCOL_VERSION});
+    const [first] = await awaitAuthStatusUpdates(fixture, 1);
+    return first!;
+}
+
+/** A session whose prompts complete immediately, to exercise turn boundaries. */
+async function createPromptableSession(fixture: CodexMockTestFixture): Promise<string> {
+    const agent = fixture.getCodexAcpAgent();
+    const client = fixture.getCodexAcpClient();
+    const model = createTestModel();
+    vi.spyOn(client, "authRequired").mockResolvedValue(false);
+    vi.spyOn(client, "listSkills").mockResolvedValue({data: []});
+    vi.spyOn(client, "newSession").mockResolvedValue({
+        sessionId: "turn-session",
+        currentModelId: ModelId.create(model.id, model.defaultReasoningEffort).toString(),
+        models: [model],
+        collaborationMode: "default",
+        additionalDirectories: [],
+    });
+    const session = await agent.newSession({cwd: "/workspace", mcpServers: []});
+    mockPromptTurn(fixture, session.sessionId);
+    return session.sessionId;
+}
+
+/** The `gateway` auth method: agent-owned gateway authentication. */
+function gatewayAuthRequest(providerName: string) {
+    return {
+        methodId: "gateway",
+        _meta: {
+            gateway: {
+                baseUrl: "https://gateway.example.com/v1",
+                providerName,
+            },
+        },
+    };
+}
+
+describe("authStatus extension", () => {
+    describe("capability marker", () => {
+        it("is advertised in the initialize response, without a payload", async () => {
+            const fixture = createCodexMockTestFixture();
+
+            const response = await fixture.getCodexAcpAgent().initialize({protocolVersion: PROTOCOL_VERSION});
+
+            expect(response.agentCapabilities?._meta?.[AUTH_STATUS_META_KEY]).toEqual({});
+            expect(response._meta?.[AUTH_STATUS_META_KEY]).toBeUndefined();
+        });
+    });
+
+    describe("first push after initialize", () => {
+        it("follows the initialize response and reports the account", async () => {
+            const fixture = createCodexMockTestFixture();
+            mockAccount(fixture, {type: "chatgpt", email: "user@example.com", planType: "plus"});
+
+            await fixture.getCodexAcpAgent().initialize({protocolVersion: PROTOCOL_VERSION});
+
+            // The response is ready to go out and nothing has been pushed yet, so the
+            // client can never see the identity before it knows the agent pushes one.
+            expect(authStatusUpdates(fixture)).toEqual([]);
+            expect(await awaitAuthStatusUpdates(fixture, 1)).toEqual([CHAT_GPT_PLUS]);
+        });
+
+        it("reports an API key account", async () => {
+            const fixture = createCodexMockTestFixture();
+            mockAccount(fixture, {type: "apiKey"});
+
+            expect(await initializeAndAwaitFirstPush(fixture))
+                .toEqual({kind: "api_key", label: "OpenAI API key"});
+        });
+
+        it("reports Bedrock as external auth", async () => {
+            const fixture = createCodexMockTestFixture();
+            mockAccount(fixture, {type: "amazonBedrock", usesCodexManagedCredentials: false});
+
+            expect(await initializeAndAwaitFirstPush(fixture))
+                .toEqual({kind: "external", label: "AWS Bedrock"});
+        });
+
+        it("reports a logged-out agent as kind none", async () => {
+            const fixture = createCodexMockTestFixture();
+            mockAccount(fixture, null);
+
+            // The first push is unconditional: a known logged-out state is news too.
+            expect(await initializeAndAwaitFirstPush(fixture))
+                .toEqual({kind: "none", label: "Not logged in"});
+        });
+
+        it("reports gateway for a provider configured in Codex's own config", async () => {
+            const fixture = createCodexMockTestFixture();
+            mockAccount(fixture, {type: "chatgpt", email: "user@example.com", planType: "plus"});
+            vi.spyOn(fixture.getCodexAcpClient(), "getAgentConfiguredModelProvider")
+                .mockResolvedValue("custom-provider");
+
+            expect(await initializeAndAwaitFirstPush(fixture))
+                .toEqual({kind: "gateway", label: "Custom model gateway", detail: "custom-provider"});
+        });
+
+        it("ignores routing the client configured through the providers API", async () => {
+            const fixture = createCodexMockTestFixture();
+            const agent = fixture.getCodexAcpAgent();
+            mockAccount(fixture, {type: "chatgpt", email: "user@example.com", planType: "plus"});
+
+            await agent.setProvider({
+                providerId: "openai",
+                apiType: "openai",
+                baseUrl: "https://gateway.example.com/v1",
+            });
+
+            expect(await initializeAndAwaitFirstPush(fixture)).toEqual(CHAT_GPT_PLUS);
+        });
+
+        it("capitalizes unknown plan values and omits the unknown plan marker", async () => {
+            const rawPlanFixture = createCodexMockTestFixture();
+            mockAccount(rawPlanFixture, {type: "chatgpt", email: null, planType: "prolite"});
+            expect(await initializeAndAwaitFirstPush(rawPlanFixture)).toEqual({
+                kind: "account",
+                label: "ChatGPT Prolite",
+                account: {plan: "prolite"},
+            });
+
+            const unknownPlanFixture = createCodexMockTestFixture();
+            mockAccount(unknownPlanFixture, {type: "chatgpt", email: null, planType: "unknown"});
+            expect(await initializeAndAwaitFirstPush(unknownPlanFixture)).toEqual({
+                kind: "account",
+                label: "ChatGPT",
+                account: {plan: "unknown"},
+            });
+        });
+
+        it("keeps the plan the legacy authentication/status method drops", async () => {
+            const fixture = createCodexMockTestFixture();
+            mockAccount(fixture, {type: "chatgpt", email: "user@example.com", planType: "business"});
+
+            const legacy = await fixture.getCodexAcpAgent().extMethod("authentication/status", {});
+            expect(legacy).toEqual({type: "chat-gpt", email: "user@example.com"});
+
+            const authStatus = await initializeAndAwaitFirstPush(fixture);
+            expect(authStatus.label).toBe("ChatGPT Business");
+            expect(authStatus.account).toEqual({email: "user@example.com", plan: "business"});
+        });
+
+        it("pushes nothing when the identity cannot be read", async () => {
+            const fixture = createCodexMockTestFixture();
+            vi.spyOn(fixture.getCodexAcpClient(), "getAccount")
+                .mockRejectedValue(new Error("app-server is gone"));
+
+            await fixture.getCodexAcpAgent().initialize({protocolVersion: PROTOCOL_VERSION});
+            await drainScheduledWork();
+
+            // An agent that cannot learn its identity says nothing, and the client
+            // shows "not reported" instead of an invented state.
+            expect(authStatusUpdates(fixture)).toEqual([]);
+        });
+    });
+
+    describe("_auth/status_update notification", () => {
+        it("is sent after a successful authenticate", async () => {
+            const fixture = createCodexMockTestFixture();
+            vi.spyOn(fixture.getCodexAcpClient(), "authenticate").mockResolvedValue(true);
+            mockAccount(fixture, {type: "chatgpt", email: "user@example.com", planType: "pro"});
+
+            await fixture.getCodexAcpAgent().authenticate({methodId: "chat-gpt"});
+
+            expect(authStatusUpdates(fixture)).toEqual([{
+                kind: "account",
+                label: "ChatGPT Pro",
+                account: {email: "user@example.com", plan: "pro"},
+            }]);
+        });
+
+        it("reports the agent-owned login while client-driven routing is active", async () => {
+            const fixture = createCodexMockTestFixture();
+            const agent = fixture.getCodexAcpAgent();
+            vi.spyOn(fixture.getCodexAcpClient(), "authenticate").mockResolvedValue(true);
+            mockAccount(fixture, {type: "chatgpt", email: "user@example.com", planType: "plus"});
+
+            await agent.setProvider({
+                providerId: "openai",
+                apiType: "openai",
+                baseUrl: "https://gateway.example.com/v1",
+            });
+            await agent.authenticate({methodId: "chat-gpt"});
+
+            expect(authStatusUpdates(fixture)).toEqual([CHAT_GPT_PLUS]);
+        });
+
+        it("is sent after a logout", async () => {
+            const fixture = createCodexMockTestFixture();
+            const agent = fixture.getCodexAcpAgent();
+            vi.spyOn(fixture.getCodexAcpClient(), "authenticate").mockResolvedValue(true);
+            vi.spyOn(fixture.getCodexAcpClient(), "logout").mockResolvedValue();
+            const accountSpy = mockAccount(fixture, {type: "chatgpt", email: "user@example.com", planType: "pro"});
+
+            await agent.authenticate({methodId: "chat-gpt"});
+            accountSpy.mockResolvedValue({account: null, requiresOpenaiAuth: true});
+            await agent.logout({});
+
+            expect(authStatusUpdates(fixture)).toEqual([
+                {
+                    kind: "account",
+                    label: "ChatGPT Pro",
+                    account: {email: "user@example.com", plan: "pro"},
+                },
+                {kind: "none", label: "Not logged in"},
+            ]);
+        });
+
+        it("is sent when the app-server pushes account/updated", async () => {
+            const fixture = createCodexMockTestFixture();
+            vi.spyOn(fixture.getCodexAcpClient(), "authenticate").mockResolvedValue(true);
+            mockAccount(fixture, {type: "chatgpt", email: "user@example.com", planType: "plus"});
+            const agent = fixture.getCodexAcpAgent();
+
+            await agent.authenticate({methodId: "chat-gpt"});
+            agent.handleAccountUpdated({authMode: "chatgpt", planType: "pro"});
+
+            expect(await awaitAuthStatusUpdates(fixture, 2)).toEqual([
+                CHAT_GPT_PLUS,
+                {
+                    // The push carries no email; the last known one survives an unchanged kind.
+                    kind: "account",
+                    label: "ChatGPT Pro",
+                    account: {email: "user@example.com", plan: "pro"},
+                },
+            ]);
+        });
+
+        it("drops the last known email when the account kind changes", async () => {
+            const fixture = createCodexMockTestFixture();
+            vi.spyOn(fixture.getCodexAcpClient(), "authenticate").mockResolvedValue(true);
+            mockAccount(fixture, {type: "chatgpt", email: "user@example.com", planType: "plus"});
+            const agent = fixture.getCodexAcpAgent();
+
+            await agent.authenticate({methodId: "chat-gpt"});
+            agent.handleAccountUpdated({authMode: "apikey", planType: null});
+
+            expect((await awaitAuthStatusUpdates(fixture, 2)).at(-1)).toEqual({
+                kind: "api_key",
+                label: "OpenAI API key",
+            });
+        });
+
+        it("maps the bedrockAccessKeys auth mode to external Bedrock", async () => {
+            const fixture = createCodexMockTestFixture();
+            vi.spyOn(fixture.getCodexAcpClient(), "authenticate").mockResolvedValue(true);
+            mockAccount(fixture, {type: "chatgpt", email: "user@example.com", planType: "plus"});
+            const agent = fixture.getCodexAcpAgent();
+
+            await agent.authenticate({methodId: "chat-gpt"});
+            agent.handleAccountUpdated({authMode: "bedrockAccessKeys", planType: null});
+
+            expect((await awaitAuthStatusUpdates(fixture, 2)).at(-1)).toEqual({
+                kind: "external",
+                label: "AWS Bedrock",
+            });
+        });
+
+        it("is not sent again while the identity is unchanged", async () => {
+            const fixture = createCodexMockTestFixture();
+            vi.spyOn(fixture.getCodexAcpClient(), "authenticate").mockResolvedValue(true);
+            mockAccount(fixture, {type: "chatgpt", email: "user@example.com", planType: "plus"});
+            const agent = fixture.getCodexAcpAgent();
+
+            // Four reads of the same login: two authenticates, the `initialize` read,
+            // and an account push.
+            await agent.authenticate({methodId: "chat-gpt"});
+            await agent.authenticate({methodId: "chat-gpt"});
+            await agent.initialize({protocolVersion: PROTOCOL_VERSION});
+            agent.handleAccountUpdated({authMode: "chatgpt", planType: "plus"});
+            await drainScheduledWork();
+
+            expect(authStatusUpdates(fixture)).toEqual([CHAT_GPT_PLUS]);
+        });
+
+        it("is sent again once the identity actually changes", async () => {
+            const fixture = createCodexMockTestFixture();
+            vi.spyOn(fixture.getCodexAcpClient(), "authenticate").mockResolvedValue(true);
+            const accountSpy = mockAccount(
+                fixture,
+                {type: "chatgpt", email: "user@example.com", planType: "plus"},
+            );
+            const agent = fixture.getCodexAcpAgent();
+
+            await agent.authenticate({methodId: "chat-gpt"});
+            accountSpy.mockResolvedValue({
+                account: {type: "chatgpt", email: "user@example.com", planType: "pro"},
+                requiresOpenaiAuth: false,
+            });
+            await agent.authenticate({methodId: "chat-gpt"});
+
+            expect(authStatusUpdates(fixture)).toEqual([
+                CHAT_GPT_PLUS,
+                {
+                    kind: "account",
+                    label: "ChatGPT Pro",
+                    account: {email: "user@example.com", plan: "pro"},
+                },
+            ]);
+        });
+
+        it("keeps the gateway status when an account event arrives", async () => {
+            const fixture = createCodexMockTestFixture();
+            mockAccount(fixture, {type: "chatgpt", email: "user@example.com", planType: "plus"});
+            const agent = fixture.getCodexAcpAgent();
+
+            await agent.authenticate(gatewayAuthRequest("ACME Gateway"));
+            agent.handleAccountUpdated({authMode: "chatgpt", planType: "pro"});
+            agent.handleAccountUpdated({authMode: null, planType: null});
+            await drainScheduledWork();
+
+            // The account push says nothing about gateway authentication, so it is ignored.
+            expect(authStatusUpdates(fixture))
+                .toEqual([{kind: "gateway", label: "Custom model gateway", detail: "ACME Gateway"}]);
+        });
+    });
+
+    describe("freshness", () => {
+        it("does not re-read the identity on a turn", async () => {
+            const fixture = createCodexMockTestFixture();
+            const accountSpy = mockAccount(
+                fixture,
+                {type: "chatgpt", email: "user@example.com", planType: "plus"},
+            );
+            const sessionId = await createPromptableSession(fixture);
+            accountSpy.mockClear();
+
+            await fixture.getCodexAcpAgent().prompt({
+                sessionId,
+                prompt: [{type: "text", text: "hello"}],
+            });
+            await awaitAuthStatusUpdates(fixture, 1);
+
+            // A login or a logout made elsewhere arrives as `account/updated`, so a
+            // turn buys nothing by reading the account again.
+            expect(accountSpy).not.toHaveBeenCalled();
+        });
+
+        it("reports an out-of-band login through the account/updated push", async () => {
+            const fixture = createCodexMockTestFixture();
+            const agent = fixture.getCodexAcpAgent();
+            mockAccount(fixture, null);
+            await createPromptableSession(fixture);
+            await awaitAuthStatusUpdates(fixture, 1);
+
+            // Someone logs in from another terminal while this connection is idle.
+            agent.handleAccountUpdated({authMode: "chatgpt", planType: "pro"});
+
+            expect(await awaitAuthStatusUpdates(fixture, 2)).toEqual([
+                {kind: "none", label: "Not logged in"},
+                {kind: "account", label: "ChatGPT Pro", account: {plan: "pro"}},
+            ]);
+        });
+    });
+
+    describe("account/updated event routing", () => {
+        it("forwards the app-server notification to the connection-level sink", async () => {
+            const received: AccountUpdatedNotification[] = [];
+            const connection = {
+                notify: vi.fn(async () => {}),
+                request: vi.fn(),
+            } as unknown as AcpClientConnection;
+            const handler = new CodexEventHandler(
+                connection,
+                createTestSessionState(),
+                false,
+                false,
+                "epoch",
+                undefined,
+                (notification: AccountUpdatedNotification) => received.push(notification),
+            );
+
+            await handler.handleNotification({
+                method: "account/updated",
+                params: {authMode: "chatgpt", planType: "plus"},
+            });
+
+            expect(received).toEqual([{authMode: "chatgpt", planType: "plus"}]);
+        });
+    });
+});

--- a/src/__tests__/CodexACPAgent/data/load-session-history.json
+++ b/src/__tests__/CodexACPAgent/data/load-session-history.json
@@ -1,4 +1,16 @@
 {
+  "method": "notify",
+  "args": [
+    "_auth/status_update",
+    {
+      "authStatus": {
+        "kind": "none",
+        "label": "Not logged in"
+      }
+    }
+  ]
+}
+{
   "method": "sessionUpdate",
   "args": [
     {

--- a/src/__tests__/CodexACPAgent/data/load-session-response-item-history-fallback.json
+++ b/src/__tests__/CodexACPAgent/data/load-session-response-item-history-fallback.json
@@ -1,4 +1,16 @@
 {
+  "method": "notify",
+  "args": [
+    "_auth/status_update",
+    {
+      "authStatus": {
+        "kind": "none",
+        "label": "Not logged in"
+      }
+    }
+  ]
+}
+{
   "method": "sessionUpdate",
   "args": [
     {

--- a/src/__tests__/CodexACPAgent/initialize.test.ts
+++ b/src/__tests__/CodexACPAgent/initialize.test.ts
@@ -61,6 +61,9 @@ describe('CodexACPAgent - initialize', () => {
                     http: true,
                     sse: false,
                 },
+                _meta: {
+                    authStatus: {},
+                },
             },
             authMethods: getCodexAuthMethods(),
             _meta: {

--- a/src/__tests__/CodexACPAgent/session-fork.test.ts
+++ b/src/__tests__/CodexACPAgent/session-fork.test.ts
@@ -29,7 +29,14 @@ describe("ACP session fork", () => {
 
         expect(response.sessionId).toBe("fork-id");
         expect(agent.getSessionState("fork-id").cwd).toBe("/workspace");
-        expect(fixture.getAcpConnectionEvents([])).toEqual([]);
+        // Forking creates a session, so the connection reports the account it was
+        // created under (`authStatus` extension). Nothing else is sent.
+        expect(fixture.getAcpConnectionEvents([])).toEqual([
+            {
+                method: "notify",
+                args: ["_auth/status_update", {authStatus: {kind: "none", label: "Not logged in"}}],
+            },
+        ]);
         expect(forkSpy).toHaveBeenCalledWith({
             sessionId: "source-id",
             cwd: "/workspace",

--- a/src/__tests__/acp-test-utils.ts
+++ b/src/__tests__/acp-test-utils.ts
@@ -15,6 +15,7 @@ import {DEFAULT_COLLABORATION_MODE} from "../CollaborationModeConfig";
 import {expect, vi} from "vitest";
 import type {Model, ReasoningEffortOption} from "../app-server/v2";
 import {CodexSubagentEventRouter} from "../subagents/CodexSubagentEventRouter";
+import {AUTH_STATUS_UPDATE_METHOD} from "../AuthStatusMeta";
 
 export type MethodCallEvent = { method: string; args: any[] };
 
@@ -442,6 +443,19 @@ export function createTestModel(overrides?: Partial<Model>): Model {
         isDefault: true,
         ...overrides,
     };
+}
+
+/**
+ * Waits for the connection's first `_auth/status_update`. `initialize` starts
+ * the identity read that produces it and never waits for the read, so a test
+ * that must not race it waits here instead.
+ */
+export async function awaitFirstAuthStatusPush(fixture: TestFixture): Promise<void> {
+    await vi.waitFor(() => {
+        const pushed = fixture.getAcpConnectionEvents([]).some(event =>
+            event.method === "notify" && event.args[0] === AUTH_STATUS_UPDATE_METHOD);
+        expect(pushed).toBe(true);
+    });
 }
 
 export function setupPromptTestSession(sessionOverrides?: Partial<SessionState>) {


### PR DESCRIPTION
## What

An interim ACP extension that reports which auth identity the agent process pays with: `kind` (`account` | `api_key` | `gateway` | `external` | `none`), `label`, optional `detail`, optional `account { email, organization, plan }`. Connection-scoped. Reporting only.

It is push only:

- The agent sends the notification `_auth/status_update` with `{ authStatus }`. The client sends nothing, and there is no request method to ask for the value.
- `agentCapabilities._meta.authStatus` is an empty marker object. It means "this agent pushes its identity". It carries no payload and gates nothing the client sends.

The method name carries the `_` prefix ACP requires for custom methods, and both the capability and the payload live under `_meta`. Everything is additive. Same contract as claude-agent-acp ([#1080](https://github.com/agentclientprotocol/claude-agent-acp/pull/1080)) and Junie.

## When the agent pushes

- **Once after `initialize`**, whatever the account read says, including `none`. The read is started from a check-phase callback, so the push can never overtake the `initialize` response, and `initialize` never waits for the read.
- **On change only**, after that: a completed `authenticate` or `logout`, each session create, fork and load (a refused session reports too, so the client knows which account was refused), and the app-server's `account/updated` event, which covers a login or a logout done in another terminal.

No timers, and no read at a turn boundary: `account/updated` already reports out-of-band changes, so a turn costs nothing here.

An agent that cannot read its identity pushes nothing, and the client keeps showing "not reported". `kind: "none"` is not that case: it is a known logged-out state, and it is reported.

## Mapping

`chatgpt` becomes `account`, with the plan in the label ("ChatGPT Pro") and the email in `account`. `apiKey` and `personalAccessToken` become `api_key`. `amazonBedrock`, the two Bedrock auth modes and `agentIdentity` become `external`. The `gateway` auth method, or a model provider configured in Codex's own config, becomes `gateway`, with the provider name in `detail`. Routing the client sets through `providers/set` is ignored: the agent reports its own login, not the client's override. The legacy `authentication/status` method stays and is marked deprecated in its doc comment.

## Why push only

The earlier design also had an `_auth/status` request. All three reasons for it are covered without it: a first value at connect is the unconditional push after `initialize`, freshness is the `account/updated` event, and the capability flag now says "I push". Dropping the request removes a message crossing in the client (a push and a pull answer racing), a generation counter, a re-ask after authentication, and a read timeout.

## Compatibility

Additive. A client that does not know the extension sees one extra empty object in `agentCapabilities._meta` and drops the notification.

## Test plan

- `npm run typecheck` and `npm run build`: clean.
- `npm test`: 514 passed, 26 skipped. Run three more times without `--retry` to catch races in the fire-and-forget read; none.
- `src/__tests__/CodexACPAgent/auth-status.test.ts` covers the capability marker, the first push following the `initialize` response, the mappers (including `bedrockAccessKeys`), push-on-change and the suppressed repeat, the `account/updated` path, gateway status surviving an account event, "no re-read on a turn", and an unreadable identity pushing nothing.

## Not in this PR

- A `docs/` page for the extension; sibling extensions have one.
- A `detail` line for `api_key` and `external` (Codex exposes no key source; Bedrock's `usesCodexManagedCredentials` could be one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
