### PR TITLE
fix: announce ad-hoc spawned subagents so their output is not dropped

### DIFF
--- a/src/__tests__/CodexACPAgent/collab-agent-events.test.ts
+++ b/src/__tests__/CodexACPAgent/collab-agent-events.test.ts
@@ -1023,6 +1023,87 @@ describe("CodexEventHandler - collab agent tool call events", () => {
         expect(terminal?.args[0].update.state).toBe("cancelled");
     });
 
+    it("announces an unannounced spawn so its output is not lost", async () => {
+        // Codex names the subagents it defines, but an ad-hoc `spawn_agent`
+        // produces no activity item at all. The spawn's own completion is the
+        // last moment before the child starts talking, so it is what announces.
+        await initializeNativeSubagents();
+        const notifications: ServerNotification[] = [
+            {
+                method: "item/completed",
+                params: {
+                    threadId: sessionId,
+                    turnId: "turn-1",
+                    completedAtMs: 0,
+                    item: {
+                        type: "collabAgentToolCall",
+                        id: "call-spawn-adhoc",
+                        tool: "spawnAgent",
+                        status: "completed",
+                        senderThreadId: sessionId,
+                        receiverThreadIds: ["thread-adhoc"],
+                        prompt: "Trace the data flow.",
+                        model: null,
+                        reasoningEffort: null,
+                        agentsStates: {
+                            "thread-adhoc": {status: "pendingInit", message: null},
+                        },
+                    },
+                },
+            },
+            {
+                method: "item/started",
+                params: {
+                    threadId: "thread-adhoc",
+                    turnId: "turn-child",
+                    startedAtMs: 0,
+                    item: {
+                        type: "commandExecution",
+                        id: "child-command",
+                        pluginId: null,
+                        scriptPath: null,
+                        command: "rg --files",
+                        cwd: "/test/project",
+                        processId: null,
+                        source: "agent",
+                        status: "inProgress",
+                        commandActions: [],
+                        aggregatedOutput: null,
+                        exitCode: null,
+                        durationMs: null,
+                    },
+                },
+            },
+        ];
+
+        await setupPromptAndSendNotifications(mockFixture, sessionId, sessionState, notifications);
+
+        const updates = mockFixture.getAcpConnectionEvents([])
+            .filter(event => event.method === "sessionUpdate")
+            .map(event => event.args[0]);
+        // Announced against the parent, under the fallback identity, carrying
+        // the spawn prompt as the task.
+        expect(updates).toContainEqual({
+            sessionId,
+            update: {
+                sessionUpdate: "subagent_spawned",
+                subagentSessionId: "thread-adhoc",
+                name: "Agent ad-adhoc",
+                task: "Trace the data flow.",
+                capabilities: {},
+            },
+        });
+        // The work it does belongs to the child's session, not the thread's.
+        expect(updates.filter(update => update.sessionId === "thread-adhoc"))
+            .toContainEqual(expect.objectContaining({
+                update: expect.objectContaining({sessionUpdate: "tool_call"}),
+            }));
+        // And the spawn itself never appears in the thread as a bare tool call.
+        expect(updates.filter(update => update.sessionId === sessionId)
+            .map(update => update.update.sessionUpdate))
+            .not.toContain("tool_call");
+    });
+
     it("waits for a pending spawn without publishing fallback identity and suppresses late activity", async () => {
         await initializeNativeSubagents();
         const appServer = mockFixture.getCodexAppServerClient();

--- a/src/subagents/CodexSubagentEventRouter.ts
+++ b/src/subagents/CodexSubagentEventRouter.ts
@@ -153,6 +153,22 @@ export class CodexSubagentEventRouter {
             }
         }
 
+        // Waiting for an activity item to name the child only works for
+        // subagents Codex names; an ad-hoc `spawn_agent` is never announced, so
+        // the child talks into a buffer that fills and drops its oldest updates
+        // while the client never learns it existed. A completed spawn is Codex
+        // confirming the child, and lands before any of its output. An activity
+        // item that does arrive first still wins: materializing twice is a no-op.
+        if (item.tool === "spawnAgent" && notification.method === "item/completed") {
+            for (const childSessionId of item.receiverThreadIds) {
+                if (!this.pendingSpawns.has(childSessionId)) continue;
+                const state = item.agentsStates[childSessionId];
+                if (state && terminalStateOf(state.status) !== undefined) continue;
+                logger.log(`Announcing spawned subagent ${childSessionId} from its spawn; Codex named no agent path`);
+                await this.materialize(childSessionId);
+            }
+        }
+
         for (const [childSessionId, state] of Object.entries(item.agentsStates)) {
             const terminalState = state && terminalStateOf(state.status);
             if (!terminalState) continue;
@@ -305,11 +321,22 @@ export class CodexSubagentEventRouter {
             : [];
     }
 
-    private async materialize(childSessionId: string, path: string): Promise<void> {
+    /**
+     * Announces a child as a native subagent session. `path` is Codex's agent
+     * path, which names the subagent and locates it in the tree; a spawn that
+     * was never announced by an activity item has none, and is announced under
+     * the fallback identity against the parent recorded when it was spawned.
+     */
+    private async materialize(childSessionId: string, path?: string): Promise<void> {
         if (this.children.has(childSessionId)) return;
         const pending = this.pendingSpawns.get(childSessionId);
-        const name = nameFromAgentPath(path, fallbackName(childSessionId));
-        const inferredParent = this.parentForPath(path);
+        if (path === undefined && !pending) return;
+        const name = path === undefined
+            ? fallbackName(childSessionId)
+            : nameFromAgentPath(path, fallbackName(childSessionId));
+        const inferredParent = path === undefined
+            ? {threadId: this.rootSessionId, sessionId: this.rootSessionId}
+            : this.parentForPath(path);
         const parentThreadId = pending?.parentThreadId ?? inferredParent.threadId;
         const parentSessionId = pending?.parentSessionId ?? inferredParent.sessionId;
         const task = pending?.task ?? `Delegated task for ${name}`;
@@ -326,7 +353,7 @@ export class CodexSubagentEventRouter {
             sessionId: childSessionId,
             name,
             task,
-            path: normalizeAgentPath(path),
+            ...(path === undefined ? {} : {path: normalizeAgentPath(path)}),
             generation: 1,
         });
         this.pendingSpawns.delete(childSessionId);


### PR DESCRIPTION
## Problem

A spawn is registered as pending in `CodexSubagentEventRouter.handle()` and is only announced when a `subAgentActivity` item later supplies its agent path:

```ts
if (item.type === "subAgentActivity") {
    …
    await this.materialize(item.agentThreadId, item.agentPath);
```

Codex sends that item for subagents it names, but not for an ad-hoc `spawn_agent`. Every notification from the child then matches the pending-spawn branch and is buffered against a materialization that never arrives — until `MAX_PENDING_NOTIFICATIONS`, after which its oldest updates are dropped. The client is never told the subagent exists, and the transcript it produced is lost.

Because the spawn's `item/completed` is reported as represented, it is also swallowed, so the client is left with the `item/started` copy — which leaks through only because its `receiverThreadIds` is still empty — stuck at `in_progress` for the rest of the session.

## Evidence

Codex 0.153.4, adapter 1.7.0, native subagent sessions negotiated, prompt "use subagents to analyze this repo" (`APP_SERVER_LOGS`):

```
item/started   collabAgentToolCall  tool: spawnAgent  receiverThreadIds: []
item/completed collabAgentToolCall  tool: spawnAgent  receiverThreadIds: ['01a07280-e0fa-…']
                                    agentsStates: {'01a07280-e0fa-…': {status: 'pendingInit'}}
item/started   collabAgentToolCall  tool: wait        receiverThreadIds: ['01a07280-e18f-…']
```

- `subAgentActivity` items in the whole log: **0**
- child-thread notifications: **422**
- `Pending subagent 01a07280-e18f-… exceeded the notification buffer; dropping oldest updates`

Found while integrating an ACP client; the same shape is described in manaflow-ai/cmux#5698, and #238 mapped `spawn_agent` onto tool calls with nested sessions left optional.

## Fix

Announce from the spawn's own `item/completed`, which carries `receiverThreadIds` and lands before any child output — the point where `subagent_spawned` is supposed to go. `materialize()` takes the agent path as optional, since an ad-hoc spawn has none, and falls back to the identity helper that already existed for exactly that case.

Named subagents are unaffected: an activity item that arrives first still wins, because materializing a known child is a no-op, so they keep the name their path gives them. That ordering is what the existing tests assert, and they pass unmodified — including `emits native lifecycle and routes child output after capability negotiation`, which is the case where child output precedes the announcement.

Terminal states are skipped, so a spawn that completes already-terminal still finishes as pending rather than being announced, per `waits for a pending spawn without publishing fallback identity and suppresses late activity`.

## Testing

- New: `announces an unannounced spawn so its output is not lost` — asserts `subagent_spawned` against the parent under the fallback identity with the spawn prompt as its task, the child's own tool call routed to the child session, and no bare `spawnAgent` tool call in the thread.
- `npm run typecheck` and `npm test`: **542 passed, 26 skipped, 0 failed**, no existing test modified.
- Exercised end to end against real Codex through an ACP client: subagents announced, their work attributed to them, nothing left buffered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
