### PR TITLE
feat: simplify GPT model display names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.4.0",
-        "@openai/codex": "^0.153.3",
+        "@openai/codex": "^0.153.4",
         "diff": "^9.0.0",
         "open": "^11.0.1",
         "vscode-jsonrpc": "^9.0.1",
@@ -901,9 +901,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.153.3",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.3.tgz",
-      "integrity": "sha512-SwQns+YIXvaXV4a6RUd9twgTPJkkfZpuTNEkTtIkwBnfw6fpT61+d6gU1WHZxK6vWFNqJCBoJEP69FIAsoPduA==",
+      "version": "0.153.4",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.4.tgz",
+      "integrity": "sha512-wbHDmit7S/YvBGVX1DQmk13xtWblZ2cApeJ/pB7xDZ10Cna+DZc5ij7f0F4OxdsXN4FW1oLT48OpogUI1+8Y2w==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -912,19 +912,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.153.3-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.153.3-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.153.3-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.153.3-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.153.3-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.153.3-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.153.4-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.153.4-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.153.4-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.153.4-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.153.4-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.153.4-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.153.3-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.3-darwin-arm64.tgz",
-      "integrity": "sha512-cIJh2xhww3ZBXmgBt6e9gQjrdL2c9xiiq7yimDHtTGdg3wiUOADD/OsmIu/RJOitwM8OgImdHFjR59doBBdo8A==",
+      "version": "0.153.4-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.4-darwin-arm64.tgz",
+      "integrity": "sha512-B1qhN3fa1ay0R0wGziXqgwSkB5icpYChNKHhtBHff/0UtSTC7z+l8aTtvMlGjH3E8HEvY3+njIJelM9CAAoVWg==",
       "cpu": [
         "arm64"
       ],
@@ -939,9 +939,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.153.3-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.3-darwin-x64.tgz",
-      "integrity": "sha512-82Jxir4LygzF32z4y9KOMhK8rVlA4T6c10I9/MK+FhkEmTnDYcL4+VyttHdnMrX0I/Bdqj2M71gFellIaJHiDQ==",
+      "version": "0.153.4-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.4-darwin-x64.tgz",
+      "integrity": "sha512-vnSbbPzfoDZmmyzsxswsDDXQ06IVFBzkQU7/hroB3ji93Ok2utcsq8Psfk2tjF5r9mEx8RWFJhzuTGHG26/NDA==",
       "cpu": [
         "x64"
       ],
@@ -956,9 +956,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.153.3-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.3-linux-arm64.tgz",
-      "integrity": "sha512-uayZKgz5lk7Pz3JPjL98FGQGFRcrax3sGEQ9CtduyZscbIcnn3iYszRvGcubqVwiHi3B9oAVqy8V2NcWGwImLg==",
+      "version": "0.153.4-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.4-linux-arm64.tgz",
+      "integrity": "sha512-QKdjYLYV4hXIuUQDP3P6F4NXuWFoKo9WUoV4nAREIx55kiUyi8UsYdsVobkeXir5n/maEQgYMCKLHVma4rNPiw==",
       "cpu": [
         "arm64"
       ],
@@ -973,9 +973,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.153.3-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.3-linux-x64.tgz",
-      "integrity": "sha512-CyLvuM9Ij7sQuNtnHrzHtF+DtNISaauZZakyhy+MoFS1XxKTGv3FN4/qh6c94YZtLStZ7aUmfYQz59V3PV4zng==",
+      "version": "0.153.4-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.4-linux-x64.tgz",
+      "integrity": "sha512-x1EcwBlY3AObM1VTUHNM2AzAJQsyreGdagpF+qFiYi/Oa30VBktvvG0C6tLtCzqW6hjZNWkGZQWmeVk7MuJKWg==",
       "cpu": [
         "x64"
       ],
@@ -990,9 +990,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.153.3-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.3-win32-arm64.tgz",
-      "integrity": "sha512-Y5so5McyGWjfyj6q1qzgwT5UOMGo0jGPXECy88p2XWAwavtnHicoh6f4xi7VMgxEc/dxUijMPMVRJ5kqrBseXQ==",
+      "version": "0.153.4-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.4-win32-arm64.tgz",
+      "integrity": "sha512-/FBh42976ltF1kxDoPQBg1Q6+hwChRU5/sm5dfeC8kFVQMvOCGoGeY5d8rRZGVJE8XojlXo74VQb0sHowcfgBw==",
       "cpu": [
         "arm64"
       ],
@@ -1007,9 +1007,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.153.3-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.3-win32-x64.tgz",
-      "integrity": "sha512-+3BNGznK6xRYrBi8Ivsz50gQdViIKWjQ6I4zC5ELYLgBB0ETD/VBMP51LnybywJUKnZ6ow3VE/koImgfCl4Eiw==",
+      "version": "0.153.4-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.4-win32-x64.tgz",
+      "integrity": "sha512-lMkB43kJZH0VFr+hoXc11qqR7QtQIbkr07ALgj4urKL1osNyUyuy1iXd3Vzz2iCYvBUCSw7I0l/W1cEPGx9euQ==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^1.4.0",
-    "@openai/codex": "^0.153.3",
+    "@openai/codex": "^0.153.4",
     "diff": "^9.0.0",
     "open": "^11.0.1",
     "vscode-jsonrpc": "^9.0.1",

--- a/src/CodexAcpServer.ts
+++ b/src/CodexAcpServer.ts
@@ -48,6 +48,7 @@ import {
     createModelConfigOption,
     createReasoningEffortConfigOption,
     findSupportedEffort,
+    formatModelDisplayName,
     MODEL_CONFIG_ID,
     REASONING_EFFORT_CONFIG_ID,
 } from "./ModelConfigOption";
@@ -252,12 +253,6 @@ export interface CodexProcessState {
 }
 
 export class CodexAcpServer {
-    private static readonly MODEL_NAME_TOKEN_OVERRIDES: Record<string, string> = {
-        gpt: "GPT",
-        mini: "Mini",
-        codex: "Codex",
-    };
-
     private codexAcpClient: CodexAcpClient;
     private readonly connection: AcpClientConnection;
     private readonly defaultAuthRequest: CodexAuthRequest | null;
@@ -1857,19 +1852,12 @@ export class CodexAcpServer {
         return models.find(m => m.id === modelId.model);
     }
 
-    private normalizeModelDisplayName(displayName: string): string {
-        return displayName
-            .split("-")
-            .map((token) => CodexAcpServer.MODEL_NAME_TOKEN_OVERRIDES[token.toLowerCase()] ?? token)
-            .join("-");
-    }
-
     private createModelState(availableModels: Model[], selectedModelId: string): LegacySessionModelState {
         const allowedModels = availableModels
             .flatMap((model) =>
                 model.supportedReasoningEfforts.map((effort) => ({
                     modelId: ModelId.fromComponents(model, effort.reasoningEffort).toString(),
-                    name: `${this.normalizeModelDisplayName(model.displayName)} (${effort.reasoningEffort})`,
+                    name: `${formatModelDisplayName(model.displayName)} (${effort.reasoningEffort})`,
                     description: `${model.description} ${effort.description}`,
                 }))
             );

--- a/src/ModelConfigOption.ts
+++ b/src/ModelConfigOption.ts
@@ -6,6 +6,21 @@ import {AIR_RECOMMENDED_CONFIG_VALUE_KEY, withAirMeta} from "./AirExtension";
 export const MODEL_CONFIG_ID = "model";
 export const REASONING_EFFORT_CONFIG_ID = "reasoning_effort";
 
+/**
+ * Turn Codex's GPT display ids into compact picker labels without coupling the
+ * adapter to a particular model catalog. Custom/provider model names remain
+ * untouched because their punctuation may be meaningful.
+ */
+export function formatModelDisplayName(displayName: string): string {
+    if (!/^gpt-/i.test(displayName)) return displayName;
+    return displayName
+        .replace(/^gpt-/i, "")
+        .split(/[-/]+/)
+        .filter(Boolean)
+        .map(capitalize)
+        .join(" ");
+}
+
 function capitalize(value: string): string {
     return value.charAt(0).toUpperCase() + value.slice(1);
 }
@@ -25,13 +40,13 @@ export function createModelConfigOption(
 ): SessionConfigOption {
     const options: Array<{ value: string; name: string; description: string | null }> = availableModels.map(model => ({
         value: model.id,
-        name: model.displayName,
+        name: formatModelDisplayName(model.displayName),
         description: model.description,
     }));
     if (!availableModels.some(model => model.id === currentBaseModelId)) {
         options.unshift({
             value: currentBaseModelId,
-            name: currentBaseModelId,
+            name: formatModelDisplayName(currentBaseModelId),
             description: null,
         });
     }

--- a/src/__tests__/CodexACPAgent/data/model-filtering.json
+++ b/src/__tests__/CodexACPAgent/data/model-filtering.json
@@ -1,17 +1,17 @@
 [
   {
     "modelId": "gpt-5.2[medium]",
-    "name": "GPT-5.2 (medium)",
+    "name": "5.2 (medium)",
     "description": "Allowed by id. Default effort."
   },
   {
     "modelId": "gpt-5.2[low]",
-    "name": "GPT-5.2 (low)",
+    "name": "5.2 (low)",
     "description": "Allowed by id. Fast effort."
   },
   {
     "modelId": "other-id[medium]",
-    "name": "GPT-5.2 (medium)",
+    "name": "5.2 (medium)",
     "description": "Allowed Default effort."
   },
   {
@@ -21,17 +21,17 @@
   },
   {
     "modelId": "gpt-4o[medium]",
-    "name": "GPT-4o (medium)",
+    "name": "4o (medium)",
     "description": "Allowed. Default effort."
   },
   {
     "modelId": "gpt-5.3-codex[medium]",
-    "name": "GPT-5.3-Codex (medium)",
+    "name": "5.3 Codex (medium)",
     "description": "Codex suffix lowercased. Default effort."
   },
   {
     "modelId": "gpt-5.4-mini[medium]",
-    "name": "GPT-5.4-Mini (medium)",
+    "name": "5.4 Mini (medium)",
     "description": "Mini suffix lowercased. Default effort."
   }
 ]

--- a/src/__tests__/CodexACPAgent/e2e/acp-e2e-models-availability.test.ts
+++ b/src/__tests__/CodexACPAgent/e2e/acp-e2e-models-availability.test.ts
@@ -2,7 +2,7 @@ import {afterEach, beforeEach, expect, it} from "vitest";
 import {createAuthenticatedFixture, describeE2E, type SpawnedAgentFixture,} from "./acp-e2e-test-utils";
 import {ModelId} from "../../../ModelId";
 
-const DEFAULT_MODEL_ID = ModelId.create("gpt-5.6-sol", "medium")
+const DEFAULT_MODEL_ID = ModelId.create("gpt-6-astra", "low")
 
 describeE2E("Models availability", () => {
     let fixture: SpawnedAgentFixture;

--- a/src/__tests__/ModelConfigOption.test.ts
+++ b/src/__tests__/ModelConfigOption.test.ts
@@ -1,0 +1,44 @@
+import {describe, expect, it} from "vitest";
+import {createModelConfigOption, formatModelDisplayName} from "../ModelConfigOption";
+import {createTestModel} from "./acp-test-utils";
+
+describe("formatModelDisplayName", () => {
+    it.each([
+        ["gpt-6-astra", "6 Astra"],
+        ["GPT-5.6-Sol", "5.6 Sol"],
+        ["gpt-5.6-terra", "5.6 Terra"],
+        ["gpt-5.6-luna", "5.6 Luna"],
+        ["gpt-5.5", "5.5"],
+        ["gpt-5.3-codex-spark", "5.3 Codex Spark"],
+        ["gpt-5.3/codex-spark", "5.3 Codex Spark"],
+        ["gpt-oss-120B", "Oss 120B"],
+    ])("formats %s as %s", (displayName, expected) => {
+        expect(formatModelDisplayName(displayName)).toBe(expected);
+    });
+
+    it.each(["Claude Opus", "custom-provider/model-v2", "o3-mini"])(
+        "preserves non-GPT model name %s",
+        (displayName) => {
+            expect(formatModelDisplayName(displayName)).toBe(displayName);
+        },
+    );
+});
+
+describe("createModelConfigOption", () => {
+    it("uses compact GPT labels without changing model ids", () => {
+        const option = createModelConfigOption([
+            createTestModel({id: "gpt-6-astra", displayName: "GPT-6-Astra"}),
+            createTestModel({id: "gpt-5.6-sol", displayName: "GPT-5.6-Sol"}),
+            createTestModel({id: "gpt-5.3-codex-spark", displayName: "GPT-5.3-Codex-Spark"}),
+        ], "gpt-5.6-sol");
+
+        expect(option).toMatchObject({
+            currentValue: "gpt-5.6-sol",
+            options: [
+                {value: "gpt-6-astra", name: "6 Astra"},
+                {value: "gpt-5.6-sol", name: "5.6 Sol"},
+                {value: "gpt-5.3-codex-spark", name: "5.3 Codex Spark"},
+            ],
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- format GPT model picker labels using a generic transformation rule
- remove the `gpt-` prefix and replace hyphen/slash separators with spaces
- preserve model IDs and leave non-GPT provider names unchanged
- update Codex from 0.153.3 to 0.153.4 so GPT-6 Astra is advertised as visible and default
- apply the same labels to current config options and legacy model state

## Examples
- `gpt-6-astra` → `6 Astra`
- `gpt-5.3/codex-spark` → `5.3 Codex Spark`
- `o3-mini` → unchanged

## Verification
- `npm run generate-types` (no schema diff)
- `npm run typecheck`
- `npm test` (609 passed, 26 skipped)
- direct `model/list` probe against Codex 0.153.4 returns `gpt-6-astra` with `hidden: false`, `isDefault: true`
- live authenticated e2e was not run because no API key is available