### PR TITLE
fix: pass excludeTurns to the file-change report fork

### DIFF
--- a/src/CodexAcpClient.ts
+++ b/src/CodexAcpClient.ts
@@ -929,6 +929,7 @@ export class CodexAcpClient {
                 sandbox: "read-only",
                 developerInstructions: AGENT_FILE_CHANGE_REPORT_DEVELOPER_INSTRUCTIONS,
                 ephemeral: true,
+                excludeTurns: true,
             });
             void forkPromise.then(fork => {
                 if (lateStopReason !== null && forkThreadId === null) {

--- a/src/__tests__/CodexACPAgent/agent-file-change-report.test.ts
+++ b/src/__tests__/CodexACPAgent/agent-file-change-report.test.ts
@@ -184,6 +184,7 @@ describe("agent file-change report lifecycle", () => {
             sandbox: "read-only",
             developerInstructions: expect.any(String),
             ephemeral: true,
+            excludeTurns: true,
         });
         expect(turnStart).toHaveBeenNthCalledWith(2, {
             threadId: "audit-thread",


### PR DESCRIPTION
Codex 0.152.0 defaults durable threads to paginated history. The app-server rejects an ephemeral fork of a paginated thread unless the fork sets excludeTurns: true. The file-change report fork did not set it, so every report failed with providerError. The report never reads the forked turns, so the flag is safe.