### PR TITLE
feat: allow disabling session title generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The adapter advertises ACP auth methods during initialization. Clients can authe
 - `INITIAL_AGENT_MODE` - initial mode id: `read-only`, `agent`, or `agent-full-access`.
 - `NO_BROWSER` - hide browser-based ChatGPT auth when set.
 - `APP_SERVER_LOGS` - directory for adapter logs.
+- `ACP_DISABLE_TITLE_GENERATION` - set to `1` to skip the adapter's extra model call for session titles. Applies to every session in this adapter process; unset or other values retain automatic generation. Existing titles, prompt-derived fallback titles, and `/rename` remain available.
 
 ## Development
 

--- a/readme-dev.md
+++ b/readme-dev.md
@@ -12,6 +12,7 @@ Set `CODEX_PATH` to run a different Codex binary; versions other than the one sp
 - `INITIAL_AGENT_MODE` - initial mode id: `read-only`, `agent`, or `agent-full-access`.
 - `NO_BROWSER` - hide browser-based ChatGPT auth when set.
 - `APP_SERVER_LOGS` - directory for adapter logs.
+- `ACP_DISABLE_TITLE_GENERATION` - set to `1` to skip the adapter's extra model call for session titles. Applies to every session in this adapter process; unset or other values retain automatic generation. Existing titles, prompt-derived fallback titles, and `/rename` remain available. This is an adapter-specific option, not an ACP protocol setting.
 
 ### Quick start
 

--- a/src/TitleGenerator.ts
+++ b/src/TitleGenerator.ts
@@ -46,6 +46,7 @@ export class TitleGenerator {
      *                        not turn.items — turn.items contains only agent output).
      */
     onTurnCompleted(userPromptText: string): void {
+        if (process.env["ACP_DISABLE_TITLE_GENERATION"] === "1") return;
         if (this.generated) return;
         const src = this.getSessionTitleSource();
         // "explicit": user renamed or session loaded with a name — skip

--- a/src/__tests__/TitleGenerator.test.ts
+++ b/src/__tests__/TitleGenerator.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CodexAppServerClient } from "../CodexAppServerClient";
+import { TitleGenerator } from "../TitleGenerator";
+
+describe("TitleGenerator", () => {
+    afterEach(() => vi.unstubAllEnvs());
+
+    function client() {
+        return {
+            threadStart: vi.fn().mockResolvedValue({ thread: { id: "title-thread" } }),
+            runTurn: vi.fn().mockResolvedValue({
+                turn: { items: [{ type: "agentMessage", text: '{"title":"Review project memory"}' }] },
+            }),
+            threadSetName: vi.fn().mockResolvedValue({}),
+        };
+    }
+
+    it("starts no title thread or model request when disabled", async () => {
+        vi.stubEnv("ACP_DISABLE_TITLE_GENERATION", "1");
+        const codex = client();
+        const titles = new TitleGenerator(
+            codex as unknown as CodexAppServerClient, "session", "/workspace", () => "unset",
+        );
+
+        titles.onTurnCompleted("Review the project's memory notes");
+        titles.onTurnCompleted("Review another note");
+        await new Promise<void>(resolve => setImmediate(resolve));
+
+        expect(codex.threadStart).not.toHaveBeenCalled();
+        expect(codex.runTurn).not.toHaveBeenCalled();
+        expect(codex.threadSetName).not.toHaveBeenCalled();
+    });
+
+    it.each([undefined, "0"])("still generates a title when the switch is %s", async value => {
+        vi.stubEnv("ACP_DISABLE_TITLE_GENERATION", value);
+        const codex = client();
+        const titles = new TitleGenerator(
+            codex as unknown as CodexAppServerClient, "session", "/workspace", () => "unset",
+        );
+
+        titles.onTurnCompleted("Review the project's memory notes");
+        await vi.waitFor(() => expect(codex.threadSetName).toHaveBeenCalledWith({
+            threadId: "session",
+            name: "Review project memory",
+        }));
+
+        expect(codex.threadStart).toHaveBeenCalledExactlyOnceWith({
+            cwd: "/workspace",
+            ephemeral: true,
+        });
+        expect(codex.runTurn).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
Headless jobs and clients that own their session titles currently trigger an additional model call after the first turn. This adds `ACP_DISABLE_TITLE_GENERATION=1` to skip that call for every session handled by the adapter process. Unset or other values keep the existing behavior; existing names, prompt-derived fallback titles, and `/rename` still work.

The check runs before a title thread is started. The runtime option is documented in both README files. Regression tests verify zero thread/model/name requests when disabled and normal generation when the variable is unset or `0`. This is an adapter option, not a change to ACP.

Validation:
- The new opt-out test fails on the unmodified implementation and passes with the change.
- `npm test`: 555 passed, 26 skipped.
- `npm run typecheck` and `npm run build`: passed.
- `npm run bundle:all`: all six target binaries built.
- No lint script is configured. Live-provider E2E tests were not run.

Related to the title generation added in #392.
