### PR TITLE
fix: emit completed messages when providers omit deltas

### DIFF
--- a/src/CodexEventHandler.ts
+++ b/src/CodexEventHandler.ts
@@ -223,6 +223,7 @@ export class CodexEventHandler {
     private planUpdateChain: Promise<void> = Promise.resolve();
     private disposed = false;
     private readonly seenReasoningDeltaItemIds = new Set<string>();
+    private readonly seenAgentMessageDeltaItemIds = new Set<string>();
     private readonly terminalCommandIds = new Set<string>();
     private readonly terminalCommandOutputIds = new Set<string>();
     private readonly agentMessagePhases = new Map<string, string | null>();
@@ -623,6 +624,7 @@ export class CodexEventHandler {
     }
 
     private async createTextEvent(event: AgentMessageDeltaNotification): Promise<UpdateSessionEvent> {
+        this.seenAgentMessageDeltaItemIds.add(event.itemId);
         const phase = this.agentMessagePhases.get(event.itemId) ?? null;
         return createAgentTextMessageChunk(event.delta, event.itemId, createCodexMessagePhaseMeta(phase));
     }
@@ -745,7 +747,17 @@ export class CodexEventHandler {
                 return this.subagents.legacyCollaborationStarted(event.item);
             case "agentMessage":
                 this.rememberAgentMessagePhase(event.item);
-                return null;
+                if (this.seenAgentMessageDeltaItemIds.delete(event.item.id)) {
+                    return null;
+                }
+                if (event.item.text.length === 0) {
+                    return null;
+                }
+                return createAgentTextMessageChunk(
+                    event.item.text,
+                    event.item.id,
+                    createCodexMessagePhaseMeta(event.item.phase),
+                );
             case "contextCompaction":
                 return createContextCompactionStartUpdate(event.item);
             case "subAgentActivity":

--- a/src/__tests__/CodexACPAgent/agent-message-events.test.ts
+++ b/src/__tests__/CodexACPAgent/agent-message-events.test.ts
@@ -86,4 +86,102 @@ describe("CodexEventHandler - agent message events", () => {
             "data/agent-message-phases.json"
         );
     });
+
+    it("emits completed agent text when a provider omits message deltas", async () => {
+        const notifications: ServerNotification[] = [
+            {
+                method: "item/started",
+                params: {
+                    threadId: sessionId,
+                    turnId: "turn-1",
+                    startedAtMs: 0,
+                    item: {
+                        type: "agentMessage",
+                        id: "completed-only-message",
+                        text: "Ark-compatible final answer.",
+                        phase: "final_answer",
+                        memoryCitation: null,
+                        delivery: null,
+                        questions: null,
+                    },
+                },
+            },
+            {
+                method: "item/completed",
+                params: {
+                    threadId: sessionId,
+                    turnId: "turn-1",
+                    completedAtMs: 1,
+                    item: {
+                        type: "agentMessage",
+                        id: "completed-only-message",
+                        text: "Ark-compatible final answer.",
+                        phase: "final_answer",
+                        memoryCitation: null,
+                        delivery: null,
+                        questions: null,
+                    },
+                },
+            },
+        ];
+
+        await setupPromptAndSendNotifications(mockFixture, sessionId, sessionState, notifications);
+
+        const dump = mockFixture.getAcpConnectionDump([]);
+        expect(dump).toContain("Ark-compatible final answer.");
+        expect(dump.match(/Ark-compatible final answer\./g)).toHaveLength(1);
+    });
+
+    it("does not duplicate completed text after streamed deltas", async () => {
+        const notifications: ServerNotification[] = [
+            {
+                method: "item/started",
+                params: {
+                    threadId: sessionId,
+                    turnId: "turn-1",
+                    startedAtMs: 0,
+                    item: {
+                        type: "agentMessage",
+                        id: "streamed-message",
+                        text: "",
+                        phase: null,
+                        memoryCitation: null,
+                        delivery: null,
+                        questions: null,
+                    },
+                },
+            },
+            {
+                method: "item/agentMessage/delta",
+                params: {
+                    threadId: sessionId,
+                    turnId: "turn-1",
+                    itemId: "streamed-message",
+                    delta: "Streamed once.",
+                },
+            },
+            {
+                method: "item/completed",
+                params: {
+                    threadId: sessionId,
+                    turnId: "turn-1",
+                    completedAtMs: 1,
+                    item: {
+                        type: "agentMessage",
+                        id: "streamed-message",
+                        text: "Streamed once.",
+                        phase: null,
+                        memoryCitation: null,
+                        delivery: null,
+                        questions: null,
+                    },
+                },
+            },
+        ];
+
+        await setupPromptAndSendNotifications(mockFixture, sessionId, sessionState, notifications);
+
+        const dump = mockFixture.getAcpConnectionDump([]);
+        expect(dump.match(/Streamed once\./g)).toHaveLength(1);
+    });
 });


### PR DESCRIPTION
Some OpenAI-compatible Responses providers, including Volcengine Ark, deliver final text without `item/agentMessage/delta`. Codex app-server still emits `item/started` and `item/completed` for an `agentMessage` carrying the full text, but codex-acp currently ignores both. ACP clients receive reasoning and a successful `end_turn` with no final message.

Track agent-message item IDs that emitted deltas. On `item/completed`, retain the current no-op for those streamed messages; otherwise emit the completed item's non-empty text once, including its phase metadata.

Validation:

- `npm run typecheck`
- `npx vitest run --no-file-parallelism src/__tests__/CodexACPAgent/agent-message-events.test.ts`
- `npm run build`
- Real Ark `deepseek-v4-flash` ACP turn: before this change, only the thought event arrived; after this change, the client received exactly one final `agent_message_chunk` containing `ARK_ACP_RAW_OK`.
