### PR TITLE
fix: use bundled Codex for login by default

### DIFF
--- a/src/__tests__/login.test.ts
+++ b/src/__tests__/login.test.ts
@@ -1,0 +1,13 @@
+import {describe, expect, it} from "vitest";
+
+import {resolveLoginCodexPath} from "../login";
+
+describe("resolveLoginCodexPath", () => {
+    it("uses the bundled Codex app-server when CODEX_PATH is absent", () => {
+        expect(resolveLoginCodexPath({})).toBeUndefined();
+    });
+
+    it("preserves an explicit CODEX_PATH override", () => {
+        expect(resolveLoginCodexPath({CODEX_PATH: "/opt/codex/bin/codex"})).toBe("/opt/codex/bin/codex");
+    });
+});

--- a/src/login.ts
+++ b/src/login.ts
@@ -11,6 +11,10 @@ interface LoginOptions {
     clientVersion?: string;
 }
 
+export function resolveLoginCodexPath(env: NodeJS.ProcessEnv = process.env): string | undefined {
+    return env["CODEX_PATH"];
+}
+
 function parseArgs(args: string[]): LoginOptions | null {
     const options: LoginOptions = {};
 
@@ -63,7 +67,7 @@ Example:
 }
 
 async function login(options: LoginOptions): Promise<boolean> {
-    const codexPath = process.env["CODEX_PATH"] ?? "codex";
+    const codexPath = resolveLoginCodexPath();
 
     logger.log("Starting Codex connection...");
     const codexConnection = startCodexConnection(codexPath);


### PR DESCRIPTION
## Summary
- make `codex-acp login` use the bundled Codex app-server when `CODEX_PATH` is not set
- keep explicit `CODEX_PATH` overrides working for users who need a custom Codex executable
- add regression coverage for the login executable selection

Closes #459

## Test Plan
- `npm test -- src/__tests__/login.test.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- `npm test` (`51 passed | 6 skipped`, `611 passed | 26 skipped`)
